### PR TITLE
feat(local-search): Local SQLite-based indexing with PDF-preferred fulltext; CLI inspect/stats; progress improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zotero-mcp"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name = "54yyyu", email = "54yyyu@github.com" },
 ]

--- a/src/zotero_mcp/_version.py
+++ b/src/zotero_mcp/_version.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -1,0 +1,304 @@
+"""
+Local Zotero database reader for semantic search.
+
+Provides direct SQLite access to Zotero's local database for faster semantic search
+when running in local mode.
+"""
+
+import os
+import sqlite3
+import platform
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Any
+from dataclasses import dataclass
+
+from .utils import is_local_mode
+
+
+@dataclass
+class ZoteroItem:
+    """Represents a Zotero item with text content for semantic search."""
+    item_id: int
+    key: str
+    item_type_id: int
+    title: Optional[str] = None
+    abstract: Optional[str] = None
+    creators: Optional[str] = None
+    fulltext: Optional[str] = None
+    notes: Optional[str] = None
+    extra: Optional[str] = None
+    date_added: Optional[str] = None
+    date_modified: Optional[str] = None
+    
+    def get_searchable_text(self) -> str:
+        """
+        Combine all text fields into a single searchable string.
+        
+        Returns:
+            Combined text content for semantic search indexing.
+        """
+        parts = []
+        
+        if self.title:
+            parts.append(f"Title: {self.title}")
+        
+        if self.creators:
+            parts.append(f"Authors: {self.creators}")
+            
+        if self.abstract:
+            parts.append(f"Abstract: {self.abstract}")
+            
+        if self.extra:
+            parts.append(f"Extra: {self.extra}")
+            
+        if self.notes:
+            parts.append(f"Notes: {self.notes}")
+            
+        if self.fulltext:
+            # Truncate fulltext to avoid overly long documents
+            truncated_fulltext = self.fulltext[:5000] + "..." if len(self.fulltext) > 5000 else self.fulltext
+            parts.append(f"Content: {truncated_fulltext}")
+            
+        return "\n\n".join(parts)
+
+
+class LocalZoteroReader:
+    """
+    Direct SQLite reader for Zotero's local database.
+    
+    Provides fast access to item metadata and fulltext for semantic search
+    without going through the Zotero API.
+    """
+    
+    def __init__(self, db_path: Optional[str] = None):
+        """
+        Initialize the local database reader.
+        
+        Args:
+            db_path: Optional path to zotero.sqlite. If None, auto-detect.
+        """
+        self.db_path = db_path or self._find_zotero_db()
+        self._connection: Optional[sqlite3.Connection] = None
+        
+    def _find_zotero_db(self) -> str:
+        """
+        Auto-detect the Zotero database location based on OS.
+        
+        Returns:
+            Path to zotero.sqlite file.
+            
+        Raises:
+            FileNotFoundError: If database cannot be located.
+        """
+        system = platform.system()
+        
+        if system == "Darwin":  # macOS
+            db_path = Path.home() / "Zotero" / "zotero.sqlite"
+        elif system == "Windows":
+            # Try Windows 7+ location first
+            db_path = Path.home() / "Zotero" / "zotero.sqlite"
+            if not db_path.exists():
+                # Fallback to XP/2000 location
+                db_path = Path(os.path.expanduser("~/Documents and Settings")) / os.getenv("USERNAME", "") / "Zotero" / "zotero.sqlite"
+        else:  # Linux and others
+            db_path = Path.home() / "Zotero" / "zotero.sqlite"
+            
+        if not db_path.exists():
+            raise FileNotFoundError(
+                f"Zotero database not found at {db_path}. "
+                "Please ensure Zotero is installed and has been run at least once."
+            )
+            
+        return str(db_path)
+    
+    def _get_connection(self) -> sqlite3.Connection:
+        """Get database connection, creating if needed."""
+        if self._connection is None:
+            # Open in read-only mode for safety
+            uri = f"file:{self.db_path}?mode=ro"
+            self._connection = sqlite3.connect(uri, uri=True)
+            self._connection.row_factory = sqlite3.Row
+        return self._connection
+    
+    def close(self):
+        """Close database connection."""
+        if self._connection:
+            self._connection.close()
+            self._connection = None
+    
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+    
+    def get_item_count(self) -> int:
+        """
+        Get total count of non-attachment items.
+        
+        Returns:
+            Number of items in the library.
+        """
+        conn = self._get_connection()
+        cursor = conn.execute(
+            "SELECT COUNT(*) FROM items WHERE itemTypeID != 14"  # 14 = attachment
+        )
+        return cursor.fetchone()[0]
+    
+    def get_items_with_text(self, limit: Optional[int] = None) -> List[ZoteroItem]:
+        """
+        Get all items with their text content for semantic search.
+        
+        Args:
+            limit: Optional limit on number of items to return.
+            
+        Returns:
+            List of ZoteroItem objects with text content.
+        """
+        conn = self._get_connection()
+        
+        # Query to get items with their text content (simplified for now)
+        query = """
+        SELECT 
+            i.itemID,
+            i.key,
+            i.itemTypeID,
+            i.dateAdded,
+            i.dateModified,
+            title_val.value as title,
+            abstract_val.value as abstract,
+            extra_val.value as extra,
+            GROUP_CONCAT(n.note, ' ') as notes,
+            GROUP_CONCAT(
+                CASE 
+                    WHEN c.firstName IS NOT NULL AND c.lastName IS NOT NULL 
+                    THEN c.lastName || ', ' || c.firstName
+                    WHEN c.lastName IS NOT NULL 
+                    THEN c.lastName
+                    ELSE NULL
+                END, '; '
+            ) as creators
+        FROM items i
+        
+        -- Get title
+        LEFT JOIN itemData title_data ON i.itemID = title_data.itemID AND title_data.fieldID = 1
+        LEFT JOIN itemDataValues title_val ON title_data.valueID = title_val.valueID
+        
+        -- Get abstract  
+        LEFT JOIN itemData abstract_data ON i.itemID = abstract_data.itemID AND abstract_data.fieldID = 2
+        LEFT JOIN itemDataValues abstract_val ON abstract_data.valueID = abstract_val.valueID
+        
+        -- Get extra field
+        LEFT JOIN itemData extra_data ON i.itemID = extra_data.itemID AND extra_data.fieldID = 16
+        LEFT JOIN itemDataValues extra_val ON extra_data.valueID = extra_val.valueID
+        
+        -- Get notes
+        LEFT JOIN itemNotes n ON i.itemID = n.parentItemID OR i.itemID = n.itemID
+        
+        -- Get creators
+        LEFT JOIN itemCreators ic ON i.itemID = ic.itemID
+        LEFT JOIN creators c ON ic.creatorID = c.creatorID
+        
+        WHERE i.itemTypeID != 14  -- Exclude attachments
+        
+        GROUP BY i.itemID, i.key, i.itemTypeID, i.dateAdded, i.dateModified,
+                 title_val.value, abstract_val.value, extra_val.value
+        
+        ORDER BY i.dateModified DESC
+        """
+        
+        if limit:
+            query += f" LIMIT {limit}"
+        
+        cursor = conn.execute(query)
+        items = []
+        
+        for row in cursor:
+            item = ZoteroItem(
+                item_id=row['itemID'],
+                key=row['key'],
+                item_type_id=row['itemTypeID'],
+                title=row['title'],
+                abstract=row['abstract'],
+                creators=row['creators'],
+                fulltext=None,  # TODO: Implement fulltext extraction
+                notes=row['notes'],
+                extra=row['extra'],
+                date_added=row['dateAdded'],
+                date_modified=row['dateModified']
+            )
+            items.append(item)
+            
+        return items
+    
+    def get_item_by_key(self, key: str) -> Optional[ZoteroItem]:
+        """
+        Get a specific item by its Zotero key.
+        
+        Args:
+            key: The Zotero item key.
+            
+        Returns:
+            ZoteroItem if found, None otherwise.
+        """
+        items = self.get_items_with_text()
+        for item in items:
+            if item.key == key:
+                return item
+        return None
+    
+    def search_items_by_text(self, query: str, limit: int = 50) -> List[ZoteroItem]:
+        """
+        Simple text search through item content.
+        
+        Args:
+            query: Search query string.
+            limit: Maximum number of results.
+            
+        Returns:
+            List of matching ZoteroItem objects.
+        """
+        items = self.get_items_with_text()
+        matching_items = []
+        
+        query_lower = query.lower()
+        
+        for item in items:
+            searchable_text = item.get_searchable_text().lower()
+            if query_lower in searchable_text:
+                matching_items.append(item)
+                if len(matching_items) >= limit:
+                    break
+                    
+        return matching_items
+
+
+def get_local_zotero_reader() -> Optional[LocalZoteroReader]:
+    """
+    Get a LocalZoteroReader instance if in local mode.
+    
+    Returns:
+        LocalZoteroReader instance if in local mode and database exists,
+        None otherwise.
+    """
+    if not is_local_mode():
+        return None
+        
+    try:
+        return LocalZoteroReader()
+    except FileNotFoundError:
+        return None
+
+
+def is_local_db_available() -> bool:
+    """
+    Check if local Zotero database is available.
+    
+    Returns:
+        True if local database can be accessed, False otherwise.
+    """
+    reader = get_local_zotero_reader()
+    if reader:
+        reader.close()
+        return True
+    return False

--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -366,7 +366,7 @@ class LocalZoteroReader:
         return items
 
     # Public helper to extract fulltext on demand for a specific item
-    def extract_fulltext_for_item(self, item_id: int) -> Optional[str]:
+    def extract_fulltext_for_item(self, item_id: int) -> Optional[tuple[str, str]]:
         return self._extract_fulltext_for_item(item_id)
     
     def get_item_by_key(self, key: str) -> Optional[ZoteroItem]:

--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -9,7 +9,6 @@ import os
 import sqlite3
 import platform
 import logging
-from typing import Optional as _Optional
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
 from dataclasses import dataclass
@@ -153,7 +152,7 @@ class LocalZoteroReader:
         for row in conn.execute(query, (parent_item_id,)):
             yield row["attachmentKey"], row["path"], row["contentType"]
 
-    def _resolve_attachment_path(self, attachment_key: str, zotero_path: str) -> _Optional[Path]:
+    def _resolve_attachment_path(self, attachment_key: str, zotero_path: str) -> Optional[Path]:
         """Resolve a Zotero attachment path like 'storage:filename.pdf' to a filesystem path."""
         if not zotero_path:
             return None
@@ -212,7 +211,7 @@ class LocalZoteroReader:
         except Exception:
             return ""
 
-    def _extract_fulltext_for_item(self, item_id: int) -> _Optional[tuple[str, str]]:
+    def _extract_fulltext_for_item(self, item_id: int) -> Optional[tuple[str, str]]:
         """Attempt to extract fulltext and source from the item's best attachment.
 
         Preference: use PDF when available; fall back to HTML when no PDF exists.
@@ -367,7 +366,7 @@ class LocalZoteroReader:
         return items
 
     # Public helper to extract fulltext on demand for a specific item
-    def extract_fulltext_for_item(self, item_id: int) -> _Optional[str]:
+    def extract_fulltext_for_item(self, item_id: int) -> Optional[str]:
         return self._extract_fulltext_for_item(item_id)
     
     def get_item_by_key(self, key: str) -> Optional[ZoteroItem]:

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -241,7 +241,18 @@ class ZoteroSemanticSearch:
         logger.info("Fetching items from local Zotero database...")
         
         try:
-            with LocalZoteroReader() as reader:
+            # Load per-run config, including extraction limits if provided
+            pdf_max_pages = None
+            # If semantic_search config file exists, prefer its setting
+            try:
+                if self.config_path and os.path.exists(self.config_path):
+                    with open(self.config_path, 'r') as _f:
+                        _cfg = json.load(_f)
+                        pdf_max_pages = _cfg.get('semantic_search', {}).get('extraction', {}).get('pdf_max_pages')
+            except Exception:
+                pass
+
+            with LocalZoteroReader(pdf_max_pages=pdf_max_pages) as reader:
                 # Phase 1: fetch metadata only (fast)
                 print("Scanning local Zotero database for items...", flush=True)
                 local_items = reader.get_items_with_text(limit=limit, include_fulltext=False)

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -158,6 +158,11 @@ class ZoteroSemanticSearch:
             "url": data.get("url", ""),
             "doi": data.get("DOI", ""),
         }
+        # If local fulltext field exists, add markers so we can filter later
+        if data.get("fulltext"):
+            metadata["has_fulltext"] = True
+            if data.get("fulltextSource"):
+                metadata["fulltext_source"] = data.get("fulltextSource")
         
         # Add tags as a single string
         if tags := data.get("tags"):
@@ -237,7 +242,93 @@ class ZoteroSemanticSearch:
         
         try:
             with LocalZoteroReader() as reader:
-                local_items = reader.get_items_with_text(limit=limit)
+                # Phase 1: fetch metadata only (fast)
+                print("Scanning local Zotero database for items...", flush=True)
+                local_items = reader.get_items_with_text(limit=limit, include_fulltext=False)
+                candidate_count = len(local_items)
+                print(f"Found {candidate_count} candidate items.", flush=True)
+
+                # Optional deduplication: if preprint and journalArticle share a DOI/title, keep journalArticle
+                # Build index by (normalized DOI or normalized title)
+                def norm(s: Optional[str]) -> Optional[str]:
+                    if not s:
+                        return None
+                    return "".join(s.lower().split())
+
+                key_to_best = {}
+                for it in local_items:
+                    doi_key = ("doi", norm(getattr(it, "doi", None))) if getattr(it, "doi", None) else None
+                    title_key = ("title", norm(getattr(it, "title", None))) if getattr(it, "title", None) else None
+
+                    def consider(k):
+                        if not k:
+                            return
+                        cur = key_to_best.get(k)
+                        # Prefer journalArticle over preprint; otherwise keep first
+                        if cur is None:
+                            key_to_best[k] = it
+                        else:
+                            prefer_types = {"journalArticle": 2, "preprint": 1}
+                            cur_score = prefer_types.get(getattr(cur, "item_type", ""), 0)
+                            new_score = prefer_types.get(getattr(it, "item_type", ""), 0)
+                            if new_score > cur_score:
+                                key_to_best[k] = it
+
+                    consider(doi_key)
+                    consider(title_key)
+
+                # If a preprint loses against a journal article for same DOI/title, drop it
+                filtered_items = []
+                for it in local_items:
+                    # If there is a journalArticle alternative for same DOI or title, and this is preprint, drop
+                    if getattr(it, "item_type", None) == "preprint":
+                        k_doi = ("doi", norm(getattr(it, "doi", None))) if getattr(it, "doi", None) else None
+                        k_title = ("title", norm(getattr(it, "title", None))) if getattr(it, "title", None) else None
+                        drop = False
+                        for k in (k_doi, k_title):
+                            if not k:
+                                continue
+                            best = key_to_best.get(k)
+                            if best is not None and best is not it and getattr(best, "item_type", None) == "journalArticle":
+                                drop = True
+                                break
+                        if drop:
+                            continue
+                    filtered_items.append(it)
+
+                local_items = filtered_items
+                total_to_extract = len(local_items)
+                if total_to_extract != candidate_count:
+                    try:
+                        print(
+                            f"After filtering/dedup: {total_to_extract} items to process. Extracting content...",
+                            flush=True,
+                        )
+                    except Exception:
+                        pass
+                else:
+                    try:
+                        print("Extracting content...", flush=True)
+                    except Exception:
+                        pass
+
+                # Phase 2: selectively extract fulltext only now, with lightweight progress
+                extracted = 0
+                for it in local_items:
+                    if not getattr(it, "fulltext", None):
+                        text = reader.extract_fulltext_for_item(it.item_id)
+                        if text:
+                            # Support new (text, source) return format
+                            if isinstance(text, tuple) and len(text) == 2:
+                                it.fulltext, it.fulltext_source = text[0], text[1]
+                            else:
+                                it.fulltext = text
+                    extracted += 1
+                    if extracted % 25 == 0 and total_to_extract:
+                        try:
+                            print(f"Extracted content for {extracted}/{total_to_extract} items...", flush=True)
+                        except Exception:
+                            pass
                 
                 # Convert to API-compatible format
                 api_items = []
@@ -248,10 +339,13 @@ class ZoteroSemanticSearch:
                         "version": 0,  # Local items don't have versions
                         "data": {
                             "key": item.key,
-                            "itemType": "journalArticle",  # Default, could be improved
+                            "itemType": getattr(item, 'item_type', None) or "journalArticle",
                             "title": item.title or "",
                             "abstractNote": item.abstract or "",
                             "extra": item.extra or "",
+                            # Include a slice of extracted fulltext if available
+                            "fulltext": getattr(item, 'fulltext', None) or "",
+                            "fulltextSource": getattr(item, 'fulltext_source', None) or "",
                             "dateAdded": item.date_added,
                             "dateModified": item.date_modified,
                             "creators": self._parse_creators_string(item.creators) if item.creators else []
@@ -388,9 +482,18 @@ class ZoteroSemanticSearch:
             
             stats["total_items"] = len(all_items)
             logger.info(f"Found {stats['total_items']} items to process")
+            # Immediate progress line so users see counts up-front
+            try:
+                print(f"Total items to index: {stats['total_items']}", flush=True)
+            except Exception:
+                pass
             
             # Process items in batches
             batch_size = 50
+            # Track next milestone for progress printing (every 10 items)
+            next_milestone = 10 if stats["total_items"] >= 10 else stats["total_items"]
+            # Count of items seen (including skipped), used for progress milestones
+            seen_items = 0
             for i in range(0, len(all_items), batch_size):
                 batch = all_items[i:i + batch_size]
                 batch_stats = self._process_item_batch(batch, force_full_rebuild)
@@ -400,8 +503,25 @@ class ZoteroSemanticSearch:
                 stats["updated_items"] += batch_stats["updated"]
                 stats["skipped_items"] += batch_stats["skipped"]
                 stats["errors"] += batch_stats["errors"]
+                seen_items += len(batch)
                 
-                logger.info(f"Processed {stats['processed_items']}/{stats['total_items']} items")
+                logger.info(f"Processed {seen_items}/{stats['total_items']} items (added: {stats['added_items']}, skipped: {stats['skipped_items']})")
+                # Print progress every 10 seen items (even if all are skipped)
+                try:
+                    while seen_items >= next_milestone and next_milestone > 0:
+                        print(
+                            f"Processed: {next_milestone}/{stats['total_items']} "
+                            f"added:{stats['added_items']} "
+                            f"skipped:{stats['skipped_items']} "
+                            f"errors:{stats['errors']}",
+                            flush=True,
+                        )
+                        next_milestone += 10
+                        if next_milestone > stats["total_items"]:
+                            next_milestone = stats["total_items"]
+                            break
+                except Exception:
+                    pass
             
             # Update last update time
             self.update_config["last_update"] = datetime.now().isoformat()
@@ -443,7 +563,9 @@ class ZoteroSemanticSearch:
                     continue
                 
                 # Create document text and metadata
-                doc_text = self._create_document_text(item)
+                # Prefer fulltext if available, else fall back to structured fields
+                fulltext = item.get("data", {}).get("fulltext", "")
+                doc_text = fulltext if fulltext.strip() else self._create_document_text(item)
                 metadata = self._create_metadata(item)
                 
                 if not doc_text.strip():

--- a/src/zotero_mcp/setup_helper.py
+++ b/src/zotero_mcp/setup_helper.py
@@ -261,7 +261,26 @@ def setup_semantic_search(existing_semantic_config: dict = None, semantic_config
         }
         print(f"Database will be updated every {days} days.")
     
+    # Configure extraction settings
+    print("\n=== Content Extraction Settings ===")
+    print("Set a page cap for PDF extraction to balance speed vs. coverage.")
+    print("Press Enter to use the default.")
+    default_pdf_max = existing_semantic_config.get("extraction", {}).get("pdf_max_pages", 10) if existing_semantic_config else 10
+    while True:
+        raw = input(f"PDF max pages [{default_pdf_max}]: ").strip()
+        if raw == "":
+            pdf_max_pages = default_pdf_max
+            break
+        try:
+            pdf_max_pages = int(raw)
+            if pdf_max_pages > 0:
+                break
+            print("Please enter a positive integer")
+        except ValueError:
+            print("Please enter a valid number")
+
     config["update_config"] = update_config
+    config["extraction"] = {"pdf_max_pages": pdf_max_pages}
     
     return config
 

--- a/src/zotero_mcp/utils.py
+++ b/src/zotero_mcp/utils.py
@@ -1,4 +1,5 @@
 from typing import List, Dict
+import os
 
 def format_creators(creators: List[Dict[str, str]]) -> str:
     """
@@ -17,3 +18,13 @@ def format_creators(creators: List[Dict[str, str]]) -> str:
         elif "name" in creator:
             names.append(creator["name"])
     return "; ".join(names) if names else "No authors listed"
+
+
+def is_local_mode() -> bool:
+    """Return True if running in local mode.
+
+    Local mode is enabled when environment variable `ZOTERO_LOCAL` is set to a
+    truthy value ("true", "yes", or "1", case-insensitive).
+    """
+    value = os.getenv("ZOTERO_LOCAL", "")
+    return value.lower() in {"true", "yes", "1"}


### PR DESCRIPTION
This PR is an attempt to address the issues users are facing when attempting to semantic_index their local-based Zotero libraries. For instance, issues #35 and #44 should be addressed. 

The approach is to bypass the local API for semantic search indexing and, in place of the API, access the Zotero sqlite database directly to read data for a local library. We leverage a number of data fields from the sql tables to be a bit more selective of what is indexed, though the logic could likely be expanded for specific use cases. With local indexing and likely some very large libraries to index, overall the process may take much longer for some users. More verbosity was added to the CLI to help with the longer processing time. 

This approach (interacting with the local db instead of the undocumented API) may indeed be useful for other functionalities---particularly tagging and annotations---but of course, writes to the local db might require both additional dev scrutiny as well as additional care for issues like batch rollback, etc.

I have bumped the version to v0.1.1 just to make this feature easier to test locally. We can adjust the version as needed.

## Summary
- Index from local Zotero sqlite (bypass JS client) with true `item_type`/`DOI`; exclude attachments/notes/annotations
- Prefer PDF fulltext (fallback HTML); cap PDF pages; tag `fulltext_source`; suppress pdfminer noise
- Two-phase update: fast metadata scan then selective fulltext extraction with progress logs
- Deduplicate preprints when a matching journal article exists (by DOI or normalized title)
- CLI: merge `db-stats` into `db-inspect --stats`; show fulltext coverage by type; keep `db-status`

## Changes
- `src/zotero_mcp/local_db.py`: new resilient local reader, PDF/HTML extraction, path resolution, item type filtering
- `src/zotero_mcp/semantic_search.py`: local-path ingestion, dedup, progress every 10, fulltext preference
- `src/zotero_mcp/cli.py`: `db-inspect` with `--stats`, removed separate `db-stats`
- `src/zotero_mcp/utils.py`: `is_local_mode`
- Version: 0.1.1

## Test plan
- Install as uv tool from branch; run:
  - `zotero-mcp update-db --force-rebuild --limit 100` (see "Scanning…", “Total items…”, and per-10 progress)
  - `zotero-mcp db-inspect --stats` (verify item types and fulltext coverage; chapters and conference papers included)
  - `zotero-mcp db-inspect --show-documents --limit 10` (spot-check real PDF body text)

## Notes
- Dedup is conservative and only drops preprints when a journal article is present for the same DOI/title.