### PR TITLE
feat: add Pinecone as alternative vector store backend for semantic search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Pinecone vector store backend** — alternative to ChromaDB for semantic search. New optional `[pinecone]` extra enables cloud-hosted vector search via [Pinecone](https://www.pinecone.io/).
+  - `vector_store.py`: backend-agnostic `VectorStoreClient` protocol and `create_vector_client()` factory; selects backend via `ZOTERO_VECTOR_BACKEND` env var or `vector_backend` config key (default: `"chroma"`).
+  - `pinecone_client.py`: drop-in `PineconeClient` with standalone embedding adapters (default/OpenAI/Gemini/HuggingFace), Chroma-style filter translation, and score-to-distance conversion.
+  - `setup_helper.py`: interactive setup now prompts for vector backend choice (ChromaDB or Pinecone) with API key, index name, cloud, and region configuration.
+  - `cli.py`: `db-inspect` command detects Pinecone backend and adapts stats/document display accordingly.
+
 ## [0.2.2] - 2026-03-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -97,8 +97,7 @@ Heavy ML/PDF dependencies are separated into optional extras so the base install
 
 | Extra | What it adds | Install command |
 |-------|-------------|-----------------|
-| `semantic` | Semantic search via ChromaDB, sentence-transformers, OpenAI/Gemini embeddings | `pip install "zotero-mcp-server[semantic]"` |
-| `pdf` | PDF outline extraction (PyMuPDF) and EPUB annotation support | `pip install "zotero-mcp-server[pdf]"` |
+| `semantic` | Semantic search via ChromaDB, sentence-transformers, OpenAI/Gemini embeddings | `pip install "zotero-mcp-server[semantic]"` || `pinecone` | Semantic search via [Pinecone](https://www.pinecone.io/) cloud vector DB (alternative to ChromaDB) | `pip install "zotero-mcp-server[pinecone]"` || `pdf` | PDF outline extraction (PyMuPDF) and EPUB annotation support | `pip install "zotero-mcp-server[pdf]"` |
 | `scite` | [Scite](https://scite.ai) citation intelligence — tallies and retraction alerts (no account needed) | `pip install "zotero-mcp-server[scite]"` |
 | `all` | Everything above | `pip install "zotero-mcp-server[all]"` |
 
@@ -278,6 +277,7 @@ zotero-mcp setup --no-local --api-key YOUR_API_KEY --library-id YOUR_LIBRARY_ID
 - `ZOTERO_LIBRARY_TYPE`: The type of library (user or group, default: user)
 
 **Semantic Search:**
+- `ZOTERO_VECTOR_BACKEND`: Vector store backend — `chroma` (default) or `pinecone`
 - `ZOTERO_EMBEDDING_MODEL`: Embedding model to use (default, openai, gemini)
 - `OPENAI_API_KEY`: Your OpenAI API key (for OpenAI embeddings)
 - `OPENAI_EMBEDDING_MODEL`: OpenAI model name (text-embedding-3-small, text-embedding-3-large)
@@ -286,6 +286,10 @@ zotero-mcp setup --no-local --api-key YOUR_API_KEY --library-id YOUR_LIBRARY_ID
 - `GEMINI_EMBEDDING_MODEL`: Gemini model name (gemini-embedding-001)
 - `GEMINI_BASE_URL`: Custom Gemini endpoint URL (optional, for use with compatible APIs)
 - `ZOTERO_DB_PATH`: Custom `zotero.sqlite` path (optional)
+
+**Pinecone (alternative to ChromaDB):**
+- `PINECONE_API_KEY`: Your Pinecone API key
+- `PINECONE_INDEX_NAME`: Pinecone index name (default: `zotero-library`)
 
 ### Command-Line Options
 
@@ -403,6 +407,11 @@ A 45-point live integration test plan is included at `docs/integration-test-plan
 - **Semantic search returns no results**: Ensure the database is initialized with `zotero-mcp update-db` and check status with `zotero-mcp db-status`
 - **Limited search quality**: For better semantic search results, use `zotero-mcp update-db --fulltext` to index full-text content (requires local Zotero setup)
 - **OpenAI/Gemini API errors**: Verify your API keys are correctly set and have sufficient credits/quota
+
+### Pinecone Issues
+- **"PINECONE_API_KEY not found"**: Set the `PINECONE_API_KEY` environment variable or configure it via `zotero-mcp setup`
+- **Index creation fails**: Verify your Pinecone plan supports serverless indexes and the chosen cloud/region is available
+- **Switching from ChromaDB to Pinecone**: Set `ZOTERO_VECTOR_BACKEND=pinecone` and run `zotero-mcp update-db --force-rebuild` to re-index into Pinecone
 
 ### Update Issues
 - **Update command fails**: Check your internet connection and try `zotero-mcp update --force`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,13 @@ semantic = [
     "google-genai>=0.7.0",
     "tiktoken>=0.7.0",
 ]
+pinecone = [
+    "pinecone>=5.0.0",
+    "sentence-transformers>=2.2.0",
+    "openai>=1.0.0",
+    "google-genai>=0.7.0",
+    "tiktoken>=0.7.0",
+]
 pdf = [
     "pymupdf>=1.24.0",
     "ebooklib>=0.18",
@@ -45,7 +52,7 @@ scite = [
     "requests>=2.28.0",
 ]
 all = [
-    "zotero-mcp-server[semantic,pdf,scite]",
+    "zotero-mcp-server[semantic,pinecone,pdf,scite]",
 ]
 dev = [
     "zotero-mcp-server[all]",

--- a/src/zotero_mcp/cli.py
+++ b/src/zotero_mcp/cli.py
@@ -484,12 +484,23 @@ def main():
         try:
             search = create_semantic_search(str(config_path))
             client = search.chroma_client
-            col = client.collection
+
+            # Detect backend: Pinecone clients expose get_all_documents();
+            # ChromaDB clients expose .collection directly.
+            _is_pinecone = hasattr(client, "get_all_documents")
 
             if args.stats:
-                # Show aggregate stats (merged from former db-stats)
-                meta = col.get(include=["metadatas"])  # type: ignore
-                metas = meta.get("metadatas", [])
+                # Show aggregate stats
+                if _is_pinecone:
+                    # Pinecone: fetch a bigger sample for stats
+                    info = client.get_collection_info()
+                    sample_limit = min(info.get("count", 500), 500)
+                    data = client.get_all_documents(limit=sample_limit)
+                    metas = data.get("metadatas", [])
+                else:
+                    col = client.collection
+                    meta = col.get(include=["metadatas"])  # type: ignore
+                    metas = meta.get("metadatas", [])
                 print("=== Semantic DB Inspection (Stats) ===")
                 info = client.get_collection_info()
                 print(f"Collection: {info.get('name')} @ {info.get('persist_directory')}")
@@ -531,12 +542,17 @@ def main():
                         print(f"  {t[:80]}{'...' if len(t)>80 else ''}: {c}")
                 return
 
-            include = ["metadatas"]
-            if args.show_documents:
-                include.append("documents")
-
-            # Fetch up to limit; filter client-side if requested
-            data = col.get(limit=args.limit, include=include)
+            # Non-stats inspection: fetch documents for display
+            if _is_pinecone:
+                data = client.get_all_documents(
+                    limit=args.limit, include_documents=args.show_documents
+                )
+            else:
+                include = ["metadatas"]
+                if args.show_documents:
+                    include.append("documents")
+                col = client.collection
+                data = col.get(limit=args.limit, include=include)
 
             print("=== Semantic DB Inspection ===")
             total = client.get_collection_info().get("count", 0)

--- a/src/zotero_mcp/pinecone_client.py
+++ b/src/zotero_mcp/pinecone_client.py
@@ -1,0 +1,670 @@
+"""
+Pinecone client for semantic search functionality.
+
+This module provides a Pinecone-backed vector database for semantic search
+over Zotero libraries. It implements the same interface as ChromaClient,
+allowing it to be used as a drop-in replacement.
+"""
+
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Maximum bytes for document text stored in Pinecone metadata.
+# Pinecone allows 40KB total metadata per vector; we reserve ~5KB for
+# structured fields and store up to 35KB of document text.
+_MAX_DOC_TEXT_BYTES = 35_000
+
+# Known embedding dimensions for auto-creating Pinecone indexes.
+_EMBEDDING_DIMENSIONS: dict[str, int] = {
+    "default": 384,  # all-MiniLM-L6-v2
+    "openai": 1536,  # text-embedding-3-small
+    "gemini": 768,  # gemini-embedding-001
+    "qwen": 1024,  # Qwen3-Embedding-0.6B
+    "embeddinggemma": 384,  # embeddinggemma-300m
+}
+
+
+# ---------------------------------------------------------------------------
+# Standalone embedding functions (no chromadb dependency)
+# ---------------------------------------------------------------------------
+
+
+class _BaseEmbedding:
+    """Base class for embedding functions used by PineconeClient."""
+
+    max_input_tokens: int = 8000
+    model_name: str = ""
+
+    def __call__(self, texts: list[str]) -> list[list[float]]:
+        raise NotImplementedError
+
+    def embed_query(self, text: str) -> list[float]:
+        """Embed a single query string."""
+        return self.__call__([text])[0]
+
+    def truncate(self, text: str, max_tokens: int) -> str:
+        """Truncate text to approximately *max_tokens* tokens."""
+        max_chars = max_tokens * 3
+        return text[:max_chars] if len(text) > max_chars else text
+
+
+class _OpenAIEmbedding(_BaseEmbedding):
+    max_input_tokens = 8000
+
+    def __init__(
+        self, model_name: str = "text-embedding-3-small", api_key: str | None = None, base_url: str | None = None
+    ):
+        self.model_name = model_name
+        import openai
+
+        kwargs: dict[str, Any] = {"api_key": api_key or os.getenv("OPENAI_API_KEY")}
+        resolved_base = base_url or os.getenv("OPENAI_BASE_URL")
+        if resolved_base:
+            kwargs["base_url"] = resolved_base
+        self.client = openai.OpenAI(**kwargs)
+
+    def __call__(self, texts: list[str]) -> list[list[float]]:
+        response = self.client.embeddings.create(model=self.model_name, input=texts)
+        return [data.embedding for data in response.data]
+
+    def truncate(self, text: str, max_tokens: int) -> str:
+        try:
+            import tiktoken
+
+            enc = tiktoken.get_encoding("cl100k_base")
+            tokens = enc.encode(text)
+            if len(tokens) > max_tokens:
+                return enc.decode(tokens[:max_tokens])
+        except ImportError:
+            max_chars = max_tokens * 3
+            if len(text) > max_chars:
+                return text[:max_chars]
+        return text
+
+
+class _GeminiEmbedding(_BaseEmbedding):
+    max_input_tokens = 2000
+
+    def __init__(
+        self, model_name: str = "gemini-embedding-001", api_key: str | None = None, base_url: str | None = None
+    ):
+        self.model_name = model_name
+        from google import genai
+        from google.genai import types
+
+        resolved_key = api_key or os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+        kwargs: dict[str, Any] = {"api_key": resolved_key}
+        resolved_base = base_url or os.getenv("GEMINI_BASE_URL")
+        if resolved_base:
+            kwargs["http_options"] = types.HttpOptions(baseUrl=resolved_base)
+        self.client = genai.Client(**kwargs)
+        self._types = types
+
+    def __call__(self, texts: list[str]) -> list[list[float]]:
+        embeddings: list[list[float]] = []
+        for text in texts:
+            response = self.client.models.embed_content(
+                model=self.model_name,
+                contents=[text],
+                config=self._types.EmbedContentConfig(
+                    task_type="retrieval_document",
+                    title="Zotero library document",
+                ),
+            )
+            embeddings.append(response.embeddings[0].values)
+        return embeddings
+
+    def embed_query(self, text: str) -> list[float]:
+        response = self.client.models.embed_content(
+            model=self.model_name,
+            contents=[text],
+            config=self._types.EmbedContentConfig(task_type="retrieval_query"),
+        )
+        return response.embeddings[0].values
+
+    def truncate(self, text: str, max_tokens: int) -> str:
+        max_chars = max_tokens * 4
+        return text[:max_chars] if len(text) > max_chars else text
+
+
+class _HuggingFaceEmbedding(_BaseEmbedding):
+    def __init__(self, model_name: str = "Qwen/Qwen3-Embedding-0.6B"):
+        self.model_name = model_name
+        from sentence_transformers import SentenceTransformer
+
+        logger.info(f"Loading embedding model: {model_name}")
+        self.model = SentenceTransformer(model_name, trust_remote_code=True)
+        self.max_input_tokens = getattr(self.model, "max_seq_length", 500)
+
+    def __call__(self, texts: list[str]) -> list[list[float]]:
+        embeddings = self.model.encode(texts, convert_to_numpy=True)
+        return embeddings.tolist()
+
+    def truncate(self, text: str, max_tokens: int) -> str:
+        tokenizer = getattr(self.model, "tokenizer", None)
+        if tokenizer is not None:
+            encoded = tokenizer.encode(text, add_special_tokens=False)
+            if len(encoded) > max_tokens:
+                return tokenizer.decode(encoded[:max_tokens])
+        else:
+            max_chars = max_tokens * 2
+            if len(text) > max_chars:
+                return text[:max_chars]
+        return text
+
+
+class _DefaultEmbedding(_BaseEmbedding):
+    """Uses sentence-transformers all-MiniLM-L6-v2 (same as ChromaDB default)."""
+
+    max_input_tokens = 256
+
+    def __init__(self):
+        from sentence_transformers import SentenceTransformer
+
+        self.model_name = "all-MiniLM-L6-v2"
+        self.model = SentenceTransformer(self.model_name)
+
+    def __call__(self, texts: list[str]) -> list[list[float]]:
+        embeddings = self.model.encode(texts, convert_to_numpy=True)
+        return embeddings.tolist()
+
+    def truncate(self, text: str, max_tokens: int) -> str:
+        max_chars = max_tokens * 2
+        return text[:max_chars] if len(text) > max_chars else text
+
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Ensure all metadata values are Pinecone-compatible types.
+
+    Pinecone accepts: str, int, float, bool, and list[str].
+    None values and unsupported types are dropped.
+    """
+    clean: dict[str, Any] = {}
+    for k, v in metadata.items():
+        if v is None:
+            continue
+        if isinstance(v, (str, int, float, bool)):
+            clean[k] = v
+        elif isinstance(v, list) and all(isinstance(x, str) for x in v):
+            clean[k] = v
+        else:
+            # Convert to string as fallback
+            clean[k] = str(v)
+    return clean
+
+
+def _translate_filter(where: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Translate ChromaDB-style metadata filters to Pinecone format.
+
+    ChromaDB: ``{"item_type": "journalArticle"}``  (shorthand equality)
+    Pinecone: ``{"item_type": {"$eq": "journalArticle"}}``
+
+    Logical operators (``$and``, ``$or``) and explicit operator dicts are
+    passed through unchanged.
+    """
+    if not where:
+        return None
+
+    translated: dict[str, Any] = {}
+    for key, value in where.items():
+        if key.startswith("$"):
+            # Logical operators ($and, $or, $not)
+            if isinstance(value, list):
+                translated[key] = [_translate_filter(f) for f in value]
+            else:
+                translated[key] = value
+        elif isinstance(value, dict):
+            # Already in operator format, e.g. {"$gt": 5}
+            translated[key] = value
+        else:
+            # Simple equality shorthand → explicit $eq
+            translated[key] = {"$eq": value}
+    return translated
+
+
+# ---------------------------------------------------------------------------
+# PineconeClient
+# ---------------------------------------------------------------------------
+
+
+class PineconeClient:
+    """Pinecone vector database client for Zotero semantic search.
+
+    Implements the same public interface as ``ChromaClient`` so it can be
+    used as a drop-in alternative backend.
+    """
+
+    def __init__(
+        self,
+        collection_name: str = "zotero_library",
+        embedding_model: str = "default",
+        embedding_config: dict[str, Any] | None = None,
+        api_key: str | None = None,
+        index_name: str | None = None,
+        cloud: str = "aws",
+        region: str = "us-east-1",
+    ):
+        self.collection_name = collection_name
+        self.embedding_model = embedding_model
+        self.embedding_config = embedding_config or {}
+        self.namespace = collection_name  # map collection → Pinecone namespace
+
+        # Resolve API key
+        self.api_key = api_key or os.getenv("PINECONE_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Pinecone API key is required. Set PINECONE_API_KEY environment "
+                "variable or pass api_key to PineconeClient."
+            )
+
+        from pinecone import Pinecone
+
+        self.pc = Pinecone(api_key=self.api_key)
+
+        # Embedding function (standalone, no chromadb dependency)
+        self.embedding_function = self._create_embedding_function()
+
+        # Resolve index name
+        self.index_name = index_name or os.getenv("PINECONE_INDEX_NAME", "zotero-library")
+
+        # Ensure index exists (creates if needed)
+        self._ensure_index(cloud, region)
+        self.index = self.pc.Index(self.index_name)
+
+        logger.info(
+            f"Pinecone client initialized: index={self.index_name}, "
+            f"namespace={self.namespace}, model={self.embedding_model}"
+        )
+
+    # ----- embedding setup ---------------------------------------------------
+
+    def _create_embedding_function(self) -> _BaseEmbedding:
+        """Create the appropriate embedding function."""
+        if self.embedding_model == "openai":
+            return _OpenAIEmbedding(
+                model_name=self.embedding_config.get("model_name", "text-embedding-3-small"),
+                api_key=self.embedding_config.get("api_key"),
+                base_url=self.embedding_config.get("base_url"),
+            )
+        elif self.embedding_model == "gemini":
+            return _GeminiEmbedding(
+                model_name=self.embedding_config.get("model_name", "gemini-embedding-001"),
+                api_key=self.embedding_config.get("api_key"),
+                base_url=self.embedding_config.get("base_url"),
+            )
+        elif self.embedding_model == "qwen":
+            return _HuggingFaceEmbedding(
+                model_name=self.embedding_config.get("model_name", "Qwen/Qwen3-Embedding-0.6B"),
+            )
+        elif self.embedding_model == "embeddinggemma":
+            return _HuggingFaceEmbedding(
+                model_name=self.embedding_config.get("model_name", "google/embeddinggemma-300m"),
+            )
+        elif self.embedding_model not in ("default", "openai", "gemini"):
+            # Treat any other value as a HuggingFace model name
+            return _HuggingFaceEmbedding(model_name=self.embedding_model)
+        else:
+            return _DefaultEmbedding()
+
+    def _get_embedding_dimension(self) -> int:
+        """Determine the embedding vector dimension for index creation."""
+        model_name = self.embedding_config.get("model_name", "")
+
+        if self.embedding_model in _EMBEDDING_DIMENSIONS:
+            # Handle OpenAI large model variant
+            if self.embedding_model == "openai" and "large" in model_name:
+                return 3072
+            return _EMBEDDING_DIMENSIONS[self.embedding_model]
+
+        # Unknown model — generate a test embedding to discover dimension
+        test_vec = self.embedding_function.embed_query("dimension test")
+        return len(test_vec)
+
+    # ----- index management --------------------------------------------------
+
+    def _ensure_index(self, cloud: str, region: str) -> None:
+        """Create the Pinecone index if it does not already exist."""
+        existing_names = [idx.name for idx in self.pc.list_indexes()]
+        if self.index_name in existing_names:
+            return
+
+        dimension = self._get_embedding_dimension()
+        logger.info(f"Creating Pinecone index '{self.index_name}' (dim={dimension}, cloud={cloud}, region={region})")
+
+        from pinecone import ServerlessSpec
+
+        self.pc.create_index(
+            name=self.index_name,
+            dimension=dimension,
+            metric="cosine",
+            spec=ServerlessSpec(cloud=cloud, region=region),
+        )
+
+        # Wait for the index to become ready
+        import time
+
+        for _ in range(120):  # max ~2 minutes
+            desc = self.pc.describe_index(self.index_name)
+            if desc.status.get("ready", False):
+                break
+            time.sleep(1)
+        else:
+            logger.warning("Pinecone index creation timed out; continuing anyway")
+
+    # ----- public interface (mirrors ChromaClient) ---------------------------
+
+    @property
+    def embedding_max_tokens(self) -> int:
+        return getattr(self.embedding_function, "max_input_tokens", 8000)
+
+    def truncate_text(self, text: str, max_tokens: int | None = None) -> str:
+        if max_tokens is None:
+            max_tokens = self.embedding_max_tokens
+        if hasattr(self.embedding_function, "truncate"):
+            return self.embedding_function.truncate(text, max_tokens)
+        # Fallback
+        try:
+            import tiktoken
+
+            enc = tiktoken.get_encoding("cl100k_base")
+            tokens = enc.encode(text)
+            if len(tokens) > max_tokens:
+                return enc.decode(tokens[:max_tokens])
+        except Exception:
+            max_chars = max_tokens * 2
+            if len(text) > max_chars:
+                return text[:max_chars]
+        return text
+
+    def add_documents(
+        self,
+        documents: list[str],
+        metadatas: list[dict[str, Any]],
+        ids: list[str],
+    ) -> None:
+        self.upsert_documents(documents, metadatas, ids)
+
+    def upsert_documents(
+        self,
+        documents: list[str],
+        metadatas: list[dict[str, Any]],
+        ids: list[str],
+    ) -> None:
+        if not documents:
+            return
+
+        # Generate embeddings
+        embeddings = self.embedding_function(documents)
+
+        vectors: list[dict[str, Any]] = []
+        for i in range(len(documents)):
+            metadata = _sanitize_metadata(metadatas[i])
+
+            # Store document text in metadata (respecting size limit)
+            doc_text = documents[i]
+            encoded = doc_text.encode("utf-8")
+            if len(encoded) > _MAX_DOC_TEXT_BYTES:
+                doc_text = encoded[:_MAX_DOC_TEXT_BYTES].decode("utf-8", errors="ignore")
+            metadata["_document_text"] = doc_text
+
+            values = embeddings[i]
+            if hasattr(values, "tolist"):
+                values = values.tolist()
+
+            vectors.append({"id": ids[i], "values": values, "metadata": metadata})
+
+        # Pinecone recommends max 100 vectors per upsert call
+        batch_size = 100
+        for start in range(0, len(vectors), batch_size):
+            batch = vectors[start : start + batch_size]
+            self.index.upsert(vectors=batch, namespace=self.namespace)
+
+        logger.info(f"Upserted {len(documents)} documents to Pinecone")
+
+    def search(
+        self,
+        query_texts: list[str],
+        n_results: int = 10,
+        where: dict[str, Any] | None = None,
+        where_document: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        all_ids: list[list[str]] = []
+        all_distances: list[list[float]] = []
+        all_documents: list[list[str]] = []
+        all_metadatas: list[list[dict[str, Any]]] = []
+
+        pinecone_filter = _translate_filter(where)
+
+        for query in query_texts:
+            query_vector = self.embedding_function.embed_query(query)
+            if hasattr(query_vector, "tolist"):
+                query_vector = query_vector.tolist()
+
+            query_kwargs: dict[str, Any] = {
+                "namespace": self.namespace,
+                "vector": query_vector,
+                "top_k": n_results,
+                "include_metadata": True,
+            }
+            if pinecone_filter:
+                query_kwargs["filter"] = pinecone_filter
+
+            response = self.index.query(**query_kwargs)
+
+            ids: list[str] = []
+            distances: list[float] = []
+            documents: list[str] = []
+            metadatas: list[dict[str, Any]] = []
+
+            for match in response.matches:
+                ids.append(match.id)
+                # Pinecone returns cosine similarity (0–1, higher = closer).
+                # ChromaDB returns L2 distances (lower = closer).
+                # semantic_search.py computes: similarity = 1 - distance
+                # So we convert: distance = 1 - score
+                distances.append(1.0 - (match.score or 0.0))
+
+                metadata = dict(match.metadata) if match.metadata else {}
+                doc_text = metadata.pop("_document_text", "")
+                documents.append(doc_text)
+                metadatas.append(metadata)
+
+            all_ids.append(ids)
+            all_distances.append(distances)
+            all_documents.append(documents)
+            all_metadatas.append(metadatas)
+
+        logger.info(f"Pinecone search returned {len(all_ids[0]) if all_ids else 0} results")
+
+        return {
+            "ids": all_ids,
+            "distances": all_distances,
+            "documents": all_documents,
+            "metadatas": all_metadatas,
+        }
+
+    def delete_documents(self, ids: list[str]) -> None:
+        if not ids:
+            return
+        self.index.delete(ids=ids, namespace=self.namespace)
+        logger.info(f"Deleted {len(ids)} documents from Pinecone")
+
+    def get_collection_info(self) -> dict[str, Any]:
+        try:
+            stats = self.index.describe_index_stats()
+            ns_stats = stats.namespaces.get(self.namespace)
+            count = ns_stats.vector_count if ns_stats else 0
+            return {
+                "name": self.collection_name,
+                "count": count,
+                "embedding_model": self.embedding_model,
+                "persist_directory": f"pinecone://{self.index_name}/{self.namespace}",
+                "backend": "pinecone",
+            }
+        except Exception as e:
+            logger.error(f"Error getting Pinecone collection info: {e}")
+            return {
+                "name": self.collection_name,
+                "count": 0,
+                "embedding_model": self.embedding_model,
+                "persist_directory": f"pinecone://{self.index_name}/{self.namespace}",
+                "backend": "pinecone",
+                "error": str(e),
+            }
+
+    def reset_collection(self) -> None:
+        """Delete all vectors in the current namespace."""
+        self.index.delete(delete_all=True, namespace=self.namespace)
+        logger.info(f"Reset Pinecone namespace '{self.namespace}'")
+
+    def document_exists(self, doc_id: str) -> bool:
+        try:
+            result = self.index.fetch(ids=[doc_id], namespace=self.namespace)
+            return doc_id in (result.vectors or {})
+        except Exception:
+            return False
+
+    def get_document_metadata(self, doc_id: str) -> dict[str, Any] | None:
+        try:
+            result = self.index.fetch(ids=[doc_id], namespace=self.namespace)
+            vectors = result.vectors or {}
+            if doc_id in vectors:
+                metadata = dict(vectors[doc_id].metadata or {})
+                metadata.pop("_document_text", None)
+                return metadata
+            return None
+        except Exception:
+            return None
+
+    def get_existing_ids(self, ids: list[str]) -> set[str]:
+        if not ids:
+            return set()
+        existing: set[str] = set()
+        try:
+            # Pinecone fetch supports up to 1000 IDs per call
+            for start in range(0, len(ids), 1000):
+                batch = ids[start : start + 1000]
+                result = self.index.fetch(ids=batch, namespace=self.namespace)
+                existing.update((result.vectors or {}).keys())
+        except Exception:
+            pass
+        return existing
+
+    def get_all_documents(
+        self,
+        limit: int = 20,
+        include_documents: bool = False,
+    ) -> dict[str, Any]:
+        """Retrieve a sample of stored vectors (for inspection/debugging).
+
+        Returns a dict matching the structure expected by the CLI db-inspect
+        command: ``{"ids": [...], "metadatas": [...], "documents": [...]}``.
+
+        Pinecone does not support listing all vectors efficiently; we use the
+        list endpoint (pagination over IDs) to fetch up to *limit* vectors.
+        """
+        ids_to_fetch: list[str] = []
+        try:
+            paginator = self.index.list(namespace=self.namespace, limit=limit)
+            for page in paginator:
+                ids_to_fetch.extend(page)
+                if len(ids_to_fetch) >= limit:
+                    break
+        except Exception as e:
+            logger.warning(f"Pinecone list failed: {e}")
+            return {"ids": [], "metadatas": [], "documents": []}
+
+        ids_to_fetch = ids_to_fetch[:limit]
+        if not ids_to_fetch:
+            return {"ids": [], "metadatas": [], "documents": []}
+
+        result = self.index.fetch(ids=ids_to_fetch, namespace=self.namespace)
+        vectors = result.vectors or {}
+
+        out_ids: list[str] = []
+        out_metadatas: list[dict[str, Any]] = []
+        out_documents: list[str] = []
+
+        for vid in ids_to_fetch:
+            vec = vectors.get(vid)
+            if not vec:
+                continue
+            out_ids.append(vid)
+            metadata = dict(vec.metadata or {})
+            doc_text = metadata.pop("_document_text", "")
+            out_metadatas.append(metadata)
+            out_documents.append(doc_text if include_documents else "")
+
+        return {"ids": out_ids, "metadatas": out_metadatas, "documents": out_documents}
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def create_pinecone_client(config_path: str | None = None) -> PineconeClient:
+    """Create a PineconeClient instance from configuration.
+
+    Reads settings from *config_path* (JSON) and environment variables,
+    mirroring the behaviour of ``create_chroma_client``.
+    """
+    config: dict[str, Any] = {
+        "collection_name": "zotero_library",
+        "embedding_model": "default",
+        "embedding_config": {},
+    }
+    pinecone_config: dict[str, Any] = {}
+
+    # Load from file
+    if config_path and os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                file_config = json.load(f)
+                ss = file_config.get("semantic_search", {})
+                config.update({k: v for k, v in ss.items() if k in config})
+                pinecone_config = ss.get("pinecone", {})
+        except Exception as e:
+            logger.warning(f"Error loading config from {config_path}: {e}")
+
+    # Environment variable overrides
+    env_embedding_model = os.getenv("ZOTERO_EMBEDDING_MODEL")
+    if env_embedding_model:
+        config["embedding_model"] = env_embedding_model
+
+    # Resolve embedding config from env (same logic as chroma_client)
+    if config["embedding_model"] == "openai":
+        api_key = os.getenv("OPENAI_API_KEY")
+        model = os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
+        base_url = os.getenv("OPENAI_BASE_URL")
+        if api_key:
+            config["embedding_config"] = {"api_key": api_key, "model_name": model}
+            if base_url:
+                config["embedding_config"]["base_url"] = base_url
+    elif config["embedding_model"] == "gemini":
+        api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+        model = os.getenv("GEMINI_EMBEDDING_MODEL", "gemini-embedding-001")
+        base_url = os.getenv("GEMINI_BASE_URL")
+        if api_key:
+            config["embedding_config"] = {"api_key": api_key, "model_name": model}
+            if base_url:
+                config["embedding_config"]["base_url"] = base_url
+
+    return PineconeClient(
+        collection_name=config["collection_name"],
+        embedding_model=config["embedding_model"],
+        embedding_config=config["embedding_config"],
+        api_key=pinecone_config.get("api_key"),
+        index_name=pinecone_config.get("index_name"),
+        cloud=pinecone_config.get("cloud", "aws"),
+        region=pinecone_config.get("region", "us-east-1"),
+    )

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -23,7 +23,7 @@ except Exception:
 
 from pyzotero import zotero
 
-from .chroma_client import ChromaClient, create_chroma_client
+from .vector_store import VectorStoreClient, create_vector_client
 from .client import get_zotero_client
 from .utils import format_creators, is_local_mode
 from .local_db import LocalZoteroReader, get_local_zotero_reader
@@ -72,21 +72,28 @@ class CrossEncoderReranker:
 
 
 class ZoteroSemanticSearch:
-    """Semantic search interface for Zotero libraries using ChromaDB."""
+    """Semantic search interface for Zotero libraries.
+
+    Supports ChromaDB and Pinecone as vector store backends.
+    The backend is selected via the ``vector_backend`` config key or the
+    ``ZOTERO_VECTOR_BACKEND`` environment variable (default: ``"chroma"``).
+    """
 
     def __init__(self,
-                 chroma_client: ChromaClient | None = None,
+                 chroma_client: VectorStoreClient | None = None,
+                 vector_client: VectorStoreClient | None = None,
                  config_path: str | None = None,
                  db_path: str | None = None):
         """
         Initialize semantic search.
 
         Args:
-            chroma_client: Optional ChromaClient instance
+            chroma_client: Deprecated alias for vector_client (backward compat)
+            vector_client: Optional VectorStoreClient instance
             config_path: Path to configuration file
             db_path: Optional path to Zotero database (overrides config file)
         """
-        self.chroma_client = chroma_client or create_chroma_client(config_path)
+        self._vector_client = vector_client or chroma_client or create_vector_client(config_path)
         self.zotero_client = get_zotero_client()
         self.config_path = config_path
         self.db_path = db_path  # CLI override for Zotero database path
@@ -97,6 +104,16 @@ class ZoteroSemanticSearch:
         # Reranker (lazy-initialized on first search)
         self._reranker: CrossEncoderReranker | None = None
         self._reranker_config = self._load_reranker_config()
+
+    @property
+    def chroma_client(self) -> VectorStoreClient:
+        """Backward-compatible alias for the vector store client."""
+        return self._vector_client
+
+    @property
+    def vector_client(self) -> VectorStoreClient:
+        """The active vector store client (ChromaDB or Pinecone)."""
+        return self._vector_client
 
     def _load_reranker_config(self) -> dict[str, Any]:
         """Load reranker configuration from file or use defaults."""
@@ -298,7 +315,7 @@ class ZoteroSemanticSearch:
 
         return False
 
-    def _get_items_from_source(self, limit: int | None = None, extract_fulltext: bool = False, chroma_client: ChromaClient | None = None, force_rebuild: bool = False) -> list[dict[str, Any]]:
+    def _get_items_from_source(self, limit: int | None = None, extract_fulltext: bool = False, chroma_client: VectorStoreClient | None = None, force_rebuild: bool = False) -> list[dict[str, Any]]:
         """
         Get items from either local database or API.
 
@@ -330,7 +347,7 @@ class ZoteroSemanticSearch:
         else:
             return self._get_items_from_api(limit)
 
-    def _get_items_from_local_db(self, limit: int | None = None, extract_fulltext: bool = False, chroma_client: ChromaClient | None = None, force_rebuild: bool = False) -> list[dict[str, Any]]:
+    def _get_items_from_local_db(self, limit: int | None = None, extract_fulltext: bool = False, chroma_client: VectorStoreClient | None = None, force_rebuild: bool = False) -> list[dict[str, Any]]:
         """
         Get items from local Zotero database.
 

--- a/src/zotero_mcp/setup_helper.py
+++ b/src/zotero_mcp/setup_helper.py
@@ -150,6 +150,48 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
 
     print("Configure embedding models for semantic search over your Zotero library.")
 
+    # Choose vector backend
+    print("\nVector database backend:")
+    print("1. ChromaDB - Local vector database (default, no account needed)")
+    print("2. Pinecone - Cloud vector database (requires API key)")
+
+    while True:
+        backend_choice = input("\nChoose vector backend (1-2): ").strip()
+        if backend_choice in ["1", "2"]:
+            break
+        print("Please enter 1 or 2")
+
+    config = {}
+
+    if backend_choice == "2":
+        config["vector_backend"] = "pinecone"
+        print("Using Pinecone as vector backend.")
+
+        # Get Pinecone API key
+        api_key = getpass.getpass("Enter your Pinecone API key (hidden): ").strip()
+        pinecone_cfg: dict = {}
+        if api_key:
+            pinecone_cfg["api_key"] = api_key
+        else:
+            print("Warning: No API key provided. Set PINECONE_API_KEY environment variable.")
+
+        # Get index name
+        index_name = input("Pinecone index name [zotero-library]: ").strip()
+        if index_name:
+            pinecone_cfg["index_name"] = index_name
+
+        # Get cloud/region
+        print("\nPinecone serverless cloud options: aws, gcp, azure")
+        cloud = input("Cloud provider [aws]: ").strip() or "aws"
+        region = input("Region [us-east-1]: ").strip() or "us-east-1"
+        pinecone_cfg["cloud"] = cloud
+        pinecone_cfg["region"] = region
+
+        config["pinecone"] = pinecone_cfg
+    else:
+        config["vector_backend"] = "chroma"
+        print("Using ChromaDB as vector backend.")
+
     # Choose embedding model
     print("\nAvailable embedding models:")
     print("1. Default (all-MiniLM-L6-v2) - Free, runs locally")
@@ -161,8 +203,6 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
         if choice in ["1", "2", "3"]:
             break
         print("Please enter 1, 2, or 3")
-
-    config = {}
 
     if choice == "1":
         config["embedding_model"] = "default"

--- a/src/zotero_mcp/vector_store.py
+++ b/src/zotero_mcp/vector_store.py
@@ -1,0 +1,112 @@
+"""
+Vector store abstraction layer.
+
+Provides a ``VectorStoreClient`` protocol that both ``ChromaClient`` and
+``PineconeClient`` satisfy, plus a factory function that creates the right
+backend based on configuration.
+"""
+
+import json
+import logging
+import os
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class VectorStoreClient(Protocol):
+    """Protocol defining the vector store client interface.
+
+    Both ``ChromaClient`` and ``PineconeClient`` satisfy this protocol so
+    they can be used interchangeably by ``ZoteroSemanticSearch``.
+    """
+
+    embedding_model: str
+
+    @property
+    def embedding_max_tokens(self) -> int: ...
+
+    def truncate_text(self, text: str, max_tokens: int | None = None) -> str: ...
+
+    def add_documents(
+        self,
+        documents: list[str],
+        metadatas: list[dict[str, Any]],
+        ids: list[str],
+    ) -> None: ...
+
+    def upsert_documents(
+        self,
+        documents: list[str],
+        metadatas: list[dict[str, Any]],
+        ids: list[str],
+    ) -> None: ...
+
+    def search(
+        self,
+        query_texts: list[str],
+        n_results: int = 10,
+        where: dict[str, Any] | None = None,
+        where_document: dict[str, Any] | None = None,
+    ) -> dict[str, Any]: ...
+
+    def delete_documents(self, ids: list[str]) -> None: ...
+
+    def get_collection_info(self) -> dict[str, Any]: ...
+
+    def reset_collection(self) -> None: ...
+
+    def document_exists(self, doc_id: str) -> bool: ...
+
+    def get_document_metadata(self, doc_id: str) -> dict[str, Any] | None: ...
+
+    def get_existing_ids(self, ids: list[str]) -> set[str]: ...
+
+
+def get_vector_backend(config_path: str | None = None) -> str:
+    """Determine which vector backend to use.
+
+    Resolution order:
+    1. ``ZOTERO_VECTOR_BACKEND`` environment variable
+    2. ``semantic_search.vector_backend`` in the config JSON file
+    3. Default: ``"chroma"``
+    """
+    backend = os.getenv("ZOTERO_VECTOR_BACKEND", "").lower()
+    if backend:
+        return backend
+
+    if config_path and os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                cfg = json.load(f)
+            backend = cfg.get("semantic_search", {}).get("vector_backend", "").lower()
+            if backend:
+                return backend
+        except Exception:
+            pass
+
+    return "chroma"
+
+
+def create_vector_client(config_path: str | None = None) -> VectorStoreClient:
+    """Create a vector store client based on configuration.
+
+    Reads the ``vector_backend`` setting from config or the
+    ``ZOTERO_VECTOR_BACKEND`` environment variable.  Defaults to
+    ``"chroma"`` for backward compatibility.
+
+    Supported backends: ``"chroma"``, ``"pinecone"``.
+    """
+    backend = get_vector_backend(config_path)
+
+    if backend == "pinecone":
+        from .pinecone_client import create_pinecone_client
+
+        return create_pinecone_client(config_path)
+    elif backend == "chroma":
+        from .chroma_client import create_chroma_client
+
+        return create_chroma_client(config_path)
+    else:
+        raise ValueError(f"Unknown vector backend: '{backend}'. Supported backends: 'chroma', 'pinecone'")

--- a/tests/test_pinecone_client.py
+++ b/tests/test_pinecone_client.py
@@ -1,0 +1,401 @@
+"""Tests for the Pinecone client and vector store abstraction layer."""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pinecone_match(id: str, score: float, metadata: dict):
+    """Create a mock Pinecone match object."""
+    match = MagicMock()
+    match.id = id
+    match.score = score
+    match.metadata = metadata
+    return match
+
+
+def _make_query_response(matches):
+    resp = MagicMock()
+    resp.matches = matches
+    return resp
+
+
+def _make_fetch_response(vectors_dict):
+    """Create a mock Pinecone fetch response."""
+    resp = MagicMock()
+    resp.vectors = vectors_dict
+    return resp
+
+
+def _make_index_stats(namespace_name, vector_count):
+    """Create a mock describe_index_stats response."""
+    ns = MagicMock()
+    ns.vector_count = vector_count
+    stats = MagicMock()
+    stats.namespaces = {namespace_name: ns}
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# vector_store module tests
+# ---------------------------------------------------------------------------
+
+
+class TestVectorStoreFactory:
+    """Tests for vector_store.get_vector_backend and create_vector_client."""
+
+    def test_default_backend_is_chroma(self, tmp_path):
+        from zotero_mcp.vector_store import get_vector_backend
+
+        # No config, no env → chroma
+        assert get_vector_backend(None) == "chroma"
+        assert get_vector_backend(str(tmp_path / "nonexistent.json")) == "chroma"
+
+    def test_env_var_overrides_config(self, tmp_path):
+        from zotero_mcp.vector_store import get_vector_backend
+
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"semantic_search": {"vector_backend": "chroma"}}))
+
+        with patch.dict(os.environ, {"ZOTERO_VECTOR_BACKEND": "pinecone"}):
+            assert get_vector_backend(str(config_file)) == "pinecone"
+
+    def test_config_file_backend(self, tmp_path):
+        from zotero_mcp.vector_store import get_vector_backend
+
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"semantic_search": {"vector_backend": "pinecone"}}))
+
+        with patch.dict(os.environ, {}, clear=False):
+            # Remove env var if set
+            os.environ.pop("ZOTERO_VECTOR_BACKEND", None)
+            assert get_vector_backend(str(config_file)) == "pinecone"
+
+    def test_unknown_backend_raises(self, tmp_path):
+        from zotero_mcp.vector_store import create_vector_client
+
+        with patch.dict(os.environ, {"ZOTERO_VECTOR_BACKEND": "weaviate"}):
+            with pytest.raises(ValueError, match="Unknown vector backend"):
+                create_vector_client(None)
+
+
+# ---------------------------------------------------------------------------
+# PineconeClient tests (mocked — no real Pinecone calls)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_pinecone_env():
+    """Set required env vars and patch the Pinecone SDK."""
+    with patch.dict(os.environ, {"PINECONE_API_KEY": "test-key-1234"}):
+        yield
+
+
+@pytest.fixture
+def mock_pc_and_index(mock_pinecone_env):
+    """Patch Pinecone SDK so PineconeClient can be instantiated."""
+    mock_index = MagicMock()
+    mock_pc_instance = MagicMock()
+
+    # list_indexes returns existing index
+    idx_obj = MagicMock()
+    idx_obj.name = "zotero-library"
+    mock_pc_instance.list_indexes.return_value = [idx_obj]
+    mock_pc_instance.Index.return_value = mock_index
+    mock_pc_instance.describe_index.return_value = MagicMock(status={"ready": True})
+
+    with (
+        patch("pinecone.Pinecone", return_value=mock_pc_instance) as pc_cls,
+        patch("sentence_transformers.SentenceTransformer") as mock_st,
+    ):
+        # Mock SentenceTransformer for _DefaultEmbedding
+        mock_model = MagicMock()
+        mock_model.max_seq_length = 256
+        import numpy as np
+
+        mock_model.encode.return_value = np.array([[0.1] * 384])
+        mock_st.return_value = mock_model
+
+        yield {
+            "pc_cls": pc_cls,
+            "pc_instance": mock_pc_instance,
+            "index": mock_index,
+            "st_model": mock_model,
+        }
+
+
+def _create_client(mock_pc_and_index):
+    """Helper to create a PineconeClient with all deps mocked."""
+    from zotero_mcp.pinecone_client import PineconeClient
+
+    client = PineconeClient(embedding_model="default")
+    return client
+
+
+class TestPineconeClientInit:
+    def test_missing_api_key_raises(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PINECONE_API_KEY", None)
+            from zotero_mcp.pinecone_client import PineconeClient
+
+            with pytest.raises(ValueError, match="Pinecone API key is required"):
+                PineconeClient()
+
+    def test_creates_client_with_existing_index(self, mock_pc_and_index):
+        client = _create_client(mock_pc_and_index)
+        assert client.index_name == "zotero-library"
+        assert client.namespace == "zotero_library"
+        assert client.embedding_model == "default"
+
+    def test_creates_index_if_not_exists(self, mock_pinecone_env):
+        mock_index = MagicMock()
+        mock_pc_instance = MagicMock()
+        mock_pc_instance.list_indexes.return_value = []  # no indexes
+        mock_pc_instance.Index.return_value = mock_index
+        desc = MagicMock()
+        desc.status = {"ready": True}
+        mock_pc_instance.describe_index.return_value = desc
+
+        with (
+            patch("pinecone.Pinecone", return_value=mock_pc_instance),
+            patch("pinecone.ServerlessSpec"),
+            patch("sentence_transformers.SentenceTransformer") as mock_st,
+        ):
+            import numpy as np
+
+            mock_model = MagicMock()
+            mock_model.max_seq_length = 256
+            mock_model.encode.return_value = np.array([[0.1] * 384])
+            mock_st.return_value = mock_model
+
+            from zotero_mcp.pinecone_client import PineconeClient
+
+            PineconeClient(embedding_model="default")
+
+            mock_pc_instance.create_index.assert_called_once()
+            call_kwargs = mock_pc_instance.create_index.call_args
+            assert call_kwargs.kwargs["dimension"] == 384
+            assert call_kwargs.kwargs["metric"] == "cosine"
+
+
+class TestPineconeClientOperations:
+    def test_upsert_documents(self, mock_pc_and_index):
+        client = _create_client(mock_pc_and_index)
+        idx = mock_pc_and_index["index"]
+
+        client.upsert_documents(
+            documents=["test document one"],
+            metadatas=[{"title": "Test", "item_type": "journalArticle"}],
+            ids=["key1"],
+        )
+
+        idx.upsert.assert_called_once()
+
+    def test_search_returns_chroma_compatible_format(self, mock_pc_and_index):
+        client = _create_client(mock_pc_and_index)
+        idx = mock_pc_and_index["index"]
+
+        idx.query.return_value = _make_query_response(
+            [
+                _make_pinecone_match("k1", 0.95, {"title": "Paper A", "_document_text": "Full text A"}),
+                _make_pinecone_match("k2", 0.80, {"title": "Paper B", "_document_text": "Full text B"}),
+            ]
+        )
+
+        results = client.search(query_texts=["machine learning"], n_results=2)
+
+        assert "ids" in results
+        assert "distances" in results
+        assert "documents" in results
+        assert "metadatas" in results
+
+        # Single query → single list
+        assert len(results["ids"]) == 1
+        assert results["ids"][0] == ["k1", "k2"]
+
+        # Distances = 1 - score (for compatibility with semantic_search.py)
+        assert abs(results["distances"][0][0] - 0.05) < 0.001
+        assert abs(results["distances"][0][1] - 0.20) < 0.001
+
+        # Document text extracted from metadata
+        assert results["documents"][0] == ["Full text A", "Full text B"]
+
+        # _document_text should be removed from returned metadata
+        assert "_document_text" not in results["metadatas"][0][0]
+        assert results["metadatas"][0][0]["title"] == "Paper A"
+
+    def test_search_with_filter(self, mock_pc_and_index):
+        client = _create_client(mock_pc_and_index)
+        idx = mock_pc_and_index["index"]
+        idx.query.return_value = _make_query_response([])
+
+        client.search(
+            query_texts=["test"],
+            n_results=5,
+            where={"item_type": "journalArticle"},
+        )
+
+        call_kwargs = idx.query.call_args.kwargs
+        assert call_kwargs["filter"] == {"item_type": {"$eq": "journalArticle"}}
+
+    def test_delete_documents(self, mock_pc_and_index):
+        client = _create_client(mock_pc_and_index)
+        idx = mock_pc_and_index["index"]
+
+        client.delete_documents(["k1", "k2"])
+        idx.delete.assert_called_once_with(ids=["k1", "k2"], namespace="zotero_library")
+
+    def test_reset_collection(self, mock_pc_and_index):
+        client = _create_client(mock_pc_and_index)
+        idx = mock_pc_and_index["index"]
+
+        client.reset_collection()
+        idx.delete.assert_called_once_with(delete_all=True, namespace="zotero_library")
+
+    def test_document_exists(self, mock_pc_and_index):
+        client = _create_client(mock_pc_and_index)
+        idx = mock_pc_and_index["index"]
+
+        vec = MagicMock()
+        vec.metadata = {"title": "Test"}
+        idx.fetch.return_value = _make_fetch_response({"k1": vec})
+
+        assert client.document_exists("k1") is True
+        assert client.document_exists("k_missing") is False
+
+    def test_get_document_metadata(self, mock_pc_and_index):
+        client = _create_client(mock_pc_and_index)
+        idx = mock_pc_and_index["index"]
+
+        vec = MagicMock()
+        vec.metadata = {"title": "Hello", "_document_text": "full text here"}
+        idx.fetch.return_value = _make_fetch_response({"k1": vec})
+
+        meta = client.get_document_metadata("k1")
+        assert meta is not None
+        assert meta["title"] == "Hello"
+        assert "_document_text" not in meta
+
+    def test_get_existing_ids(self, mock_pc_and_index):
+        client = _create_client(mock_pc_and_index)
+        idx = mock_pc_and_index["index"]
+
+        vec1 = MagicMock()
+        vec2 = MagicMock()
+        idx.fetch.return_value = _make_fetch_response({"k1": vec1, "k3": vec2})
+
+        existing = client.get_existing_ids(["k1", "k2", "k3"])
+        assert existing == {"k1", "k3"}
+
+    def test_get_collection_info(self, mock_pc_and_index):
+        client = _create_client(mock_pc_and_index)
+        idx = mock_pc_and_index["index"]
+
+        idx.describe_index_stats.return_value = _make_index_stats("zotero_library", 42)
+
+        info = client.get_collection_info()
+        assert info["count"] == 42
+        assert info["backend"] == "pinecone"
+        assert info["name"] == "zotero_library"
+
+
+class TestFilterTranslation:
+    def test_simple_equality(self):
+        from zotero_mcp.pinecone_client import _translate_filter
+
+        result = _translate_filter({"item_type": "journalArticle"})
+        assert result == {"item_type": {"$eq": "journalArticle"}}
+
+    def test_operator_passthrough(self):
+        from zotero_mcp.pinecone_client import _translate_filter
+
+        result = _translate_filter({"year": {"$gte": 2020}})
+        assert result == {"year": {"$gte": 2020}}
+
+    def test_logical_operators(self):
+        from zotero_mcp.pinecone_client import _translate_filter
+
+        result = _translate_filter(
+            {
+                "$and": [
+                    {"item_type": "journalArticle"},
+                    {"year": {"$gte": 2020}},
+                ]
+            }
+        )
+        assert result == {
+            "$and": [
+                {"item_type": {"$eq": "journalArticle"}},
+                {"year": {"$gte": 2020}},
+            ]
+        }
+
+    def test_none_returns_none(self):
+        from zotero_mcp.pinecone_client import _translate_filter
+
+        assert _translate_filter(None) is None
+
+
+class TestSanitizeMetadata:
+    def test_removes_none_values(self):
+        from zotero_mcp.pinecone_client import _sanitize_metadata
+
+        result = _sanitize_metadata({"a": "hello", "b": None, "c": 42})
+        assert result == {"a": "hello", "c": 42}
+
+    def test_converts_unsupported_types(self):
+        from zotero_mcp.pinecone_client import _sanitize_metadata
+
+        result = _sanitize_metadata({"a": {"nested": "dict"}})
+        assert isinstance(result["a"], str)
+
+    def test_keeps_valid_types(self):
+        from zotero_mcp.pinecone_client import _sanitize_metadata
+
+        original = {"s": "str", "i": 1, "f": 1.5, "b": True, "l": ["a", "b"]}
+        result = _sanitize_metadata(original)
+        assert result == original
+
+
+class TestEmbeddingDimensions:
+    def test_known_dimensions(self, mock_pc_and_index):
+        client = _create_client(mock_pc_and_index)
+        # default model → 384
+        assert client._get_embedding_dimension() == 384
+
+    def test_openai_large_variant(self, mock_pc_and_index):
+        client = _create_client(mock_pc_and_index)
+        client.embedding_model = "openai"
+        client.embedding_config = {"model_name": "text-embedding-3-large"}
+        assert client._get_embedding_dimension() == 3072
+
+
+class TestCreatePineconeClient:
+    def test_from_config_file(self, tmp_path, mock_pc_and_index):
+        config = {
+            "semantic_search": {
+                "collection_name": "my_collection",
+                "embedding_model": "default",
+                "vector_backend": "pinecone",
+                "pinecone": {
+                    "index_name": "my-index",
+                    "cloud": "gcp",
+                    "region": "us-central1",
+                },
+            }
+        }
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config))
+
+        from zotero_mcp.pinecone_client import create_pinecone_client
+
+        client = create_pinecone_client(str(config_file))
+
+        assert client.collection_name == "my_collection"
+        assert client.namespace == "my_collection"


### PR DESCRIPTION
## Add Pinecone as alternative vector store backend

### Summary

Adds [Pinecone](https://www.pinecone.io/) as an optional cloud-hosted vector database backend for semantic search, alongside the existing ChromaDB local backend. Users can switch between backends via the `ZOTERO_VECTOR_BACKEND` environment variable or the interactive `zotero-mcp setup` wizard.

### Motivation

ChromaDB is excellent for local use, but some users need a cloud-hosted vector store for larger libraries, shared access, or deployment scenarios where local persistence isn't practical. Pinecone provides a managed, scalable alternative without requiring users to manage infrastructure.

### Changes

| File | What changed |
|------|-------------|
| `src/zotero_mcp/vector_store.py` | **New** — `VectorStoreClient` protocol + `create_vector_client()` factory |
| `src/zotero_mcp/pinecone_client.py` | **New** — Full `PineconeClient` with standalone embedding adapters |
| `tests/test_pinecone_client.py` | **New** — Unit tests for Pinecone client + vector store factory |
| `src/zotero_mcp/semantic_search.py` | Refactored to use backend-agnostic `VectorStoreClient` interface |
| `src/zotero_mcp/cli.py` | `db-inspect` detects and handles Pinecone backend |
| `src/zotero_mcp/setup_helper.py` | Interactive setup prompts for backend selection |
| `pyproject.toml` | New `[pinecone]` optional extra; added to `[all]` |
| `CHANGELOG.md` | Documented under `[Unreleased]` |
| `README.md` | Updated extras table, env vars, and troubleshooting |

### Design decisions

- **Backward compatible** — ChromaDB remains the default; existing users are unaffected
- **Protocol-based abstraction** — `VectorStoreClient` is a Python `Protocol`, not an ABC, to avoid import-time dependencies
- **Standalone embeddings** — Pinecone client includes its own embedding adapters to avoid pulling in ChromaDB when only Pinecone is installed
- **Score normalization** — Pinecone cosine scores are converted to Chroma-style distances for consistent ranking in `semantic_search.py`

### How to test

```bash
# Manual end-to-end (requires Pinecone API key)
ZOTERO_LOCAL=true ZOTERO_VECTOR_BACKEND=pinecone \
  PINECONE_API_KEY=... PINECONE_INDEX_NAME=zotero-library \
  zotero-mcp update-db --fulltext
```

### Checklist

- [x] All 398 existing tests pass
- [x] New tests for Pinecone client and factory
- [x] Ruff lint + format clean
- [x] CHANGELOG updated
- [x] README updated
- [x] No API keys or secrets in committed files
- [x] Backward compatible — default behavior unchanged
