### PR TITLE
Fix tiktoken ValueError on special tokens in fulltext

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -73,7 +73,7 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
             import tiktoken
             if not hasattr(self, '_tokenizer'):
                 self._tokenizer = tiktoken.get_encoding("cl100k_base")
-            tokens = self._tokenizer.encode(text)
+            tokens = self._tokenizer.encode(text, disallowed_special=())
             if len(tokens) > max_tokens:
                 tokens = tokens[:max_tokens]
                 text = self._tokenizer.decode(tokens)
@@ -354,7 +354,7 @@ class ChromaClient:
         try:
             import tiktoken
             enc = tiktoken.get_encoding("cl100k_base")
-            tokens = enc.encode(text)
+            tokens = enc.encode(text, disallowed_special=())
             if len(tokens) > max_tokens:
                 tokens = tokens[:max_tokens]
                 text = enc.decode(tokens)

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -41,7 +41,7 @@ def _truncate_to_tokens(text: str, max_tokens: int = 8000) -> str:
     falls back to conservative character-based estimation.
     """
     if _tokenizer is not None:
-        tokens = _tokenizer.encode(text)
+        tokens = _tokenizer.encode(text, disallowed_special=())
         if len(tokens) > max_tokens:
             tokens = tokens[:max_tokens]
             text = _tokenizer.decode(tokens)

--- a/tests/test_semantic_search_quality.py
+++ b/tests/test_semantic_search_quality.py
@@ -326,7 +326,7 @@ class TestModelAwareTokenizer:
 # ---------------------------------------------------------------------------
 # Regression: tiktoken special tokens in PDF text must not raise ValueError
 # Bug: tiktoken.encode() defaults to disallowed_special="all", which raises
-# when input contains strings like <|endoftext|> (common in ML papers).
+# ValueError when input contains strings like <|endoftext|> (common in ML papers).
 # Fix: all encode() call sites pass disallowed_special=().
 # ---------------------------------------------------------------------------
 

--- a/tests/test_semantic_search_quality.py
+++ b/tests/test_semantic_search_quality.py
@@ -324,6 +324,60 @@ class TestModelAwareTokenizer:
 
 
 # ---------------------------------------------------------------------------
+# Regression: tiktoken special tokens in PDF text must not raise ValueError
+# Bug: tiktoken.encode() defaults to disallowed_special="all", which raises
+# when input contains strings like <|endoftext|> (common in ML papers).
+# Fix: all encode() call sites pass disallowed_special=().
+# ---------------------------------------------------------------------------
+
+class TestTiktokenSpecialTokenHandling:
+    """Text containing tiktoken special tokens must not raise ValueError."""
+
+    SPECIAL_TOKEN_TEXT = (
+        "The model uses <|endoftext|> as a separator token. "
+        "Other tokens include <|fim_prefix|> and <|fim_suffix|>."
+    )
+
+    def test_openai_truncate_with_special_tokens(self):
+        from zotero_mcp.chroma_client import OpenAIEmbeddingFunction
+
+        ef = OpenAIEmbeddingFunction.__new__(OpenAIEmbeddingFunction)
+        # Must not raise ValueError
+        result = ef.truncate(self.SPECIAL_TOKEN_TEXT, max_tokens=5)
+        assert len(result) > 0
+        assert len(result) < len(self.SPECIAL_TOKEN_TEXT)
+
+    def test_openai_truncate_preserves_special_token_text(self):
+        from zotero_mcp.chroma_client import OpenAIEmbeddingFunction
+
+        ef = OpenAIEmbeddingFunction.__new__(OpenAIEmbeddingFunction)
+        # With a generous limit, text should pass through unchanged
+        result = ef.truncate(self.SPECIAL_TOKEN_TEXT, max_tokens=5000)
+        assert result == self.SPECIAL_TOKEN_TEXT
+
+    def test_chroma_truncate_text_fallback_with_special_tokens(self):
+        from zotero_mcp.chroma_client import ChromaClient
+
+        client = ChromaClient.__new__(ChromaClient)
+        # Use an embedding function without a truncate method to hit fallback
+        client.embedding_function = MagicMock(spec=[])
+        client.embedding_function.max_input_tokens = 5000
+
+        # Must not raise ValueError
+        result = client.truncate_text(self.SPECIAL_TOKEN_TEXT, max_tokens=5)
+        assert len(result) > 0
+        assert len(result) < len(self.SPECIAL_TOKEN_TEXT)
+
+    def test_truncate_to_tokens_with_special_tokens(self):
+        from zotero_mcp.semantic_search import _truncate_to_tokens
+
+        # Must not raise ValueError
+        result = _truncate_to_tokens(self.SPECIAL_TOKEN_TEXT, max_tokens=5)
+        assert len(result) > 0
+        assert len(result) < len(self.SPECIAL_TOKEN_TEXT)
+
+
+# ---------------------------------------------------------------------------
 # Fix 5: Cross-encoder re-ranking
 # ---------------------------------------------------------------------------
 

--- a/tests/test_semantic_search_quality.py
+++ b/tests/test_semantic_search_quality.py
@@ -338,20 +338,25 @@ class TestTiktokenSpecialTokenHandling:
         "Other tokens include <|fim_prefix|> and <|fim_suffix|>."
     )
 
+    @staticmethod
+    def _expected_truncation(text, max_tokens):
+        """Compute expected tiktoken truncation for exact-output assertions."""
+        import tiktoken
+        enc = tiktoken.get_encoding("cl100k_base")
+        tokens = enc.encode(text, disallowed_special=())[:max_tokens]
+        return enc.decode(tokens)
+
     def test_openai_truncate_with_special_tokens(self):
         from zotero_mcp.chroma_client import OpenAIEmbeddingFunction
 
         ef = OpenAIEmbeddingFunction.__new__(OpenAIEmbeddingFunction)
-        # Must not raise ValueError
         result = ef.truncate(self.SPECIAL_TOKEN_TEXT, max_tokens=5)
-        assert len(result) > 0
-        assert len(result) < len(self.SPECIAL_TOKEN_TEXT)
+        assert result == self._expected_truncation(self.SPECIAL_TOKEN_TEXT, 5)
 
     def test_openai_truncate_preserves_special_token_text(self):
         from zotero_mcp.chroma_client import OpenAIEmbeddingFunction
 
         ef = OpenAIEmbeddingFunction.__new__(OpenAIEmbeddingFunction)
-        # With a generous limit, text should pass through unchanged
         result = ef.truncate(self.SPECIAL_TOKEN_TEXT, max_tokens=5000)
         assert result == self.SPECIAL_TOKEN_TEXT
 
@@ -363,18 +368,20 @@ class TestTiktokenSpecialTokenHandling:
         client.embedding_function = MagicMock(spec=[])
         client.embedding_function.max_input_tokens = 5000
 
-        # Must not raise ValueError
         result = client.truncate_text(self.SPECIAL_TOKEN_TEXT, max_tokens=5)
-        assert len(result) > 0
-        assert len(result) < len(self.SPECIAL_TOKEN_TEXT)
+        assert result == self._expected_truncation(self.SPECIAL_TOKEN_TEXT, 5)
 
     def test_truncate_to_tokens_with_special_tokens(self):
         from zotero_mcp.semantic_search import _truncate_to_tokens
 
-        # Must not raise ValueError
         result = _truncate_to_tokens(self.SPECIAL_TOKEN_TEXT, max_tokens=5)
-        assert len(result) > 0
-        assert len(result) < len(self.SPECIAL_TOKEN_TEXT)
+        assert result == self._expected_truncation(self.SPECIAL_TOKEN_TEXT, 5)
+
+    def test_truncate_to_tokens_preserves_special_token_text(self):
+        from zotero_mcp.semantic_search import _truncate_to_tokens
+
+        result = _truncate_to_tokens(self.SPECIAL_TOKEN_TEXT, max_tokens=5000)
+        assert result == self.SPECIAL_TOKEN_TEXT
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_semantic_search_quality.py
+++ b/tests/test_semantic_search_quality.py
@@ -7,6 +7,7 @@ Covers:
 - Fix 5: Cross-encoder re-ranking
 """
 
+import importlib.util
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -330,6 +331,10 @@ class TestModelAwareTokenizer:
 # Fix: all encode() call sites pass disallowed_special=().
 # ---------------------------------------------------------------------------
 
+@pytest.mark.skipif(
+    not importlib.util.find_spec("tiktoken"),
+    reason="tiktoken not installed",
+)
 class TestTiktokenSpecialTokenHandling:
     """Text containing tiktoken special tokens must not raise ValueError."""
 


### PR DESCRIPTION
## Summary

- Fix `ValueError: Encountered text corresponding to disallowed special token '<|endoftext|>'` during `update-db --fulltext`
- Affects items whose PDF text contains OpenAI special token strings (common in ML papers)
- Three `tiktoken.encode()` call sites now pass `disallowed_special=()` to encode special token strings as normal text
- Five regression tests with exact-output assertions covering all three call sites

## Details

`tiktoken.encode()` defaults to `disallowed_special="all"`, which raises when input contains strings like `<|endoftext|>`. This causes `update-db --fulltext` to skip any paper whose PDF discusses GPT-style special tokens.

The fix uses `disallowed_special=()` (not `allowed_special="all"`) because:
1. **Accurate token counting** — matches how the OpenAI embeddings API tokenizes the same text
2. **No embedding distortion** — avoids signaling a false document boundary to the model
3. **Defensive** — treats everything as plain text, which is the correct semantics for truncation

## Test plan

- [x] `pytest` passes (377 tests)
- [x] Red-green verified: all 5 regression tests fail without the fix
- [x] `update-db --fulltext` successfully indexes papers containing `<|endoftext|>` in their PDF text