### PR TITLE
Bugfix/search notes

### DIFF
--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -29,7 +29,7 @@ from zotero_mcp.utils import format_creators, clean_html
 @asynccontextmanager
 async def server_lifespan(server: FastMCP):
     """Manage server startup and shutdown lifecycle."""
-    sys.stderr.write("Starting Stefans Zotero MCP server...\n")
+    sys.stderr.write("Starting Zotero MCP server...\n")
 
     # Check for semantic search auto-update on startup
     try:


### PR DESCRIPTION
When calling tool_zotero_search_notes_post the following error is returned „'FunctionTool' object is not callable“