### PR TITLE
fix: abort when --fulltext is used without ZOTERO_LOCAL enabled

### DIFF
--- a/src/zotero_mcp/cli.py
+++ b/src/zotero_mcp/cli.py
@@ -387,7 +387,15 @@ def main():
 
             print("Starting database update...")
             if args.fulltext:
-                print("Note: --fulltext flag enabled. Will extract content from local database if available.")
+                from zotero_mcp.utils import is_local_mode
+                if not is_local_mode():
+                    print(
+                        "Error: --fulltext requires local mode but ZOTERO_LOCAL is not enabled.\n"
+                        "Set ZOTERO_LOCAL=true or run 'zotero-mcp setup' to enable local mode.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+                print("Extracting fulltext from local Zotero database...", file=sys.stderr)
             stats = search.update_database(
                 force_full_rebuild=args.force_rebuild,
                 limit=args.limit,

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -260,7 +260,8 @@ class ZoteroSemanticSearch:
         """
         Get items from either local database or API.
 
-        Uses local database only when both extract_fulltext=True and is_local_mode().
+        When extract_fulltext=True, requires local mode (ZOTERO_LOCAL=true);
+        raises SystemExit if local mode is not enabled.
         Otherwise uses API (faster, metadata-only).
 
         Args:
@@ -272,7 +273,12 @@ class ZoteroSemanticSearch:
         Returns:
             List of items in API-compatible format
         """
-        if extract_fulltext and is_local_mode():
+        if extract_fulltext:
+            if not is_local_mode():
+                raise SystemExit(
+                    "Error: --fulltext requires local mode but ZOTERO_LOCAL is not enabled.\n"
+                    "Set ZOTERO_LOCAL=true or run 'zotero-mcp setup' to enable local mode."
+                )
             return self._get_items_from_local_db(
                 limit,
                 extract_fulltext=extract_fulltext,

--- a/tests/test_fulltext_local_mode.py
+++ b/tests/test_fulltext_local_mode.py
@@ -1,0 +1,64 @@
+"""Tests for --fulltext + ZOTERO_LOCAL interaction."""
+
+import sys
+
+import pytest
+
+if sys.version_info >= (3, 14):
+    pytest.skip(
+        "chromadb currently relies on pydantic v1 paths that are incompatible with Python 3.14+",
+        allow_module_level=True,
+    )
+
+from zotero_mcp import semantic_search
+
+
+class FakeChromaClient:
+    def __init__(self):
+        self.embedding_max_tokens = 8000
+
+    def get_existing_ids(self, ids):
+        return set()
+
+    def upsert_documents(self, documents, metadatas, ids):
+        pass
+
+    def reset_collection(self):
+        pass
+
+
+def test_get_items_from_source_aborts_when_fulltext_without_local_mode(monkeypatch):
+    """Requesting fulltext extraction without local mode should raise SystemExit."""
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: object())
+    monkeypatch.setattr(semantic_search, "is_local_mode", lambda: False)
+    search = semantic_search.ZoteroSemanticSearch(chroma_client=FakeChromaClient())
+
+    with pytest.raises(SystemExit, match="ZOTERO_LOCAL"):
+        search._get_items_from_source(extract_fulltext=True)
+
+
+def test_get_items_from_source_proceeds_when_fulltext_with_local_mode(monkeypatch):
+    """Requesting fulltext extraction with local mode should not raise."""
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: object())
+    monkeypatch.setattr(semantic_search, "is_local_mode", lambda: True)
+
+    # Mock _get_items_from_local_db to avoid needing a real DB
+    search = semantic_search.ZoteroSemanticSearch(chroma_client=FakeChromaClient())
+    monkeypatch.setattr(search, "_get_items_from_local_db", lambda *a, **kw: [])
+
+    # Should not raise
+    result = search._get_items_from_source(extract_fulltext=True)
+    assert result == []
+
+
+def test_get_items_from_source_no_abort_without_fulltext(monkeypatch):
+    """Without --fulltext, should proceed regardless of local mode."""
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: object())
+    monkeypatch.setattr(semantic_search, "is_local_mode", lambda: False)
+
+    search = semantic_search.ZoteroSemanticSearch(chroma_client=FakeChromaClient())
+    monkeypatch.setattr(search, "_get_items_from_api", lambda *a, **kw: [])
+
+    # Should not raise — fulltext not requested
+    result = search._get_items_from_source(extract_fulltext=False)
+    assert result == []


### PR DESCRIPTION
## Motivation
Previously, `--fulltext` was silently ignored when `ZOTERO_LOCAL` was not set to `true`. The code fell through to metadata-only indexing with no warning, so users could burn API credits on a full rebuild thinking they were getting fulltext embeddings.

Now aborts early with a clear error message:

```
Error: --fulltext requires local mode but ZOTERO_LOCAL is not enabled.
Set ZOTERO_LOCAL=true or run 'zotero-mcp setup' to enable local mode.
```

## Changes
The check is implemented at two layers:
- **CLI** (`cli.py`): Catches the misconfiguration before any work begins, exits with code 1
- **Library** (`semantic_search.py`): Raises `SystemExit` as a safety net for programmatic callers

## Context
- This happened to me because my Claude Desktop config (`claude_desktop_config.json`) had `ZOTERO_LOCAL=false` under `mcpServers.zotero.env`. 
- The CLI loads this config via `setup_zotero_environment()`, which overrides the `ZOTERO_LOCAL=true` fallback default. 
- The original message "Note: --fulltext flag enabled. Will extract content from local database if available." message implied graceful degradation but actually meant "silently does nothing."

## Tests
- Claude created new unit tests in `tests/test_fulltext_local_mode.py` covering: abort when fulltext+no-local, proceed when fulltext+local, no abort without fulltext
- All tests pass
- I manually ran `ZOTERO_LOCAL=false zotero-mcp update-db --fulltext` and verified it aborts immediately with the error message