### PR TITLE
fix: enable search_notes to find notes by content

### DIFF
--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -24,7 +24,6 @@ from zotero_mcp.client import (
     generate_bibtex,
     get_active_library,
     get_attachment_details,
-    get_web_zotero_client,
     get_zotero_client,
     set_active_library,
 )
@@ -2194,42 +2193,32 @@ def create_note(
             "tags": [{"tag": tag} for tag in (tags or [])]
         }
 
-        # In local mode, the local API does not support POST to create items,
-        # and the connector/saveItems endpoint ignores parentItem (creating
-        # standalone notes instead of child notes). If an API key is available,
-        # use the web API which properly supports parentItem.
+        # Use connector/saveItems for local mode since the local API
+        # does not support POST to /api/users/0/items
         if is_local_mode():
-            web_zot = get_web_zotero_client()
-            if web_zot is not None:
-                result = web_zot.create_items([note_data])
+            port = os.getenv("ZOTERO_LOCAL_PORT", "23119")
+            connector_url = f"http://127.0.0.1:{port}/connector/saveItems"
+            payload = {
+                "items": [
+                    {
+                        "itemType": "note",
+                        "note": html_content,
+                        "tags": [tag for tag in (tags or [])],
+                        "parentItem": item_key,
+                    }
+                ],
+                "uri": "about:blank",
+            }
+            resp = requests.post(
+                connector_url,
+                headers={"Content-Type": "application/json"},
+                json=payload,
+                timeout=30,
+            )
+            if resp.status_code == 201:
+                return f"Successfully created note for \"{parent_title}\" (parent key: {item_key})"
             else:
-                # Fallback: connector endpoint (note will NOT be attached as child)
-                port = os.getenv("ZOTERO_LOCAL_PORT", "23119")
-                connector_url = f"http://127.0.0.1:{port}/connector/saveItems"
-                payload = {
-                    "items": [
-                        {
-                            "itemType": "note",
-                            "note": html_content,
-                            "tags": [tag for tag in (tags or [])],
-                            "parentItem": item_key,
-                        }
-                    ],
-                    "uri": "about:blank",
-                }
-                resp = requests.post(
-                    connector_url,
-                    headers={"Content-Type": "application/json"},
-                    json=payload,
-                    timeout=30,
-                )
-                if resp.status_code == 201:
-                    return (
-                        f"Note created for \"{parent_title}\" but may not be attached as a child item. "
-                        f"Set ZOTERO_API_KEY and ZOTERO_LIBRARY_ID to enable proper child note creation."
-                    )
-                else:
-                    return f"Failed to create note via local connector (HTTP {resp.status_code}): {resp.text}"
+                return f"Failed to create note via local connector (HTTP {resp.status_code}): {resp.text}"
         else:
             # Remote API: use pyzotero's create_items
             result = zot.create_items([note_data])


### PR DESCRIPTION
## Summary

`zotero_search_notes` currently returns no results for any query. This PR fixes two issues that combine to make the tool non-functional:

**Bug 1: Missing `qmode="everything"`**

The Zotero API's `q` parameter defaults to `qmode=titleCreatorYear`, which only searches title, creator, and year fields. Since notes don't have meaningful values for these fields, the API always returns an empty result set. The fix adds `qmode="everything"` so the API searches within note body content. (The `search_items` function on [line 89](https://github.com/54yyyu/zotero-mcp/blob/e67c24d/src/zotero_mcp/server.py#L89) already exposes this parameter correctly.)

**Bug 2: Overly strict client-side filter**

After the API call, the code filters results with:
```python
if query_lower in note_text:
```
This requires the **entire query** to appear as a contiguous substring. A query like `"belief updating financial"` fails to match a note containing `"belief updating... financial domains"` because the words aren't adjacent. Changed to token-based matching (`all(term in note_text for term in query_terms)`) so all query words must appear, but not necessarily contiguously.

**Note:** A separate issue with `create_note` not attaching notes as child items in local mode is addressed in #139.

## Testing

Verified against a local Zotero library (2,381 items, `ZOTERO_LOCAL=true`):
- Direct Zotero API call with `qmode=everything` returns the correct notes (`curl` test)
- After both fixes, `zotero_search_notes` returns matching notes for multi-word queries
- Exact substring queries (e.g., `"I have added a note"`) continue to work as before

## Changes

Two lines changed in `src/zotero_mcp/server.py`:
- Line 2001: Added `qmode="everything"` to `add_parameters` call
- Lines 2029-2036: Changed from full-string substring match to per-term matching