### PR TITLE
Make setup-info arg more safe/effective for error reports

### DIFF
--- a/src/zotero_mcp/utils.py
+++ b/src/zotero_mcp/utils.py
@@ -1,4 +1,3 @@
-import os
 from typing import List, Dict
 
 def format_creators(creators: List[Dict[str, str]]) -> str:

--- a/src/zotero_mcp/utils.py
+++ b/src/zotero_mcp/utils.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Dict
 
 def format_creators(creators: List[Dict[str, str]]) -> str:
@@ -17,3 +18,23 @@ def format_creators(creators: List[Dict[str, str]]) -> str:
         elif "name" in creator:
             names.append(creator["name"])
     return "; ".join(names) if names else "No authors listed"
+
+
+def is_local_mode() -> bool:
+    """
+    Check if Zotero MCP is configured for local mode.
+    
+    Returns:
+        True if ZOTERO_LOCAL is set to "true", "yes", or "1", False otherwise.
+    """
+    return os.getenv("ZOTERO_LOCAL", "").lower() in ["true", "yes", "1"]
+
+
+def is_remote_mode() -> bool:
+    """
+    Check if Zotero MCP is configured for remote mode.
+    
+    Returns:
+        True if not in local mode, False otherwise.
+    """
+    return not is_local_mode()

--- a/src/zotero_mcp/utils.py
+++ b/src/zotero_mcp/utils.py
@@ -18,23 +18,3 @@ def format_creators(creators: List[Dict[str, str]]) -> str:
         elif "name" in creator:
             names.append(creator["name"])
     return "; ".join(names) if names else "No authors listed"
-
-
-def is_local_mode() -> bool:
-    """
-    Check if Zotero MCP is configured for local mode.
-    
-    Returns:
-        True if ZOTERO_LOCAL is set to "true", "yes", or "1", False otherwise.
-    """
-    return os.getenv("ZOTERO_LOCAL", "").lower() in ["true", "yes", "1"]
-
-
-def is_remote_mode() -> bool:
-    """
-    Check if Zotero MCP is configured for remote mode.
-    
-    Returns:
-        True if not in local mode, False otherwise.
-    """
-    return not is_local_mode()


### PR DESCRIPTION
Update setup-info to: 
1. Obfuscate the user's API-KEY and LIBRARY-ID in the output (from the Claude Desktop Config.) 
2. Deliver Database statistics just like the db-status command does (but without making any changes). 
3. Do not advertise the "db-status" command at the end of the setup-info output.