### PR TITLE
fix: create_note attaches child notes properly in local mode

### DIFF
--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -2201,6 +2201,15 @@ def create_note(
             web_zot = get_web_zotero_client()
             if web_zot is not None:
                 result = web_zot.create_items([note_data])
+                if "success" in result and result["success"]:
+                    successful = result["success"]
+                    if len(successful) > 0:
+                        note_key = next(iter(successful.keys()))
+                        return f"Successfully created note for \"{parent_title}\"\n\nNote key: {note_key}"
+                    else:
+                        return f"Note creation response was successful but no key was returned: {result}"
+                else:
+                    return f"Failed to create note: {result.get('failed', 'Unknown error')}"
             else:
                 # Fallback: connector endpoint (note will NOT be attached as child)
                 port = os.getenv("ZOTERO_LOCAL_PORT", "23119")


### PR DESCRIPTION
## Summary

Fixes #138

In local mode (`ZOTERO_LOCAL=true`), `create_note` uses the `/connector/saveItems` endpoint, which silently ignores the `parentItem` field. This means notes are created as standalone items instead of being attached as children of the target paper.

**This PR fixes two issues:**

1. **Notes not attached as children:** When `ZOTERO_API_KEY` and `ZOTERO_LIBRARY_ID` are set, the function now uses the web API via `get_web_zotero_client()` (already available in `client.py`), which properly supports `parentItem`. When the API key is not available, the connector endpoint is still used as a fallback, but with a warning message explaining the limitation.

2. **Missing return statement causing validation error:** The web API code path was missing return statements after `create_items()`, causing the function to return `None` instead of a success/failure string. This triggered an MCP output validation error (`"None is not of type 'string'"`).

### Why the web API is needed

- The Zotero local API (`/api/users/0/items`) does not support POST — it returns `"Endpoint does not support method"`
- The `/connector/saveItems` endpoint (designed for browser extensions) ignores `parentItem`, always creating standalone notes
- Only the web API (`api.zotero.org`) properly supports creating child notes via the `parentItem` field in the note data

### Changes

- `server.py`: In `create_note()`, when in local mode, attempt to use the web API first (via existing `get_web_zotero_client()`). Fall back to connector endpoint with a warning if no API key is configured. Added proper return statements for the web API success/failure paths.
- Added `get_web_zotero_client` to the imports from `client.py`

## Test plan

- [x] Create note with `ZOTERO_API_KEY` + `ZOTERO_LIBRARY_ID` set → note attached as child, success message returned
- [x] Verify note appears under parent item in Zotero desktop app
- [x] Tested on multiple items to confirm consistent behavior
- [x] Verified no output validation errors after return statement fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)