### PR TITLE
feat: enable claude to add papers from DOI and enhance identifier import with PDF attachment and improve collection management

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ Example prompts:
 - "Search for papers on operating system with tag '#Arm'"
 - "Export the BibTeX citation for papers on machine learning"
 - "Create a new journal article in my library titled 'Deep Learning Applications'"
+- "Add a paper by DOI 10.1038/nphys1170"
+- "Import this DOI URL into Zotero: https://doi.org/10.1145/3368089.3409715"
+- "Import this arXiv paper: arXiv:2401.00001"
+- "Add paper from URL: https://arxiv.org/abs/2301.12345"
 - "Update item ABCD1234 to add author Jane Smith"
 - "Update the abstract for item EFGH5678 with the new abstract text"
 - "Add a new book to my library with author John Doe and add it to my 'Reading List' collection"
@@ -331,6 +335,13 @@ zotero_create_item(
     collection_names=["PhD Research", "Machine Learning"]
 )
 
+# Single collection name string is also accepted
+zotero_create_item(
+    item_type="journalArticle",
+    title="Transformer Survey",
+    collection_names="PhD Research"
+)
+
 # Using collection keys (if you already know them)
 zotero_create_item(
     item_type="book",
@@ -404,10 +415,19 @@ The first time you use PDF annotation features, the necessary tools will be auto
 - `zotero_create_note`: Create a new note for an item
 
 ### ✍️ Item & Collection Management Tools
+- `zotero_add_by_identifier`: Add items by DOI or arXiv (`10.x/...`, `https://doi.org/...`, `arXiv:...`, `https://arxiv.org/abs/...`)
 - `zotero_create_item`: Create new items in your library (articles, books, webpages, etc.)
 - `zotero_update_item`: Update existing items (modify title, authors, date, abstract, tags, etc.)
 - `zotero_create_collection`: Create new collections (projects/folders)
 - `zotero_add_items_to_collection`: Add existing items to a collection
+
+`zotero_update_item` collection behavior: passing `collections=[...]` replaces existing collection membership with exactly the provided keys.
+
+`zotero_add_by_identifier` PDF attachment behavior:
+- `attach_mode="auto"` (default): try imported file first, then linked URL fallback.
+- `attach_mode="import_file"`: try imported file only.
+- `attach_mode="linked_url"`: linked URL attachment only.
+- Tool output includes per-item status: `pdf: imported`, `pdf: linked_url`, or `pdf: failed (...)`.
 
 ## 🔍 Troubleshooting
 
@@ -415,6 +435,7 @@ The first time you use PDF annotation features, the necessary tools will be auto
 - **No results found**: Ensure Zotero is running and the local API is enabled. You need to toggle on `Allow other applications on this computer to communicate with Zotero` in Zotero preferences.
 - **Can't connect to library**: Check your API key and library ID if using web API
 - **Full text not available**: Make sure you're using Zotero 7+ for local full-text access
+- **PDF opens in browser instead of Zotero reader**: Use `attach_mode="import_file"` when adding by identifier so Zotero stores a real file attachment.
 - **Local library limitations**: Some functionality (tagging, library modifications) may not work with local JS API. Consider using web library setup for full functionality. (See the [docs](docs/getting-started.md#local-library-limitations) for more info.)
 - **Installation/search option switching issues**: Database problems from changing install methods or search options can often be resolved with `zotero-mcp update-db --force-rebuild`
 

--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -12,6 +12,8 @@ import uuid
 import asyncio
 import json
 import re
+import xml.etree.ElementTree as ET
+from urllib.parse import urljoin
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 
@@ -93,6 +95,47 @@ async def server_lifespan(server: FastMCP):
 
 # Create an MCP server (fastmcp 2.14+ no longer accepts `dependencies`)
 mcp = FastMCP("Zotero", lifespan=server_lifespan)
+
+
+def _normalize_str_list_input(
+    value: Union[List[str], str, None],
+    *,
+    field_name: str
+) -> List[str]:
+    """Normalize list-like user input into a trimmed list of non-empty strings."""
+    if value is None:
+        return []
+
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return []
+
+        parsed: object = None
+        parsed_ok = False
+        try:
+            parsed = json.loads(raw)
+            parsed_ok = True
+        except json.JSONDecodeError:
+            parsed_ok = False
+
+        if parsed_ok:
+            if isinstance(parsed, list):
+                return [str(v).strip() for v in parsed if str(v).strip()]
+            if isinstance(parsed, str):
+                parsed_str = parsed.strip()
+                return [parsed_str] if parsed_str else []
+            raise ValueError(f"{field_name} must be a list of strings or a string")
+
+        parts = [p.strip() for p in raw.split(",") if p.strip()]
+        if len(parts) > 1:
+            return parts
+        return [raw]
+
+    raise ValueError(f"{field_name} must be a list of strings or a string")
 
 
 @mcp.tool(
@@ -2305,30 +2348,35 @@ def search_notes(
 
 @mcp.tool(
     name="zotero_add_by_identifier",
-    description="Add new Zotero item(s) by identifier (DOI, ISBN, arXiv ID, or PMID)."
+    description="Add new Zotero item(s) by DOI or arXiv identifier."
 )
 def add_by_identifier(
     identifiers: Union[List[str], str],
-    collections: Optional[List[str]] = None,
+    collections: Optional[Union[List[str], str]] = None,
     collection_names: Optional[Union[List[str], str]] = None,
     tags: Optional[Union[List[str], str]] = None,
     attach_pdfs: bool = True,
+    attach_mode: Literal["auto", "import_file", "linked_url"] = "auto",
     *,
     ctx: Context
 ) -> str:
     """
-    Create Zotero items using identifiers like DOI, ISBN, arXiv, or PMID.
+    Create Zotero items using DOI or arXiv identifiers.
 
     Args:
         identifiers: Single identifier or list/JSON string of identifiers
         collections: Collection keys to add created items to
         collection_names: Collection names to resolve and add created items to
         tags: Optional tags to apply to the created items
-        attach_pdfs: If true, attempts to attach a PDF as a linked URL when discoverable
+        attach_pdfs: If true, attempts to attach a PDF when discoverable
+        attach_mode: PDF attachment mode:
+            - auto: try imported file attachment first, then linked URL fallback
+            - import_file: try imported file only
+            - linked_url: use linked URL attachment only
         ctx: MCP context
 
     Returns:
-        Markdown summary with created item keys or errors per identifier
+        Markdown summary with created item keys or errors per identifier.
     """
     def _as_list(value) -> List[str]:
         if value is None:
@@ -2352,47 +2400,67 @@ def add_by_identifier(
             return [s]
         return [str(value).strip()]
 
-    def _detect_id_type(raw: str) -> (str, str):
-        s = raw.strip()
-        s_low = s.lower()
-        # Remove common prefixes
-        for pref in ["doi:", "pmid:", "arxiv:"]:
-            if s_low.startswith(pref):
-                s = s[len(pref):].strip()
-                s_low = s.lower()
-                break
-        # URL forms
-        try:
-            if s_low.startswith("http://") or s_low.startswith("https://"):
-                # DOI URL
-                m = re.search(r"doi\.org/(10\.[^\s/#]+/.+)$", s_low)
-                if m:
-                    return ("doi", m.group(1))
-                # arXiv URL
-                m = re.search(r"arxiv\.org/(abs|pdf)/([\w\.-]+)", s_low)
-                if m:
-                    return ("arxiv", m.group(2).replace('.pdf',''))
-                # PubMed URL
-                m = re.search(r"pubmed\.ncbi\.nlm\.nih\.gov/(\d+)/?", s_low)
-                if m:
-                    return ("pmid", m.group(1))
-        except Exception:
-            pass
-        # DOI
-        if s_low.startswith("10.") and "/" in s:
-            return ("doi", s)
-        # arXiv ID
-        # Accept forms like 2101.00001, 2101.00001v2, hep-th/9901001
-        if re.match(r"^(\d{4}\.\d{4,5}(v\d+)?)$", s) or re.match(r"^[a-zA-Z-]+/\d{7}$", s):
-            return ("arxiv", s)
-        # PMID (all digits, reasonable length)
-        if re.match(r"^\d{5,9}$", s):
-            return ("pmid", s)
-        # ISBN 10/13 (strip hyphens/spaces, allow trailing X)
-        s_isbn = re.sub(r"[^0-9Xx]", "", s)
-        if re.match(r"^(\d{9}[\dXx]|\d{13})$", s_isbn):
-            return ("isbn", s_isbn.upper())
-        return ("unknown", s)
+    def _normalize_doi_candidate(raw: str) -> Optional[str]:
+        s = (raw or "").strip()
+        if not s:
+            return None
+
+        # Strip common prefix
+        if s.lower().startswith("doi:"):
+            s = s[4:].strip()
+
+        # DOI URL format
+        if s.lower().startswith("http://") or s.lower().startswith("https://"):
+            m = re.search(r"doi\.org/(10\.\d{4,9}/[^\s?#]+)", s, flags=re.IGNORECASE)
+            if not m:
+                return None
+            s = m.group(1)
+
+        # Trim common trailing punctuation from copied text
+        s = s.rstrip(".,);]")
+
+        # Basic DOI shape validation
+        if re.match(r"^10\.\d{4,9}/\S+$", s):
+            return s
+        return None
+
+    def _normalize_arxiv_candidate(raw: str) -> Optional[str]:
+        s = (raw or "").strip()
+        if not s:
+            return None
+
+        if s.lower().startswith("arxiv:"):
+            s = s[6:].strip()
+
+        # URL forms:
+        # - https://arxiv.org/abs/2401.00001
+        # - https://arxiv.org/pdf/2401.00001.pdf
+        if s.lower().startswith("http://") or s.lower().startswith("https://"):
+            m = re.search(
+                r"arxiv\.org/(?:abs|pdf)/([0-9]{4}\.[0-9]{4,5}(?:v\d+)?|[a-z\-]+/\d{7}(?:v\d+)?)(?:\.pdf)?",
+                s,
+                flags=re.IGNORECASE,
+            )
+            if not m:
+                return None
+            s = m.group(1)
+
+        if re.match(r"^[0-9]{4}\.[0-9]{4,5}(?:v\d+)?$", s):
+            return s
+        if re.match(r"^[a-z\-]+/\d{7}(?:v\d+)?$", s, flags=re.IGNORECASE):
+            return s
+        return None
+
+    def _arxiv_id_from_doi_namespace(doi: str) -> Optional[str]:
+        """
+        Detect arXiv DOI namespace forms like:
+        - 10.48550/arXiv.2603.02553
+        - 10.48550/arXiv.hep-th/9901001
+        """
+        m = re.match(r"^10\.48550/arxiv\.(.+)$", doi or "", flags=re.IGNORECASE)
+        if not m:
+            return None
+        return _normalize_arxiv_candidate(m.group(1))
 
     def _first_or(seq, default=""):
         if isinstance(seq, list) and seq:
@@ -2441,7 +2509,7 @@ def add_by_identifier(
             })
         return creators
 
-    def _fetch_crossref(doi: str) -> Tuple[Optional[Dict[str, any]], Optional[str]]:
+    def _fetch_crossref(doi: str) -> Tuple[Optional[Dict[str, object]], Optional[str]]:
         url = f"https://api.crossref.org/works/{requests.utils.quote(doi)}"
         headers = {"User-Agent": "zotero-mcp (identifier import)"}
         r = requests.get(url, headers=headers, timeout=20)
@@ -2469,7 +2537,7 @@ def add_by_identifier(
         issue = msg.get('issue') or ''
         publisher = msg.get('publisher') or ''
         url_final = msg.get('URL') or (f"https://doi.org/{doi}")
-        data: Dict[str, any] = {
+        data: Dict[str, object] = {
             "itemType": item_type,
             "title": title or f"DOI {doi}",
             "creators": creators,
@@ -2504,103 +2572,180 @@ def add_by_identifier(
             pass
         return data, pdf_url
 
-    def _fetch_openlibrary(isbn: str) -> Optional[Dict[str, any]]:
-        # Prefer the data endpoint that includes author names
-        url = f"https://openlibrary.org/api/books?bibkeys=ISBN:{isbn}&format=json&jscmd=data"
-        r = requests.get(url, timeout=20)
+    def _fetch_arxiv(arxiv_id: str) -> Tuple[Optional[Dict[str, object]], Optional[str]]:
+        url = (
+            "https://export.arxiv.org/api/query"
+            f"?search_query=id:{requests.utils.quote(arxiv_id)}&max_results=1"
+        )
+        r = requests.get(
+            url,
+            timeout=20,
+            headers={"User-Agent": "zotero-mcp (identifier import)"},
+        )
         r.raise_for_status()
-        blob = r.json() or {}
-        entry = blob.get(f"ISBN:{isbn}") or {}
-        title = entry.get('title', '')
-        authors = entry.get('authors', [])
-        creators = _authors_from_names([
-            {"literal": a.get('name', '')} for a in authors
-        ])
-        publishers = entry.get('publishers', [])
-        publisher = publishers[0].get('name') if publishers else ''
-        pub_date = entry.get('publish_date', '')
-        pages = (entry.get('pagination') or '').strip()
-        data = {
-            "itemType": "book",
-            "title": title or f"ISBN {isbn}",
-            "creators": creators,
-            "ISBN": isbn,
-        }
-        if publisher:
-            data["publisher"] = publisher
-        if pub_date:
-            data["date"] = pub_date
-        if pages:
-            data["pages"] = pages
-        return data
 
-    def _fetch_pmid(pmid: str) -> Optional[Dict[str, any]]:
-        url = f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id={pmid}&retmode=json"
-        r = requests.get(url, timeout=20)
-        r.raise_for_status()
-        data = r.json() or {}
-        res = (data.get('result') or {}).get(pmid, {})
-        if not res:
-            return None
-        title = res.get('title', '')
-        journal = res.get('fulljournalname', '')
-        pubdate = res.get('pubdate', '')
-        volume = res.get('volume', '')
-        issue = res.get('issue', '')
-        pages = res.get('pages', '')
-        authors = res.get('authors', [])
-        creators = _authors_from_names([
-            {"literal": a.get('name', '')} for a in authors if a.get('name')
-        ])
-        url_pm = f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/"
-        item = {
-            "itemType": "journalArticle",
-            "title": title or f"PMID {pmid}",
-            "creators": creators,
-            "url": url_pm,
-        }
-        if journal:
-            item["publicationTitle"] = journal
-        if pubdate:
-            item["date"] = pubdate
-        if volume:
-            item["volume"] = volume
-        if issue:
-            item["issue"] = issue
-        if pages:
-            item["pages"] = pages
-        return item
-
-    def _fetch_arxiv(arx: str) -> Optional[Dict[str, any]]:
-        url = f"http://export.arxiv.org/api/query?search_query=id:{arx}"
-        r = requests.get(url, timeout=20, headers={"User-Agent": "zotero-mcp (identifier import)"})
-        r.raise_for_status()
         root = ET.fromstring(r.text)
-        # Namespaces
-        ns = {"atom": "http://www.w3.org/2005/Atom"}
-        entry = root.find('atom:entry', ns)
-        if entry is None:
-            return None
-        title = (entry.findtext('atom:title', default='', namespaces=ns) or '').strip()
-        pub = (entry.findtext('atom:published', default='', namespaces=ns) or '').strip()
-        url_final = (entry.findtext('atom:id', default='', namespaces=ns) or '').strip()
-        authors = [a.findtext('atom:name', default='', namespaces=ns) or '' for a in entry.findall('atom:author', ns)]
-        creators = _authors_from_names([{ "literal": n } for n in authors if n])
-        item = {
-            "itemType": "preprint",
-            "title": title or f"arXiv:{arx}",
-            "creators": creators,
-            "url": url_final or f"https://arxiv.org/abs/{arx}",
+        ns = {
+            "atom": "http://www.w3.org/2005/Atom",
+            "arxiv": "http://arxiv.org/schemas/atom",
         }
-        if pub:
-            item["date"] = pub
-        return item
+        entry = root.find("atom:entry", ns)
+        if entry is None:
+            return None, None
+
+        title = (entry.findtext("atom:title", default="", namespaces=ns) or "").strip()
+        published = (entry.findtext("atom:published", default="", namespaces=ns) or "").strip()
+        abs_url = (entry.findtext("atom:id", default="", namespaces=ns) or "").strip()
+        summary = (entry.findtext("atom:summary", default="", namespaces=ns) or "").strip()
+        doi = (entry.findtext("arxiv:doi", default="", namespaces=ns) or "").strip()
+
+        authors = []
+        for author in entry.findall("atom:author", ns):
+            name = (author.findtext("atom:name", default="", namespaces=ns) or "").strip()
+            if name:
+                authors.append({"literal": name})
+
+        creators = _authors_from_names(authors)
+        item_data: Dict[str, object] = {
+            "itemType": "preprint",
+            "title": title or f"arXiv:{arxiv_id}",
+            "creators": creators,
+            "url": abs_url or f"https://arxiv.org/abs/{arxiv_id}",
+        }
+        if published:
+            item_data["date"] = published[:10]
+        if summary:
+            item_data["abstractNote"] = summary
+        if doi:
+            item_data["DOI"] = doi
+
+        pdf_url = f"https://arxiv.org/pdf/{arxiv_id}.pdf"
+        return item_data, pdf_url
+
+    def _discover_pdf_from_landing_page(landing_url: str) -> Optional[str]:
+        """Best-effort PDF discovery from DOI landing pages."""
+        try:
+            resp = requests.get(
+                landing_url,
+                timeout=20,
+                headers={"User-Agent": "zotero-mcp (identifier import)"},
+                allow_redirects=True,
+            )
+            if not resp.ok:
+                return None
+
+            html = resp.text or ""
+
+            # Common scholarly metadata tag
+            m_meta = re.search(
+                r'<meta[^>]+name=["\']citation_pdf_url["\'][^>]+content=["\']([^"\']+)["\']',
+                html,
+                flags=re.IGNORECASE,
+            )
+            if m_meta:
+                return urljoin(resp.url, m_meta.group(1).strip())
+
+            # Generic href fallback
+            m_href = re.search(
+                r'href=["\']([^"\']+\.pdf(?:\?[^"\']*)?)["\']',
+                html,
+                flags=re.IGNORECASE,
+            )
+            if m_href:
+                return urljoin(resp.url, m_href.group(1).strip())
+        except Exception:
+            return None
+        return None
+
+    def _download_pdf_to_temp(pdf_url: str) -> Tuple[Optional[str], bool, Optional[str]]:
+        """Download candidate PDF URL to a temporary file."""
+        import tempfile
+
+        try:
+            resp = requests.get(
+                pdf_url,
+                timeout=30,
+                allow_redirects=True,
+                headers={"User-Agent": "zotero-mcp (identifier import)"},
+                stream=True,
+            )
+            if not resp.ok:
+                return None, False, f"download failed (HTTP {resp.status_code})"
+
+            ctype = (resp.headers.get("Content-Type") or "").lower()
+            mime_ok = "pdf" in ctype or pdf_url.lower().endswith(".pdf")
+
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmpf:
+                for chunk in resp.iter_content(chunk_size=8192):
+                    if chunk:
+                        tmpf.write(chunk)
+                return tmpf.name, mime_ok, None
+        except Exception as e:
+            return None, False, f"download error: {e}"
+
+    def _attach_pdf_linked_url(zot_client, parent_item_key: str, pdf_url: str) -> Tuple[bool, str]:
+        """Attach PDF as linked URL."""
+        try:
+            probe = requests.head(pdf_url, timeout=10, allow_redirects=True)
+            ctype = (probe.headers.get("Content-Type") or "").lower()
+            if not (probe.ok and ("pdf" in ctype or pdf_url.lower().endswith(".pdf"))):
+                return False, "linked_url rejected (not a PDF URL)"
+
+            attachment_item = {
+                "itemType": "attachment",
+                "parentItem": parent_item_key,
+                "linkMode": "linked_url",
+                "title": "PDF",
+                "url": pdf_url,
+                "contentType": "application/pdf",
+            }
+            att_res = zot_client.create_items([attachment_item])
+            if att_res.get("success"):
+                return True, "linked_url"
+            return False, f"linked_url create failed: {att_res}"
+        except Exception as e:
+            return False, f"linked_url error: {e}"
+
+    def _attach_pdf_imported(zot_client, parent_item_key: str, pdf_path: str) -> Tuple[bool, str]:
+        """Attempt imported file attachment through available pyzotero upload helpers."""
+        fn = getattr(zot_client, "attachment_simple", None)
+        if not callable(fn):
+            return False, "import_file unsupported by active zotero client"
+
+        call_attempts = [
+            lambda: fn([pdf_path], parentid=parent_item_key),
+            lambda: fn([pdf_path], parent_item=parent_item_key),
+            lambda: fn([pdf_path], parent_item_key),
+            lambda: fn(pdf_path, parentid=parent_item_key),
+            lambda: fn(pdf_path, parent_item=parent_item_key),
+            lambda: fn(pdf_path, parent_item_key),
+        ]
+        last_err: Optional[Exception] = None
+        for attempt in call_attempts:
+            try:
+                result = attempt()
+                # pyzotero upload helpers may return dict/None/other truthy values on success
+                if isinstance(result, dict):
+                    if result.get("success") or result.get("successful") or result.get("key"):
+                        return True, "imported"
+                else:
+                    return True, "imported"
+            except TypeError as e:
+                last_err = e
+                continue
+            except Exception as e:
+                last_err = e
+                continue
+        return False, f"import_file failed: {last_err or 'unknown error'}"
 
     try:
         # Prepare inputs
         id_list = _as_list(identifiers)
         if not id_list:
             return "Error: identifiers cannot be empty"
+        if attach_mode not in {"auto", "import_file", "linked_url"}:
+            return "Error: attach_mode must be one of: auto, import_file, linked_url"
+        ctx.info(f"PDF attachment configuration: attach_pdfs={attach_pdfs}, attach_mode={attach_mode}")
 
         tag_list = _as_list(tags)
 
@@ -2608,7 +2753,7 @@ def add_by_identifier(
         zot = get_zotero_client()
         resolved_collections: List[str] = []
         if collections:
-            resolved_collections.extend(collections)
+            resolved_collections.extend(_as_list(collections))
         if collection_names:
             names = _as_list(collection_names)
             if names:
@@ -2636,46 +2781,36 @@ def add_by_identifier(
         created_count = 0
 
         for ident in id_list:
-            id_type, value = _detect_id_type(ident)
-            ctx.info(f"Processing identifier '{ident}' detected as {id_type}")
+            doi = _normalize_doi_candidate(ident)
+            arxiv_id = _normalize_arxiv_candidate(ident)
+            if doi and not arxiv_id:
+                arxiv_id = _arxiv_id_from_doi_namespace(doi)
+            ctx.info(f"Processing identifier '{ident}'")
 
             try:
-                item_data = None
-                pdf_hint: Optional[str] = None
-                if id_type == 'doi':
-                    item_data, pdf_hint = _fetch_crossref(value)
-                elif id_type == 'isbn':
-                    item_data = _fetch_openlibrary(value)
-                elif id_type == 'pmid':
-                    item_data = _fetch_pmid(value)
-                elif id_type == 'arxiv':
-                    item_data = _fetch_arxiv(value)
-                    pdf_hint = f"https://arxiv.org/pdf/{value}.pdf"
-                elif value.lower().startswith("http://") or value.lower().startswith("https://"):
-                    # Try to discover an embedded DOI in the page content
-                    try:
-                        resp = requests.get(value, timeout=20, headers={"User-Agent": "zotero-mcp (identifier import)"})
-                        if resp.ok:
-                            # ACL Anthology heuristic
-                            m_acl = re.search(r"aclanthology\.org/([A-Za-z0-9\-]+)/?", value, flags=re.IGNORECASE)
-                            if m_acl:
-                                slug = m_acl.group(1)
-                                pdf_hint = f"https://aclanthology.org/{slug}.pdf"
-                            m = re.search(r'''doi.org/(10.[^\s'"<>#]+/[\w-./:;()]+)''', resp.text, flags=re.IGNORECASE)
-                            if m:
-                                discovered_doi = m.group(1)
-                                ctx.info(f"Discovered DOI {discovered_doi} in page; importing via Crossref")
-                                item_data, cr_pdf = _fetch_crossref(discovered_doi)
-                                pdf_hint = pdf_hint or cr_pdf
-                    except requests.RequestException as page_err:
-                        ctx.warn(f"Could not fetch page to discover DOI: {page_err}")
-                else:
-                    results_md.append(f"- {ident}: Unsupported or unrecognized identifier format")
+                if not doi and not arxiv_id:
+                    results_md.append(
+                        f"- {ident}: Unsupported identifier format. "
+                        "Supported formats: DOI (`10.x/...`, `https://doi.org/...`) "
+                        "or arXiv (`arXiv:2401.00001`, `https://arxiv.org/abs/...`)."
+                    )
                     continue
+
+                pdf_hint: Optional[str] = None
+                if doi and not arxiv_id:
+                    item_data, pdf_hint = _fetch_crossref(doi)
+                else:
+                    item_data, pdf_hint = _fetch_arxiv(arxiv_id or "")
+                    if doi and item_data and not item_data.get("DOI"):
+                        item_data["DOI"] = doi
 
                 if not item_data:
                     results_md.append(f"- {ident}: No metadata found")
                     continue
+
+                if doi and attach_pdfs and not pdf_hint:
+                    landing_url = str(item_data.get("url") or f"https://doi.org/{doi}")
+                    pdf_hint = _discover_pdf_from_landing_page(landing_url)
 
                 # Attach tags if given
                 if tag_list:
@@ -2689,29 +2824,36 @@ def add_by_identifier(
                 if "success" in result and result["success"]:
                     item_key = next(iter(result["success"].values()))
 
-                    # Attach PDF as linked URL if requested and available
-                    if attach_pdfs and pdf_hint:
-                        try:
-                            probe = requests.head(pdf_hint, timeout=10, allow_redirects=True)
-                            ctype = (probe.headers.get('Content-Type') or '').lower()
-                            if probe.ok and ('pdf' in ctype or pdf_hint.lower().endswith('.pdf')):
-                                attachment_item = {
-                                    "itemType": "attachment",
-                                    "parentItem": item_key,
-                                    "linkMode": "linked_url",
-                                    "title": "PDF",
-                                    "url": pdf_hint,
-                                    "contentType": "application/pdf",
-                                }
-                                att_res = zot.create_items([attachment_item])
-                                if att_res.get('success'):
-                                    ctx.info("Attached PDF as linked URL")
+                    # Attach PDF according to attachment mode
+                    pdf_status = "not requested"
+                    if attach_pdfs:
+                        if not pdf_hint:
+                            pdf_status = "failed (no discoverable PDF URL)"
+                        elif attach_mode == "linked_url":
+                            ok, detail = _attach_pdf_linked_url(zot, item_key, pdf_hint)
+                            pdf_status = "linked_url" if ok else f"failed ({detail})"
+                        else:
+                            file_path = None
+                            try:
+                                file_path, mime_ok, dl_err = _download_pdf_to_temp(pdf_hint)
+                                if not file_path:
+                                    pdf_status = f"failed ({dl_err})"
+                                elif not mime_ok:
+                                    pdf_status = "failed (downloaded resource is not PDF)"
                                 else:
-                                    ctx.warn(f"Failed to attach PDF link: {att_res}")
-                            else:
-                                ctx.warn(f"PDF URL not accessible or not a PDF: {pdf_hint}")
-                        except Exception as attach_err:
-                            ctx.warn(f"Error attaching PDF: {attach_err}")
+                                    ok, detail = _attach_pdf_imported(zot, item_key, file_path)
+                                    if ok:
+                                        pdf_status = "imported"
+                                    elif attach_mode == "auto":
+                                        ctx.warn(f"import_file path failed; falling back to linked_url: {detail}")
+                                        ok2, detail2 = _attach_pdf_linked_url(zot, item_key, pdf_hint)
+                                        pdf_status = "linked_url" if ok2 else f"failed ({detail}; fallback {detail2})"
+                                    else:
+                                        pdf_status = f"failed ({detail})"
+                            finally:
+                                if file_path and os.path.exists(file_path):
+                                    with suppress(Exception):
+                                        os.remove(file_path)
 
                     # Add to collections
                     added_to = []
@@ -2732,7 +2874,7 @@ def add_by_identifier(
                     extra = f" (collections: {', '.join(added_to)})" if added_to else ""
                     if errors:
                         extra += f"; warnings: {'; '.join(errors)}"
-                    results_md.append(f"- {ident}: created item key `{item_key}`{extra}")
+                    results_md.append(f"- {ident}: created item key `{item_key}`{extra}; pdf: {pdf_status}")
                 else:
                     error_details = result.get('failed', {})
                     if error_details:
@@ -2954,16 +3096,18 @@ def create_item(
             if not isinstance(collections, list):
                 return f"Error: collections must be a Python list of strings"
 
-        # Fix collection_names if passed as JSON string
+        # Fix collection_names if passed as JSON string / plain string / comma-separated string
         if collection_names is not None:
-            if isinstance(collection_names, str):
-                try:
-                    collection_names = json.loads(collection_names.strip())
-                    ctx.info(f"✓ Auto-corrected collection_names from JSON string to Python list")
-                except json.JSONDecodeError as e:
-                    return f"Error: collection_names must be a list of strings. Parse error: {str(e)}"
-            if not isinstance(collection_names, list):
-                return f"Error: collection_names must be a Python list of strings"
+            try:
+                collection_names = _normalize_str_list_input(
+                    collection_names, field_name="collection_names"
+                )
+                ctx.info(
+                    "✓ Auto-corrected collection_names to Python list "
+                    f"({len(collection_names)} value(s))"
+                )
+            except ValueError as e:
+                return f"Error: {str(e)}"
 
         # Fix extra_fields if passed as JSON string
         if extra_fields is not None:
@@ -3235,50 +3379,68 @@ def update_item(
         zot = get_zotero_client()
 
         # Input validation and auto-correction for common mistakes
-        # Fix tags if passed as JSON string
-        if tags is not None:
-            if isinstance(tags, str):
-                tags_stripped = tags.strip()
-                try:
-                    tags = json.loads(tags_stripped)
-                    ctx.info(f"✓ Auto-corrected tags from JSON string to Python list")
-                except json.JSONDecodeError:
-                    if ',' in tags_stripped:
-                        tags = [tag.strip() for tag in tags_stripped.split(',') if tag.strip()]
-                        ctx.info(f"✓ Auto-corrected tags from comma-separated string to Python list")
-                    else:
-                        tags = [tags_stripped] if tags_stripped else []
-                        ctx.info(f"✓ Auto-corrected tags from single string to Python list")
+        def _normalize_update_tags_input(
+            value: Optional[Union[List[str], str]],
+            field_name: str,
+        ) -> Tuple[Optional[List[str]], Optional[str]]:
+            if value is None:
+                return None, None
 
-        # Fix add_tags if passed as JSON string
-        if add_tags is not None:
-            if isinstance(add_tags, str):
-                add_tags_stripped = add_tags.strip()
+            parsed_value: object = value
+            parsed_from_json = False
+            if isinstance(value, str):
+                raw = value.strip()
                 try:
-                    add_tags = json.loads(add_tags_stripped)
-                    ctx.info(f"✓ Auto-corrected add_tags from JSON string to Python list")
+                    parsed_value = json.loads(raw)
+                    parsed_from_json = True
+                    ctx.info(f"✓ Auto-corrected {field_name} from JSON string to Python list")
                 except json.JSONDecodeError:
-                    if ',' in add_tags_stripped:
-                        add_tags = [tag.strip() for tag in add_tags_stripped.split(',') if tag.strip()]
-                        ctx.info(f"✓ Auto-corrected add_tags from comma-separated string to Python list")
+                    if "," in raw:
+                        parsed_value = [tag.strip() for tag in raw.split(",") if tag.strip()]
+                        ctx.info(
+                            f"✓ Auto-corrected {field_name} from comma-separated string to Python list"
+                        )
                     else:
-                        add_tags = [add_tags_stripped] if add_tags_stripped else []
-                        ctx.info(f"✓ Auto-corrected add_tags from single string to Python list")
+                        parsed_value = [raw] if raw else []
+                        ctx.info(f"✓ Auto-corrected {field_name} from single string to Python list")
 
-        # Fix remove_tags if passed as JSON string
-        if remove_tags is not None:
-            if isinstance(remove_tags, str):
-                remove_tags_stripped = remove_tags.strip()
-                try:
-                    remove_tags = json.loads(remove_tags_stripped)
-                    ctx.info(f"✓ Auto-corrected remove_tags from JSON string to Python list")
-                except json.JSONDecodeError:
-                    if ',' in remove_tags_stripped:
-                        remove_tags = [tag.strip() for tag in remove_tags_stripped.split(',') if tag.strip()]
-                        ctx.info(f"✓ Auto-corrected remove_tags from comma-separated string to Python list")
-                    else:
-                        remove_tags = [remove_tags_stripped] if remove_tags_stripped else []
-                        ctx.info(f"✓ Auto-corrected remove_tags from single string to Python list")
+            if parsed_from_json and not isinstance(parsed_value, list):
+                return (
+                    None,
+                    f"Error: {field_name} must be a list of strings "
+                    "(JSON arrays only when passing JSON).",
+                )
+
+            if not isinstance(parsed_value, list):
+                return None, f"Error: {field_name} must be a list of strings."
+
+            normalized: List[str] = []
+            for i, tag_value in enumerate(parsed_value):
+                if not isinstance(tag_value, str):
+                    return (
+                        None,
+                        f"Error: {field_name} entries must all be strings. "
+                        f"Entry {i + 1} is {type(tag_value).__name__}.",
+                    )
+                stripped = tag_value.strip()
+                if stripped:
+                    normalized.append(stripped)
+
+            return normalized, None
+
+        tags, tags_error = _normalize_update_tags_input(tags, "tags")
+        if tags_error:
+            return tags_error
+
+        add_tags, add_tags_error = _normalize_update_tags_input(add_tags, "add_tags")
+        if add_tags_error:
+            return add_tags_error
+
+        remove_tags, remove_tags_error = _normalize_update_tags_input(
+            remove_tags, "remove_tags"
+        )
+        if remove_tags_error:
+            return remove_tags_error
 
         # Fix creators if passed as JSON string
         if creators is not None:
@@ -3315,23 +3477,29 @@ def update_item(
 
                 ctx.info(f"Validated {len(creators)} creator(s) successfully")
 
-        # Fix collections if passed as JSON string
+        # Fix collections if passed as JSON string / plain string / comma-separated string
         if collections is not None:
-            if isinstance(collections, str):
-                try:
-                    collections = json.loads(collections)
-                    ctx.info(f"Auto-corrected collections from JSON string to list")
-                except json.JSONDecodeError:
-                    return f"Error: collections parameter must be a list of strings, not a JSON string."
+            try:
+                collections = _normalize_str_list_input(collections, field_name="collections")
+                ctx.info(
+                    "Auto-corrected collections to list "
+                    f"({len(collections)} value(s))"
+                )
+            except ValueError as e:
+                return f"Error: {str(e)}"
 
-        # Fix collection_names if passed as JSON string
+        # Fix collection_names if passed as JSON string / plain string / comma-separated string
         if collection_names is not None:
-            if isinstance(collection_names, str):
-                try:
-                    collection_names = json.loads(collection_names)
-                    ctx.info(f"Auto-corrected collection_names from JSON string to list")
-                except json.JSONDecodeError:
-                    return f"Error: collection_names parameter must be a list of strings, not a JSON string."
+            try:
+                collection_names = _normalize_str_list_input(
+                    collection_names, field_name="collection_names"
+                )
+                ctx.info(
+                    "Auto-corrected collection_names to list "
+                    f"({len(collection_names)} value(s))"
+                )
+            except ValueError as e:
+                return f"Error: {str(e)}"
 
         # Fix extra_fields if passed as JSON string
         if extra_fields is not None:
@@ -3341,6 +3509,8 @@ def update_item(
                     ctx.info(f"Auto-corrected extra_fields from JSON string to dict")
                 except json.JSONDecodeError:
                     return f"Error: extra_fields parameter must be a dictionary, not a JSON string."
+            if not isinstance(extra_fields, dict):
+                return f"Error: extra_fields must be a dictionary. Example: {{'ISBN': '123-456'}}"
 
         # First, fetch the existing item
         try:
@@ -3430,13 +3600,19 @@ def update_item(
                         current_tag_values.add(tag)
                 updates.append(f"added {len(add_tags)} tag(s)")
 
-        # Track collections to add (don't modify item_data["collections"] directly)
-        collections_to_add = []
+        # Track collection operations (don't modify item_data["collections"] directly)
+        collections_to_set: List[str] = []
+        collections_to_add: List[str] = []
 
         if collections is not None:
             # User wants to replace collections - we'll handle this after update
-            collections_to_add = collections
-            updates.append(f"collections will be set to {len(collections)} collection(s)")
+            deduped = []
+            seen = set()
+            for key in collections:
+                if key and key not in seen:
+                    deduped.append(key)
+                    seen.add(key)
+            collections_to_set = deduped
         elif collection_names:
             # Resolve collection names to add
             ctx.info(f"Resolving collection names: {collection_names}")
@@ -3467,8 +3643,10 @@ def update_item(
                 item_data[key] = value
                 updates.append(f"{key}: '{value}'")
 
+        collection_change_requested = collections is not None or bool(collections_to_add)
+
         # Check if there are any updates
-        if not updates and not collections_to_add:
+        if not updates and not collection_change_requested:
             return f"No updates specified for item: \"{original_title}\" (Key: {item_key})"
 
         # Update the item in Zotero (if there are field updates)
@@ -3480,9 +3658,82 @@ def update_item(
                 ctx.error(f"Failed to update item: {str(update_error)}")
                 return f"Failed to update item: {str(update_error)}"
 
-        # Now add to collections if specified
+        # Apply collection changes
         collection_info = ""
-        if collections_to_add:
+        if collections is not None:
+            collection_errors = []
+            added_collections = []
+            removed_collections = []
+
+            current_collection_keys = []
+            for coll_key in item_data.get("collections", []) or []:
+                coll_key_str = str(coll_key).strip()
+                if coll_key_str and coll_key_str not in current_collection_keys:
+                    current_collection_keys.append(coll_key_str)
+
+            target_set = set(collections_to_set)
+            current_set = set(current_collection_keys)
+            to_add = [key for key in collections_to_set if key not in current_set]
+            to_remove = [key for key in current_collection_keys if key not in target_set]
+
+            if to_remove:
+                if not hasattr(zot, "deletefrom_collection"):
+                    collection_errors.append(
+                        "Collection removal is not supported by the current Zotero client. "
+                        f"Could not remove: {', '.join(to_remove)}"
+                    )
+                    ctx.warn("deletefrom_collection not available; cannot remove existing collections")
+                else:
+                    for coll_key in to_remove:
+                        try:
+                            coll_name = coll_key
+                            try:
+                                coll = zot.collection(coll_key)
+                                coll_name = coll["data"].get("name", coll_key)
+                            except Exception:
+                                pass
+
+                            remove_result = zot.deletefrom_collection(coll_key, [item_key])
+                            if remove_result:
+                                removed_collections.append(coll_name)
+                                ctx.info(f"Removed item from collection: {coll_name}")
+                            else:
+                                collection_errors.append(f"Failed to remove from '{coll_name}'")
+                                ctx.warn(f"Failed to remove item from collection: {coll_name}")
+                        except Exception as coll_error:
+                            collection_errors.append(f"Error removing from {coll_key}: {str(coll_error)}")
+                            ctx.warn(f"Error removing from collection {coll_key}: {str(coll_error)}")
+
+            for coll_key in to_add:
+                try:
+                    coll = zot.collection(coll_key)
+                    coll_name = coll["data"].get("name", coll_key)
+                    add_result = zot.addto_collection(coll_key, [item_key])
+
+                    if add_result:
+                        added_collections.append(coll_name)
+                        ctx.info(f"Added item to collection: {coll_name}")
+                    else:
+                        collection_errors.append(f"Failed to add to '{coll_name}'")
+                        ctx.warn(f"Failed to add item to collection: {coll_name}")
+                except Exception as coll_error:
+                    collection_errors.append(f"Error with collection {coll_key}: {str(coll_error)}")
+                    ctx.warn(f"Error adding to collection {coll_key}: {str(coll_error)}")
+
+            if added_collections:
+                collection_info += (
+                    f"\n\n**Added to collection(s):** {', '.join(added_collections)}"
+                )
+            if removed_collections:
+                collection_info += (
+                    f"\n\n**Removed from collection(s):** {', '.join(removed_collections)}"
+                )
+            if collection_errors:
+                collection_info += (
+                    f"\n\n**Collection warnings:**\n"
+                    + "\n".join(f"- {err}" for err in collection_errors)
+                )
+        elif collections_to_add:
             collection_errors = []
             successfully_added = []
 
@@ -3501,7 +3752,7 @@ def update_item(
                         ctx.warn(f"Failed to add item to collection: {coll_name}")
                 except Exception as coll_error:
                     collection_errors.append(f"Error with collection {coll_key}: {str(coll_error)}")
-                    ctx.error(f"Error adding to collection {coll_key}: {str(coll_error)}")
+                    ctx.warn(f"Error adding to collection {coll_key}: {str(coll_error)}")
 
             if successfully_added:
                 collection_info = f"\n\n**Added to collection(s):** {', '.join(successfully_added)}"
@@ -3512,11 +3763,12 @@ def update_item(
         response = [
             f"Successfully updated item: \"{original_title}\"",
             f"Item key: `{item_key}`",
-            "",
-            "**Updated fields:**"
         ]
-        for update in updates:
-            response.append(f"- {update}")
+        if updates:
+            response.append("")
+            response.append("**Updated fields:**")
+            for update in updates:
+                response.append(f"- {update}")
 
         if collection_info:
             response.append(collection_info)

--- a/tests/test_server_add_by_identifier.py
+++ b/tests/test_server_add_by_identifier.py
@@ -1,0 +1,505 @@
+from zotero_mcp import server
+
+
+class DummyContext:
+    def info(self, *_args, **_kwargs):
+        return None
+
+    def error(self, *_args, **_kwargs):
+        return None
+
+    def warn(self, *_args, **_kwargs):
+        return None
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        payload=None,
+        ok=True,
+        status_code=200,
+        headers=None,
+        text="",
+        url="https://example.org",
+        bytes_data=b"%PDF-1.4 test",
+    ):
+        self._payload = payload or {}
+        self.ok = ok
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = text
+        self.url = url
+        self._bytes_data = bytes_data
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise server.requests.HTTPError(f"HTTP {self.status_code}")
+
+    def iter_content(self, chunk_size=8192):
+        for i in range(0, len(self._bytes_data), chunk_size):
+            yield self._bytes_data[i : i + chunk_size]
+
+
+class FakeZotero:
+    def __init__(self):
+        self.created = []
+        self.imported = []
+
+    def collections(self):
+        return [
+            {"key": "COLL001", "data": {"name": "PhD Research"}},
+            {"key": "COLL002", "data": {"name": "Reading List"}},
+        ]
+
+    def collection(self, key):
+        if key == "COLL001":
+            return {"key": key, "data": {"name": "PhD Research"}}
+        return {"key": key, "data": {"name": "Unknown"}}
+
+    def addto_collection(self, _collection_key, _item_keys):
+        return True
+
+    def create_items(self, items):
+        self.created.extend(items)
+        if len(items) == 1 and items[0].get("itemType") == "attachment":
+            return {"success": {"0": "ATTACH001"}}
+        return {"success": {"0": "ITEM0001"}}
+
+    def attachment_simple(self, files, parentid=None, parent_item=None):
+        parent = parentid or parent_item
+        file_path = files[0] if isinstance(files, list) else files
+        self.imported.append({"file": file_path, "parentItem": parent})
+        self.created.append(
+            {
+                "itemType": "attachment",
+                "parentItem": parent,
+                "linkMode": "imported_file",
+                "title": "PDF",
+            }
+        )
+        return {"successful": {"0": "ATTACHIMP1"}}
+
+
+class FakeZoteroNoImport(FakeZotero):
+    def attachment_simple(self, *_args, **_kwargs):
+        raise RuntimeError("upload unavailable")
+
+
+def _crossref_payload(doi="10.1000/test-doi"):
+    return {
+        "message": {
+            "type": "journal-article",
+            "title": ["A DOI Based Paper"],
+            "author": [{"given": "Jane", "family": "Doe"}],
+            "container-title": ["Journal of Tests"],
+            "issued": {"date-parts": [[2024, 5, 1]]},
+            "URL": f"https://doi.org/{doi}",
+            "link": [{"content-type": "application/pdf", "URL": "https://example.org/paper.pdf"}],
+        }
+    }
+
+def _crossref_payload_no_pdf_link(doi="10.1000/no-direct-pdf"):
+    return {
+        "message": {
+            "type": "journal-article",
+            "title": ["A DOI Based Paper"],
+            "author": [{"given": "Jane", "family": "Doe"}],
+            "container-title": ["Journal of Tests"],
+            "issued": {"date-parts": [[2024, 5, 1]]},
+            "URL": f"https://doi.org/{doi}",
+        }
+    }
+
+
+def test_add_by_identifier_supports_raw_doi(monkeypatch):
+    fake_zot = FakeZotero()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+    monkeypatch.setattr(
+        server.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse(payload=_crossref_payload("10.1000/rawdoi")),
+    )
+    monkeypatch.setattr(
+        server.requests,
+        "head",
+        lambda *_args, **_kwargs: FakeResponse(headers={"Content-Type": "application/pdf"}),
+    )
+
+    result = server.add_by_identifier(
+        identifiers="10.1000/rawdoi",
+        attach_pdfs=True,
+        attach_mode="linked_url",
+        ctx=DummyContext(),
+    )
+
+    assert "Created 1 item(s)." in result
+    assert "created item key `ITEM0001`" in result
+    assert fake_zot.created[0]["DOI"] == "10.1000/rawdoi"
+    assert "pdf: linked_url" in result
+
+
+def test_add_by_identifier_supports_doi_url(monkeypatch):
+    fake_zot = FakeZotero()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+    monkeypatch.setattr(
+        server.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse(payload=_crossref_payload("10.1000/url-doi")),
+    )
+
+    result = server.add_by_identifier(
+        identifiers="https://doi.org/10.1000/url-doi",
+        attach_pdfs=False,
+        ctx=DummyContext(),
+    )
+
+    assert "Created 1 item(s)." in result
+    assert fake_zot.created[0]["DOI"] == "10.1000/url-doi"
+    assert "pdf: not requested" in result
+
+
+def test_add_by_identifier_rejects_non_doi_identifier(monkeypatch):
+    fake_zot = FakeZotero()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    result = server.add_by_identifier(
+        identifiers="PMID:12345678",
+        ctx=DummyContext(),
+    )
+
+    assert "No items were created." in result
+    assert "Supported formats: DOI" in result
+
+
+def test_add_by_identifier_reports_crossref_network_error(monkeypatch):
+    fake_zot = FakeZotero()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    def _boom(*_args, **_kwargs):
+        raise server.requests.RequestException("Crossref unavailable")
+
+    monkeypatch.setattr(server.requests, "get", _boom)
+
+    result = server.add_by_identifier(
+        identifiers="10.1000/network-failure",
+        ctx=DummyContext(),
+    )
+
+    assert "Network error fetching metadata" in result
+    assert "Crossref unavailable" in result
+
+
+def test_add_by_identifier_resolves_collection_names(monkeypatch):
+    fake_zot = FakeZotero()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+    monkeypatch.setattr(
+        server.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse(payload=_crossref_payload("10.1000/collection")),
+    )
+
+    result = server.add_by_identifier(
+        identifiers="10.1000/collection",
+        collection_names=["PhD Research"],
+        attach_pdfs=False,
+        ctx=DummyContext(),
+    )
+
+    assert "collections: PhD Research" in result
+
+
+def test_add_by_identifier_skips_pdf_attachment_if_not_pdf(monkeypatch):
+    fake_zot = FakeZotero()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+    monkeypatch.setattr(
+        server.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse(payload=_crossref_payload_no_pdf_link("10.1000/no-pdf")),
+    )
+    monkeypatch.setattr(
+        server.requests,
+        "head",
+        lambda *_args, **_kwargs: FakeResponse(headers={"Content-Type": "text/html"}),
+    )
+
+    result = server.add_by_identifier(
+        identifiers="10.1000/no-pdf",
+        attach_pdfs=True,
+        ctx=DummyContext(),
+    )
+
+    assert "Created 1 item(s)." in result
+    assert len(fake_zot.created) == 1
+    assert "pdf: failed" in result
+
+
+def test_add_by_identifier_discovers_pdf_from_landing_page(monkeypatch):
+    fake_zot = FakeZotero()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    def _mock_get(url, *_args, **_kwargs):
+        if "api.crossref.org/works/" in url:
+            return FakeResponse(payload=_crossref_payload_no_pdf_link("10.1000/discover-pdf"))
+        return FakeResponse(
+            text='<html><head><meta name="citation_pdf_url" content="/downloads/paper.pdf"></head></html>',
+            url="https://publisher.org/article",
+        )
+
+    monkeypatch.setattr(server.requests, "get", _mock_get)
+    monkeypatch.setattr(
+        server.requests,
+        "head",
+        lambda *_args, **_kwargs: FakeResponse(headers={"Content-Type": "application/pdf"}),
+    )
+
+    result = server.add_by_identifier(
+        identifiers="10.1000/discover-pdf",
+        attach_pdfs=True,
+        attach_mode="linked_url",
+        ctx=DummyContext(),
+    )
+
+    assert "Created 1 item(s)." in result
+    # metadata item + discovered PDF attachment
+    assert len(fake_zot.created) == 2
+    assert fake_zot.created[1]["itemType"] == "attachment"
+    assert "pdf: linked_url" in result
+
+
+def test_add_by_identifier_supports_arxiv_id(monkeypatch):
+    fake_zot = FakeZotero()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    arxiv_xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+      <entry>
+        <id>https://arxiv.org/abs/2401.00001</id>
+        <published>2024-01-01T00:00:00Z</published>
+        <title>ArXiv Import Test</title>
+        <summary>Test abstract from arXiv.</summary>
+        <author><name>Alice Researcher</name></author>
+        <author><name>Bob Scientist</name></author>
+        <arxiv:doi>10.1000/arxivdoi</arxiv:doi>
+      </entry>
+    </feed>"""
+
+    monkeypatch.setattr(
+        server.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse(text=arxiv_xml),
+    )
+    monkeypatch.setattr(
+        server.requests,
+        "head",
+        lambda *_args, **_kwargs: FakeResponse(headers={"Content-Type": "application/pdf"}),
+    )
+
+    result = server.add_by_identifier(
+        identifiers="arXiv:2401.00001",
+        attach_pdfs=True,
+        attach_mode="linked_url",
+        ctx=DummyContext(),
+    )
+
+    assert "Created 1 item(s)." in result
+    assert fake_zot.created[0]["itemType"] == "preprint"
+    assert fake_zot.created[0]["title"] == "ArXiv Import Test"
+    assert fake_zot.created[0]["DOI"] == "10.1000/arxivdoi"
+    assert "publicationTitle" not in fake_zot.created[0]
+    assert len(fake_zot.created) == 2
+    assert fake_zot.created[1]["itemType"] == "attachment"
+    assert "pdf: linked_url" in result
+
+
+def test_add_by_identifier_supports_arxiv_url(monkeypatch):
+    fake_zot = FakeZotero()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    arxiv_xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+      <entry>
+        <id>https://arxiv.org/abs/2301.12345</id>
+        <published>2023-01-10T00:00:00Z</published>
+        <title>URL Import Test</title>
+        <summary>Another abstract.</summary>
+        <author><name>Carol Author</name></author>
+      </entry>
+    </feed>"""
+
+    monkeypatch.setattr(
+        server.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse(text=arxiv_xml),
+    )
+
+    result = server.add_by_identifier(
+        identifiers="https://arxiv.org/abs/2301.12345",
+        attach_pdfs=False,
+        ctx=DummyContext(),
+    )
+
+    assert "Created 1 item(s)." in result
+    assert fake_zot.created[0]["itemType"] == "preprint"
+    assert fake_zot.created[0]["title"] == "URL Import Test"
+
+
+def test_add_by_identifier_supports_arxiv_namespace_doi(monkeypatch):
+    fake_zot = FakeZotero()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    arxiv_xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+      <entry>
+        <id>https://arxiv.org/abs/2603.02553</id>
+        <published>2026-03-04T00:00:00Z</published>
+        <title>Namespace DOI Import Test</title>
+        <summary>Imported via arXiv DOI namespace.</summary>
+        <author><name>Dana Example</name></author>
+      </entry>
+    </feed>"""
+
+    monkeypatch.setattr(
+        server.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse(text=arxiv_xml),
+    )
+    monkeypatch.setattr(
+        server.requests,
+        "head",
+        lambda *_args, **_kwargs: FakeResponse(headers={"Content-Type": "application/pdf"}),
+    )
+
+    result = server.add_by_identifier(
+        identifiers="10.48550/arXiv.2603.02553",
+        attach_pdfs=True,
+        attach_mode="linked_url",
+        ctx=DummyContext(),
+    )
+
+    assert "Created 1 item(s)." in result
+    assert fake_zot.created[0]["itemType"] == "preprint"
+    assert fake_zot.created[0]["DOI"] == "10.48550/arXiv.2603.02553"
+    assert "pdf: linked_url" in result
+
+
+def test_add_by_identifier_import_file_mode_success(monkeypatch):
+    fake_zot = FakeZotero()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    def _mock_get(url, *_args, **_kwargs):
+        if "api.crossref.org/works/" in url:
+            return FakeResponse(payload=_crossref_payload("10.1000/import-ok"))
+        return FakeResponse(headers={"Content-Type": "application/pdf"})
+
+    monkeypatch.setattr(server.requests, "get", _mock_get)
+
+    result = server.add_by_identifier(
+        identifiers="10.1000/import-ok",
+        attach_pdfs=True,
+        attach_mode="import_file",
+        ctx=DummyContext(),
+    )
+
+    assert "Created 1 item(s)." in result
+    assert "pdf: imported" in result
+
+
+def test_add_by_identifier_linked_url_mode(monkeypatch):
+    fake_zot = FakeZotero()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+    monkeypatch.setattr(
+        server.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse(payload=_crossref_payload("10.1000/linked")),
+    )
+    monkeypatch.setattr(
+        server.requests,
+        "head",
+        lambda *_args, **_kwargs: FakeResponse(headers={"Content-Type": "application/pdf"}),
+    )
+
+    result = server.add_by_identifier(
+        identifiers="10.1000/linked",
+        attach_pdfs=True,
+        attach_mode="linked_url",
+        ctx=DummyContext(),
+    )
+
+    assert "pdf: linked_url" in result
+    assert fake_zot.created[1]["linkMode"] == "linked_url"
+
+
+def test_add_by_identifier_import_file_mode_failure_warns(monkeypatch):
+    fake_zot = FakeZoteroNoImport()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+    monkeypatch.setattr(
+        server.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse(payload=_crossref_payload("10.1000/import-fail")),
+    )
+
+    result = server.add_by_identifier(
+        identifiers="10.1000/import-fail",
+        attach_pdfs=True,
+        attach_mode="import_file",
+        ctx=DummyContext(),
+    )
+
+    assert "Created 1 item(s)." in result
+    assert "pdf: failed" in result
+    # only metadata item should be created
+    assert len(fake_zot.created) == 1
+
+
+def test_add_by_identifier_auto_fallback_to_linked_url(monkeypatch):
+    fake_zot = FakeZoteroNoImport()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+    monkeypatch.setattr(
+        server.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse(payload=_crossref_payload("10.1000/auto-fallback")),
+    )
+    monkeypatch.setattr(
+        server.requests,
+        "head",
+        lambda *_args, **_kwargs: FakeResponse(headers={"Content-Type": "application/pdf"}),
+    )
+
+    result = server.add_by_identifier(
+        identifiers="10.1000/auto-fallback",
+        attach_pdfs=True,
+        attach_mode="auto",
+        ctx=DummyContext(),
+    )
+
+    assert "pdf: linked_url" in result
+    assert len(fake_zot.created) == 2
+    assert fake_zot.created[1]["linkMode"] == "linked_url"
+
+
+def test_add_by_identifier_auto_both_paths_fail(monkeypatch):
+    fake_zot = FakeZoteroNoImport()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+    monkeypatch.setattr(
+        server.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse(payload=_crossref_payload("10.1000/auto-both-fail")),
+    )
+    monkeypatch.setattr(
+        server.requests,
+        "head",
+        lambda *_args, **_kwargs: FakeResponse(ok=False, status_code=404, headers={"Content-Type": "text/html"}),
+    )
+
+    result = server.add_by_identifier(
+        identifiers="10.1000/auto-both-fail",
+        attach_pdfs=True,
+        attach_mode="auto",
+        ctx=DummyContext(),
+    )
+
+    assert "Created 1 item(s)." in result
+    assert "pdf: failed" in result

--- a/tests/test_server_item_management.py
+++ b/tests/test_server_item_management.py
@@ -1,0 +1,230 @@
+from zotero_mcp import server
+
+
+class DummyContext:
+    def info(self, *_args, **_kwargs):
+        return None
+
+    def error(self, *_args, **_kwargs):
+        return None
+
+    def warn(self, *_args, **_kwargs):
+        return None
+
+
+class FakeZoteroItemManagement:
+    def __init__(self):
+        self.collection_names = {
+            "A": "Alpha",
+            "B": "Beta",
+            "C": "Gamma",
+            "COLL001": "PhD Research",
+            "COLL002": "Reading List",
+        }
+        self.collection_name_to_key = {
+            "phd research": "COLL001",
+            "reading list": "COLL002",
+        }
+        self.items_by_key = {
+            "ITEM1": {
+                "key": "ITEM1",
+                "data": {
+                    "title": "Test Item",
+                    "itemType": "journalArticle",
+                    "collections": ["A", "B"],
+                    "tags": [],
+                    "creators": [],
+                },
+            }
+        }
+        self.add_calls = []
+        self.remove_calls = []
+        self.updated_items = []
+        self.created_items = []
+
+    def item(self, key):
+        if key not in self.items_by_key:
+            raise KeyError(key)
+        return self.items_by_key[key]
+
+    def update_item(self, item):
+        self.updated_items.append(item)
+        return {"success": True}
+
+    def collections(self):
+        output = []
+        for name_lower, key in self.collection_name_to_key.items():
+            output.append({"key": key, "data": {"name": self.collection_names[key]}})
+        return output
+
+    def collection(self, key):
+        if key not in self.collection_names:
+            raise KeyError(key)
+        return {"key": key, "data": {"name": self.collection_names[key]}}
+
+    def addto_collection(self, collection_key, item_keys):
+        if collection_key not in self.collection_names:
+            return False
+        self.add_calls.append((collection_key, list(item_keys)))
+        return True
+
+    def deletefrom_collection(self, collection_key, item_keys):
+        if collection_key not in self.collection_names:
+            return False
+        self.remove_calls.append((collection_key, list(item_keys)))
+        return True
+
+    def create_items(self, items):
+        self.created_items.extend(items)
+        return {"success": {"0": "ITEMNEW1"}}
+
+
+def test_update_item_collections_strict_replace_with_overlap(monkeypatch):
+    fake_zot = FakeZoteroItemManagement()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    result = server.update_item(
+        item_key="ITEM1",
+        collections=["B", "C"],
+        ctx=DummyContext(),
+    )
+
+    assert ("A", ["ITEM1"]) in fake_zot.remove_calls
+    assert ("C", ["ITEM1"]) in fake_zot.add_calls
+    assert ("B", ["ITEM1"]) not in fake_zot.add_calls
+    assert "**Removed from collection(s):** Alpha" in result
+    assert "**Added to collection(s):** Gamma" in result
+
+
+def test_update_item_collections_clear_all(monkeypatch):
+    fake_zot = FakeZoteroItemManagement()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    result = server.update_item(
+        item_key="ITEM1",
+        collections=[],
+        ctx=DummyContext(),
+    )
+
+    assert ("A", ["ITEM1"]) in fake_zot.remove_calls
+    assert ("B", ["ITEM1"]) in fake_zot.remove_calls
+    assert fake_zot.add_calls == []
+    assert "**Removed from collection(s):** Alpha, Beta" in result
+
+
+def test_update_item_collections_invalid_key_best_effort(monkeypatch):
+    fake_zot = FakeZoteroItemManagement()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    result = server.update_item(
+        item_key="ITEM1",
+        collections=["A", "INVALID"],
+        ctx=DummyContext(),
+    )
+
+    assert ("B", ["ITEM1"]) in fake_zot.remove_calls
+    assert ("A", ["ITEM1"]) not in fake_zot.add_calls
+    assert "Collection warnings" in result
+    assert "INVALID" in result
+
+
+def test_create_item_accepts_plain_collection_name_string(monkeypatch):
+    fake_zot = FakeZoteroItemManagement()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    result = server.create_item(
+        item_type="journalArticle",
+        title="Plain Collection Name",
+        collection_names="PhD Research",
+        ctx=DummyContext(),
+    )
+
+    assert "Successfully created journalArticle" in result
+    assert ("COLL001", ["ITEMNEW1"]) in fake_zot.add_calls
+
+
+def test_create_item_accepts_comma_separated_collection_names(monkeypatch):
+    fake_zot = FakeZoteroItemManagement()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    result = server.create_item(
+        item_type="journalArticle",
+        title="Comma Collections",
+        collection_names="PhD Research, Reading List",
+        ctx=DummyContext(),
+    )
+
+    assert "Successfully created journalArticle" in result
+    assert ("COLL001", ["ITEMNEW1"]) in fake_zot.add_calls
+    assert ("COLL002", ["ITEMNEW1"]) in fake_zot.add_calls
+
+
+def test_update_item_rejects_json_scalar_tags(monkeypatch):
+    fake_zot = FakeZoteroItemManagement()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    result = server.update_item(
+        item_key="ITEM1",
+        tags='"ml"',
+        ctx=DummyContext(),
+    )
+
+    assert "tags must be a list of strings" in result
+    assert fake_zot.updated_items == []
+
+
+def test_update_item_rejects_json_object_add_tags(monkeypatch):
+    fake_zot = FakeZoteroItemManagement()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    result = server.update_item(
+        item_key="ITEM1",
+        add_tags='{"not":"a-list"}',
+        ctx=DummyContext(),
+    )
+
+    assert "add_tags must be a list of strings" in result
+    assert fake_zot.updated_items == []
+
+
+def test_update_item_rejects_json_scalar_remove_tags(monkeypatch):
+    fake_zot = FakeZoteroItemManagement()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    result = server.update_item(
+        item_key="ITEM1",
+        remove_tags='"ml"',
+        ctx=DummyContext(),
+    )
+
+    assert "remove_tags must be a list of strings" in result
+    assert fake_zot.updated_items == []
+
+
+def test_update_item_rejects_non_dict_extra_fields(monkeypatch):
+    fake_zot = FakeZoteroItemManagement()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    result = server.update_item(
+        item_key="ITEM1",
+        extra_fields='["a"]',
+        ctx=DummyContext(),
+    )
+
+    assert "extra_fields must be a dictionary" in result
+    assert fake_zot.updated_items == []
+
+
+def test_update_item_accepts_plain_string_tags(monkeypatch):
+    fake_zot = FakeZoteroItemManagement()
+    monkeypatch.setattr(server, "get_zotero_client", lambda: fake_zot)
+
+    result = server.update_item(
+        item_key="ITEM1",
+        tags="ml",
+        ctx=DummyContext(),
+    )
+
+    assert "Successfully updated item" in result
+    assert len(fake_zot.updated_items) == 1
+    assert fake_zot.updated_items[0]["data"]["tags"] == [{"tag": "ml"}]


### PR DESCRIPTION

*This work refines and builds upon the excellent foundation introduced in [PR #83](https://github.com/54yyyu/zotero-mcp/pull/83) (Added the ability to add new literature to zotero).*

#### 🚀 Key Features & Improvements
* **Identifier Import (`zotero_add_by_identifier`)**: Improved regex and normalization for extracting DOIs and arXiv IDs. Direct metadata resolution via Crossref and arXiv API.
* **Automated PDF Discovery & Attachment**: Added  PDF discovery directly from DOI landing pages and arXiv endpoints. Introduced three `attach_mode` options (`auto`, `import_file`, `linked_url`).
* **Advanced Collection Management (`zotero_update_item`)**: Passing `collections=[...]` now strictly replaces the existing collection membership (safely executing `deletefrom_collection` and `addto_collection`).
* **Parameter Parsing**: Added `_normalize_str_list_input` to automatically parse and correct common LLM string-generation mistakes (e.g., passing a JSON string or comma-separated string instead of a strict Python list).

#### 📚 Documentation & Testing
* **README**: Added usage examples, documented the new `attach_mode` parameters, and updated the troubleshooting section.
* **Tests**: Introduced dedicated test suites for the new identifier and item management pipelines.
