### PR TITLE
Add CLI option for Streamable Http

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ zotero-mcp setup --no-local --api-key YOUR_API_KEY --library-id YOUR_LIBRARY_ID
 zotero-mcp serve
 
 # Specify transport method
-zotero-mcp serve --transport stdio|sse
+zotero-mcp serve --transport stdio|streamable-http|sse
 
 # Get help on setup options
 zotero-mcp setup --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "markitdown[pdf]",
     "pydantic>=2.0.0",
     "requests>=2.28.0",
+    "fastmcp>=2.3.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mcp>=1.2.0
 python-dotenv>=1.0.0
 markitdown
 pydantic>=2.0.0
+fastmcp>=2.3.0

--- a/src/zotero_mcp/cli.py
+++ b/src/zotero_mcp/cli.py
@@ -21,7 +21,7 @@ def main():
     server_parser = subparsers.add_parser("serve", help="Run the MCP server")
     server_parser.add_argument(
         "--transport",
-        choices=["stdio", "sse"],
+        choices=["stdio", "streamable-http", "sse"],
         default="stdio",
         help="Transport to use (default: stdio)",
     )
@@ -72,9 +72,15 @@ def main():
         transport = getattr(args, "transport", "stdio")
         if transport == "stdio":
             mcp.run(transport="stdio")
+        elif transport == "streamable-http":
+            host = getattr(args, "host", "localhost") 
+            port = getattr(args, "port", 8000)
+            mcp.run(transport="streamable-http", host=host, port=port)
         elif transport == "sse":
             host = getattr(args, "host", "localhost") 
             port = getattr(args, "port", 8000)
+            import warnings
+            warnings.warn("The SSE transport is deprecated and may be removed in a future version. New applications should use Streamable HTTP transport instead.", UserWarning)
             mcp.run(transport="sse", host=host, port=port)
 
 

--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -7,7 +7,7 @@ import os
 import uuid
 import tempfile
 
-from mcp.server.fastmcp import Context, FastMCP
+from fastmcp import Context, FastMCP
 
 from zotero_mcp.client import (
     AttachmentDetails,

--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -21,7 +21,7 @@ from zotero_mcp.utils import format_creators
 # Create an MCP server with appropriate dependencies
 mcp = FastMCP(
     "Zotero",
-    dependencies=["pyzotero", "mcp[cli]", "python-dotenv", "markitdown"],
+    dependencies=["pyzotero", "mcp[cli]", "python-dotenv", "markitdown", "fastmcp"],
 )
 
 


### PR DESCRIPTION
This PR add cli option for Streamable Http transport, as stated in [FastMCP doc](https://gofastmcp.com/deployment/running-server#streamable-http), which is now the recommended transport for web-based deployments. On the other hand, SSE is deprecated. [see](https://gofastmcp.com/deployment/running-server#sse).