### PR TITLE
fix: remove hardcoded fulltext truncation limits

### DIFF
--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -59,8 +59,9 @@ class ZoteroItem:
             parts.append(f"Notes: {self.notes}")
 
         if self.fulltext:
-            # Truncate fulltext to avoid overly long documents
-            truncated_fulltext = self.fulltext[:5000] + "..." if len(self.fulltext) > 5000 else self.fulltext
+            # Truncate very long fulltext for simple text search
+            max_chars = 50000
+            truncated_fulltext = self.fulltext[:max_chars] + "..." if len(self.fulltext) > max_chars else self.fulltext
             parts.append(f"Content: {truncated_fulltext}")
 
         return "\n\n".join(parts)
@@ -249,9 +250,9 @@ class LocalZoteroReader:
         text = self._extract_text_from_file(target)
         if not text:
             return None
-        # Truncate to keep embeddings reasonable
+        # Determine source type
         source = "pdf" if target.suffix.lower() == ".pdf" else ("html" if target.suffix.lower() in {".html", ".htm"} else "file")
-        return (text[:10000], source)
+        return (text, source)
 
     def close(self):
         """Close database connection."""

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -624,7 +624,9 @@ class ZoteroSemanticSearch:
                 pass
 
             # Process items in batches
-            batch_size = 50
+            # Keep batch size under OpenAI's 300k token-per-request limit
+            # (25 × 8000 max tokens = 200k, well within the limit)
+            batch_size = 25
             # Track next milestone for progress printing (every 10 items)
             next_milestone = 10 if stats["total_items"] >= 10 else stats["total_items"]
             # Count of items seen (including skipped), used for progress milestones

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+
+from zotero_mcp.local_db import ZoteroItem, LocalZoteroReader
+
+
+class FakeLocalZoteroReader(LocalZoteroReader):
+    """Subclass that skips DB init and allows injecting fake attachment text."""
+
+    def __init__(self, fake_text: str = "", fake_pdf_path: Path | None = None):
+        # Skip parent __init__ entirely — no DB needed
+        self.db_path = "/dev/null"
+        self._connection = None
+        self.pdf_max_pages = 10
+        self._fake_text = fake_text
+        self._fake_pdf_path = fake_pdf_path
+
+    def _iter_parent_attachments(self, parent_item_id: int):
+        """Yield a single fake PDF attachment."""
+        yield "FAKEKEY", "storage:fake.pdf", "application/pdf"
+
+    def _resolve_attachment_path(self, attachment_key: str, zotero_path: str):
+        """Return the injected fake path."""
+        return self._fake_pdf_path
+
+    def _extract_text_from_file(self, file_path):
+        """Return the injected fake text instead of reading a real file."""
+        return self._fake_text
+
+
+def test_extract_fulltext_preserves_long_text(tmp_path):
+    """Extracted text longer than 10,000 chars should NOT be truncated."""
+    fake_pdf = tmp_path / "fake.pdf"
+    fake_pdf.touch()
+    long_text = "x" * 25000
+    reader = FakeLocalZoteroReader(fake_text=long_text, fake_pdf_path=fake_pdf)
+    result = reader._extract_fulltext_for_item(1)
+    assert result is not None
+    text, source = result
+    assert len(text) == 25000, f"Text was truncated to {len(text)} chars"
+    assert source == "pdf"
+
+
+def test_extract_fulltext_empty_returns_none(tmp_path):
+    """Empty extracted text should return None."""
+    fake_pdf = tmp_path / "fake.pdf"
+    fake_pdf.touch()
+    reader = FakeLocalZoteroReader(fake_text="", fake_pdf_path=fake_pdf)
+    result = reader._extract_fulltext_for_item(1)
+    assert result is None
+
+
+def test_get_searchable_text_preserves_long_fulltext():
+    """get_searchable_text should not aggressively truncate fulltext."""
+    long_fulltext = "y" * 20000
+    item = ZoteroItem(item_id=1, key="TEST", item_type_id=1, fulltext=long_fulltext)
+    text = item.get_searchable_text()
+    # The full 20,000 chars should appear in the output (not truncated to 5,000)
+    assert "y" * 20000 in text
+
+
+def test_get_searchable_text_truncates_at_limit():
+    """Fulltext beyond 50,000 chars should be truncated with ellipsis."""
+    huge_fulltext = "z" * 60000
+    item = ZoteroItem(item_id=1, key="TEST", item_type_id=1, fulltext=huge_fulltext)
+    text = item.get_searchable_text()
+    # Should contain exactly 50,000 z's plus "..." — not all 60,000
+    assert "z" * 50000 in text
+    assert "z" * 50001 not in text
+    assert "..." in text


### PR DESCRIPTION
Fixes #153. Removes the two hardcoded character truncation limits in `local_db.py` that capped fulltext far below what embedding models can actually handle, and reduces embedding batch size to prevent exceeding OpenAI's per-request token limit.

## Summary
- **`_extract_fulltext_for_item()`:** Removed `text[:10000]`. Extraction volume is already bounded by `pdf_max_pages`, and the embedding pipeline has its own model-aware truncation via `_truncate_to_tokens` + `embedding_max_tokens`.
- **`get_searchable_text()`:** Raised `fulltext[:5000]` to `fulltext[:50000]`. This method is only used for simple text search, not embeddings, but 5k was unnecessarily conservative.
- **`batch_size`:** Reduced from 50 to 25 in `_process_item_batch()`. With fulltext docs up to 8k tokens each, batches of 50 could reach 400k tokens — exceeding OpenAI's 300k token-per-request limit and forcing expensive per-document fallback retries.

## Motivation
The 10,000-char cap in _extract_fulltext_for_item() truncated extracted text far below embedding model capacity (~32k chars for text-embedding-3-small), making pdf_max_pages effectively useless beyond ~3 pages. Removed — extraction volume is already bounded by pdf_max_pages, and the embedding pipeline has model-aware truncation via _truncate_to_tokens.

With the truncation removed, documents are much larger, which exposed the batch size issue: 50 large fulltext docs × 8k tokens = 400k tokens per API request, exceeding OpenAI's 300k limit. Reducing to 25 keeps worst case at 200k.

## Integration
The existing pipeline already has the right controls at each stage:

| Stage | Control | Default |
|-------|---------|---------|
| PDF extraction | `pdf_max_pages` | 10 pages |
| Embedding input | `_truncate_to_tokens` using `embedding_max_tokens` | Model-specific (8k tokens for OpenAI) |
| Batch size | `batch_size = 25` | 200k tokens max per request |

## Tests
- New unit tests in `tests/test_local_db.py` covering both truncation changes
- All tests pass
- Manually ran `zotero-mcp update-db --fulltext --force-rebuild --limit 50`, queried ChromaDB directly for documents with `has_fulltext=True` — character counts exceed the old 10k limit, no batch token errors