### PR TITLE
Fix embedding dimension mismatch when querying existing collections

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -175,7 +175,12 @@ class ChromaClient:
             # Get or create collection with embedding function handling
             try:
                 # Try to get existing collection first
-                self.collection = self.client.get_collection(name=self.collection_name)
+                # NOTE: Must pass embedding_function here, otherwise ChromaDB uses default
+                # embeddings for queries, causing dimension mismatch with stored embeddings
+                self.collection = self.client.get_collection(
+                    name=self.collection_name,
+                    embedding_function=self.embedding_function
+                )
 
                 # Check if embedding functions are compatible
                 existing_ef = getattr(self.collection, '_embedding_function', None)


### PR DESCRIPTION
## Summary

- Fixes semantic search failing with dimension mismatch error when using non-default embedding models (e.g., Gemini, OpenAI)
- Passes `embedding_function` parameter to `get_collection()` call

## Problem

When `get_collection()` is called without the `embedding_function` parameter, ChromaDB defaults to using `all-MiniLM-L6-v2` (384 dimensions) for query embeddings. If the collection was built with a different embedding model (e.g., Gemini with 3072 dimensions), this causes the error:

```
Collection expecting embedding with dimension of 3072, got 384
```

## Solution

Pass the configured `embedding_function` to `get_collection()`, ensuring queries use the same embedding model that was used to build the collection.

## Test plan

- [x] Build semantic search database with Gemini embeddings
- [x] Restart MCP server
- [x] Run semantic search query
- [x] Verify results return successfully without dimension mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)