### PR TITLE
Fix issue no libraryID on matched_item

### DIFF
--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -1178,16 +1178,16 @@ def get_annotations(
                         # Process annotations if citation key found
                         if citation_key:
                             try:
-                                # Determine library ID
-                                library_id = 1  # Default to personal library
+                                # Determine library
+                                library = "*"  # Default all libraries
                                 search_results = bibtex._make_request("item.search", [citation_key])
                                 if search_results:
                                     matched_item = next((item for item in search_results if item.get('citekey') == citation_key), None)
                                     if matched_item:
-                                        library_id = matched_item.get('libraryID', 1)
+                                        library = matched_item.get('library', "*")
                                 
                                 # Get attachments
-                                attachments = bibtex.get_attachments(citation_key, library_id)
+                                attachments = bibtex.get_attachments(citation_key, library)
                                 
                                 # Process annotations from attachments
                                 for attachment in attachments:


### PR DESCRIPTION
When getting annotations from Zotero using `zotero_get_annotations` using an item key. This always results in a "No annotations found for item: ...".

`ZOTERO_LOCAL = true`

This is because we try to find a value for the key `libraryID` in `matched_item`, but it is not available in the results from the better BibTeX API. Resulting in the default value `library_id =  1`. This is not always the case since the library ID can be configured when setting up the MCP.

First, I tried an approach by using the configured `ZOTERO_LIBRARY_ID` because I am using a ZOTERO_LIBRARY_TYPE group (yes, on a local Zotero)

```
curl --location 'http://127.0.0.1:23119/better-bibtex/json-rpc' \
--header ''\''Content-Type'\'':  '\''application/json'\'',' \
--header ''\''User-Agent'\'':  '\''python/zotero-mcp'\'',' \
--header ''\''Accept'\'':  '\''application/json'\'',' \
--header ''\''Connection'\'':  '\''keep-alive'\'',' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "item.attachments",
    "params": ["<<citation_key>>",<<library_id>>],
    "id": 1
}'
```

But this request ends up in the following error. (of course, with the actual used library ID, but for now changed to a fictional value of 1234567)

```
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32603,
        "message": "Error: library.get: {\"libraryID\":1234567,\"group\":1234567} not found"
    },
    "id": null
}
```

After a while, I figured out that the api expects a library name as a parameter instead of the ID. And this key is available on `matched_item`. So I ended up using this value. 

We also changed the default value to "*" (all libraries). This seems a more logical option than using the default value of 1, since `ZOTERO_LIBRARY_ID` could be configured to a different value, and we can not simply use the ID as a parameter for a better bibtex api call, as shown above.
