### PR TITLE
fix: attach notes as child items in local mode via web API

### DIFF
--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -24,6 +24,7 @@ from zotero_mcp.client import (
     generate_bibtex,
     get_active_library,
     get_attachment_details,
+    get_web_zotero_client,
     get_zotero_client,
     set_active_library,
 )
@@ -2192,32 +2193,42 @@ def create_note(
             "tags": [{"tag": tag} for tag in (tags or [])]
         }
 
-        # Use connector/saveItems for local mode since the local API
-        # does not support POST to /api/users/0/items
+        # In local mode, the local API does not support POST to create items,
+        # and the connector/saveItems endpoint ignores parentItem (creating
+        # standalone notes instead of child notes). If an API key is available,
+        # use the web API which properly supports parentItem.
         if is_local_mode():
-            port = os.getenv("ZOTERO_LOCAL_PORT", "23119")
-            connector_url = f"http://127.0.0.1:{port}/connector/saveItems"
-            payload = {
-                "items": [
-                    {
-                        "itemType": "note",
-                        "note": html_content,
-                        "tags": [tag for tag in (tags or [])],
-                        "parentItem": item_key,
-                    }
-                ],
-                "uri": "about:blank",
-            }
-            resp = requests.post(
-                connector_url,
-                headers={"Content-Type": "application/json"},
-                json=payload,
-                timeout=30,
-            )
-            if resp.status_code == 201:
-                return f"Successfully created note for \"{parent_title}\" (parent key: {item_key})"
+            web_zot = get_web_zotero_client()
+            if web_zot is not None:
+                result = web_zot.create_items([note_data])
             else:
-                return f"Failed to create note via local connector (HTTP {resp.status_code}): {resp.text}"
+                # Fallback: connector endpoint (note will NOT be attached as child)
+                port = os.getenv("ZOTERO_LOCAL_PORT", "23119")
+                connector_url = f"http://127.0.0.1:{port}/connector/saveItems"
+                payload = {
+                    "items": [
+                        {
+                            "itemType": "note",
+                            "note": html_content,
+                            "tags": [tag for tag in (tags or [])],
+                            "parentItem": item_key,
+                        }
+                    ],
+                    "uri": "about:blank",
+                }
+                resp = requests.post(
+                    connector_url,
+                    headers={"Content-Type": "application/json"},
+                    json=payload,
+                    timeout=30,
+                )
+                if resp.status_code == 201:
+                    return (
+                        f"Note created for \"{parent_title}\" but may not be attached as a child item. "
+                        f"Set ZOTERO_API_KEY and ZOTERO_LIBRARY_ID to enable proper child note creation."
+                    )
+                else:
+                    return f"Failed to create note via local connector (HTTP {resp.status_code}): {resp.text}"
         else:
             # Remote API: use pyzotero's create_items
             result = zot.create_items([note_data])


### PR DESCRIPTION
## Summary

Fixes #138 — `zotero_create_note` in local mode creates standalone notes instead of child notes.

### Problem

In local mode, `create_note` uses the `/connector/saveItems` endpoint because the local Zotero API doesn't support `POST` to `/api/users/0/items`. However, the connector endpoint silently ignores the `parentItem` field, so notes are always created as standalone items — never attached to the specified parent.

The function returns a success message (`"Successfully created note for ..."`), masking the fact that the note is orphaned.

### Fix

When in local mode, check if a web API client is available via the existing `get_web_zotero_client()` (which requires `ZOTERO_API_KEY` and `ZOTERO_LIBRARY_ID`). If available, use it — the web API properly supports `parentItem`. If not available, fall back to the connector with a warning message informing the user that the note may not be attached.

No new dependencies — uses the existing `get_web_zotero_client()` from `client.py`.

## Testing

Verified against a local Zotero library (`ZOTERO_LOCAL=true`):

- **Before fix:** `create_note` returns 201 success, but note has `parentItem: NONE` in the database
- **After fix (with API key):** Note is properly created as a child item, confirmed via `get_item_children`
- **After fix (without API key):** Falls back to connector, returns warning message about potential non-attachment

## Changes

- `src/zotero_mcp/server.py`:
  - Added `get_web_zotero_client` to imports from `zotero_mcp.client`
  - `create_note`: In local mode, prefer web API client for note creation; fall back to connector with warning