### PR TITLE
fix: require fastmcp 2.14+ and drop legacy dependencies arg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "markitdown[pdf]",
     "pydantic>=2.0.0",
     "requests>=2.28.0",
-    "fastmcp>=2.3.0",
+    "fastmcp>=2.14.0",
     "chromadb>=0.4.0",
     "sentence-transformers>=2.2.0",
     "openai>=1.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ mcp>=1.2.0
 python-dotenv>=1.0.0
 markitdown
 pydantic>=2.0.0
-fastmcp>=2.3.0
+fastmcp>=2.14.0

--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -62,12 +62,8 @@ async def server_lifespan(server: FastMCP):
     sys.stderr.write("Shutting down Zotero MCP server...\n")
 
 
-# Create an MCP server with appropriate dependencies
-mcp = FastMCP(
-    "Zotero",
-    dependencies=["pyzotero", "mcp[cli]", "python-dotenv", "markitdown", "fastmcp", "chromadb", "sentence-transformers", "openai", "google-genai"],
-    lifespan=server_lifespan,
-)
+# Create an MCP server (fastmcp 2.14+ no longer accepts `dependencies`)
+mcp = FastMCP("Zotero", lifespan=server_lifespan)
 
 
 @mcp.tool(


### PR DESCRIPTION
Current uv installation fails, because uv automatically uses the latest [fastmcp](https://github.com/jlowin/fastmcp/releases/tag/v2.14.0) which drops the deprecated dependencies arg.

This small patch fixes it by using fastmcp 2.14+ and dropping the legacy dependencies arg