### PR TITLE
Switch to dynamic version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zotero-mcp"
-version = "0.1.2"
+dynamic = ["version"]
 authors = [
   { name = "54yyyu", email = "54yyyu@github.com" },
 ]
@@ -43,6 +43,9 @@ dev = [
 
 [project.scripts]
 zotero-mcp = "zotero_mcp.cli:main"
+
+[tool.hatch.version]
+path = "src/zotero_mcp/_version.py"
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
Replaces the static version with dynamic versioning using Hatch. The version is now sourced from `src/zotero_mcp/_version.py`, improving maintainability.

If basically prevents updating the version number in one place but not the other.