### PR TITLE
Fix ChromaDB embedding function mismatch for non-default models

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -172,29 +172,11 @@ class ChromaClient:
             # Set up embedding function
             self.embedding_function = self._create_embedding_function()
 
-            # Get or create collection with embedding function handling
-            try:
-                # Try to get existing collection first
-                self.collection = self.client.get_collection(name=self.collection_name)
-
-                # Check if embedding functions are compatible
-                existing_ef = getattr(self.collection, '_embedding_function', None)
-                if existing_ef is not None:
-                    existing_name = getattr(existing_ef, 'name', lambda: 'default')()
-                    new_name = getattr(self.embedding_function, 'name', lambda: 'default')()
-
-                    if existing_name != new_name:
-                        # Log to stderr instead of letting ChromaDB print to stdout
-                        sys.stderr.write(f"ChromaDB: Collection exists with different embedding function: {existing_name} vs {new_name}\n")
-                        # Use the existing collection's embedding function to avoid conflicts
-                        self.embedding_function = existing_ef
-
-            except Exception:
-                # Collection doesn't exist, create it
-                self.collection = self.client.create_collection(
-                    name=self.collection_name,
-                    embedding_function=self.embedding_function
-                )
+            # Get or create collection with the configured embedding function
+            self.collection = self.client.get_or_create_collection(
+                name=self.collection_name,
+                embedding_function=self.embedding_function
+            )
 
     def _create_embedding_function(self) -> EmbeddingFunction:
         """Create the appropriate embedding function based on configuration."""


### PR DESCRIPTION
## Summary

- Fixes #126: ChromaDB always reports embedding function mismatch when using non-default models (OpenAI, Gemini, HuggingFace)
- Replaces broken `get_collection()` + manual compatibility check with `get_or_create_collection()`, which correctly passes the configured embedding function for both new and existing collections
- Removes the silent fallback to ChromaDB's default embedding function that caused mismatched queries and degraded search results

## Details

The previous code called `get_collection()` without an embedding function, then tried to compare the (always-default) `_embedding_function` attribute against the configured one. This always produced a false mismatch for non-default models and silently replaced the configured EF with ChromaDB's default `all-MiniLM-L6-v2`.

The fix is a single `get_or_create_collection()` call that passes the configured embedding function directly.

## Test plan

- [ ] Configure with OpenAI embeddings and verify no mismatch warning on startup
- [ ] Verify `--force-rebuild` still works correctly
- [ ] Verify semantic search results are correct (embeddings match between index and query time)
- [ ] Verify default embedding model still works when no custom model is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)