### PR TITLE
Add CI workflow for automated PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Build and publish to PyPI
+on:
+  push:
+    tags:
+    - '*'
+    branches:
+    - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Build package
+        run: |
+          pip install build
+          python -m build
+      - name: Publish package to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+  


### PR DESCRIPTION
Adds a basic CI/CD pipeline using `gh-action-pypi-publish`.

- Adds a workflow to build the package on push/PR/schedule
- Configures automated publishing to PyPI on tag creation
- Uses OIDC (Trusted Publishers) for secure authentication

### Important one-time setup
To make this work without secrets/passwords (which is now best practice), you must:
1. Go to **[PyPI.org Publishing Settings](https://pypi.org/manage/account/publishing/)**.
2. Add a "Pending Publisher".
3. **Owner:** `54yyyu`
4. **Repository:** `zotero-mcp`
5. **Workflow name:** `release.yml`
6. **Project Name:** `zotero-mcp` (or your intended package name).


### Creating a new release
I would recommend to use [GitHub Releases](https://github.com/54yyyu/zotero-mcp/releases) from now on. To release a new version via the GitHub website:

1. **Update Version:** Update `src/zotero_mcp/_version.py` to the new version number and commit to `main`.
2. **Create Release:** Go to [GitHub Releases](https://github.com/54yyyu/zotero-mcp/releases)  and create a new release. The CI will trigger automatically and deploy to PyPI.

I use this exact workflow in multiple repositories (including [Mesa](https://github.com/mesa/mesa), if you want an example).