### PR TITLE
fix: add page delay to pagination to prevent local API timeouts

### DIFF
--- a/src/zotero_mcp/client.py
+++ b/src/zotero_mcp/client.py
@@ -2,7 +2,9 @@
 Zotero client wrapper for MCP server.
 """
 
+import functools
 import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -15,6 +17,23 @@ from zotero_mcp.utils import format_creators
 
 # Load environment variables
 load_dotenv()
+
+# Serialize all Zotero API access. The local API (port 23119) is single-threaded;
+# concurrent requests from parallel MCP tool threads queue at the network layer and
+# risk hitting pyzotero's 30s timeout. A process-local semaphore ensures only one
+# request is in-flight at a time — the rest queue in-process (microseconds) instead
+# of at the API (seconds/timeout).
+_zotero_api_lock = threading.Semaphore(1)
+
+
+def with_zotero_api_lock(func):
+    """Serialize Zotero API access across concurrent MCP tool threads."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        with _zotero_api_lock:
+            return func(*args, **kwargs)
+    return wrapper
+
 
 # Runtime library override state — set by zotero_switch_library tool.
 # When non-empty, these values override the corresponding environment variables

--- a/src/zotero_mcp/tools/annotations.py
+++ b/src/zotero_mcp/tools/annotations.py
@@ -10,6 +10,7 @@ from fastmcp import Context
 
 from zotero_mcp._app import mcp
 from zotero_mcp import client as _client
+from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp import utils as _utils
 from zotero_mcp.tools import _helpers
 
@@ -18,6 +19,7 @@ from zotero_mcp.tools import _helpers
     name="zotero_get_annotations",
     description="Get all annotations for a specific item or across your entire Zotero library. When called without item_key, returns ALL annotations library-wide — this can be very large. Always pass item_key when you know which item you want."
 )
+@with_zotero_api_lock
 def get_annotations(
     item_key: str | None = None,
     use_pdf_extraction: bool = False,
@@ -357,6 +359,7 @@ _get_annotations = get_annotations
     name="zotero_get_notes",
     description="Retrieve notes from your Zotero library, with options to filter by parent item."
 )
+@with_zotero_api_lock
 def get_notes(
     item_key: str | None = None,
     limit: int | str | None = 20,
@@ -452,6 +455,7 @@ def get_notes(
 # Helpers for search_notes
 # ---------------------------------------------------------------------------
 
+@with_zotero_api_lock
 def _batch_resolve_parent_titles(
     zot, parent_keys: set[str], ctx: Context
 ) -> dict[str, str]:
@@ -472,6 +476,7 @@ def _batch_resolve_parent_titles(
     return titles
 
 
+@with_zotero_api_lock
 def _batch_resolve_grandparent_titles(
     zot, parent_keys: set[str], ctx: Context
 ) -> dict[str, str]:
@@ -528,6 +533,7 @@ def _batch_resolve_grandparent_titles(
     return result
 
 
+@with_zotero_api_lock
 def _format_search_results(
     query: str, note_results: list[dict], annotation_results: list[dict]
 ) -> str:
@@ -584,6 +590,7 @@ def _format_search_results(
     name="zotero_search_notes",
     description="Search for notes and annotations across your Zotero library."
 )
+@with_zotero_api_lock
 def search_notes(
     query: str,
     limit: int | str | None = 20,
@@ -713,6 +720,7 @@ def search_notes(
     name="zotero_create_note",
     description="Create a new note for a Zotero item."
 )
+@with_zotero_api_lock
 def create_note(
     item_key: str,
     note_title: str,
@@ -858,6 +866,7 @@ def create_note(
     name="zotero_create_annotation",
     description="Create a highlight annotation on a PDF or EPUB attachment with optional comment."
 )
+@with_zotero_api_lock
 def create_annotation(
     attachment_key: str,
     page: int,

--- a/src/zotero_mcp/tools/connectors.py
+++ b/src/zotero_mcp/tools/connectors.py
@@ -9,6 +9,7 @@ from fastmcp import Context
 
 from zotero_mcp._app import mcp
 from zotero_mcp import client as _client
+from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp import utils as _utils
 from zotero_mcp.tools.retrieval import get_item_fulltext
 
@@ -21,6 +22,7 @@ from zotero_mcp.tools.retrieval import get_item_fulltext
     name="search",
     description="ChatGPT-compatible search wrapper. Performs semantic search and returns JSON results."
 )
+@with_zotero_api_lock
 def chatgpt_connector_search(
     query: str,
     *,
@@ -65,6 +67,7 @@ def chatgpt_connector_search(
     name="fetch",
     description="ChatGPT-compatible fetch wrapper. Retrieves fulltext/metadata for a Zotero item by ID."
 )
+@with_zotero_api_lock
 def connector_fetch(
     id: str,
     *,

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -12,6 +12,7 @@ from fastmcp import Context
 
 from zotero_mcp._app import mcp
 from zotero_mcp import client as _client
+from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp import utils as _utils
 from zotero_mcp.tools import _helpers
 
@@ -20,6 +21,7 @@ from zotero_mcp.tools import _helpers
     name="zotero_get_item_metadata",
     description="Get detailed metadata for a specific Zotero item by its key. If the metadata and abstract don't contain the specific information you need, use zotero_get_item_fulltext to read the full paper — but note that fulltext retrieval is resource-intensive and should not be used for searching; use zotero_search_items or zotero_semantic_search instead."
 )
+@with_zotero_api_lock
 def get_item_metadata(
     item_key: str,
     include_abstract: bool = True,
@@ -64,6 +66,7 @@ def get_item_metadata(
     name="zotero_get_item_fulltext",
     description="Get the full text content of a Zotero item by its key. WARNING: Returns the entire paper text (often 10K+ tokens). Only use when you need to read the actual paper content, not just metadata. Do NOT use this for searching — use zotero_search_items or zotero_semantic_search instead. Avoid calling this on multiple papers in one conversation unless the user specifically asks to read them."
 )
+@with_zotero_api_lock
 def get_item_fulltext(
     item_key: str,
     *,
@@ -203,6 +206,7 @@ def get_item_fulltext(
     name="zotero_get_collections",
     description="List all collections in your Zotero library."
 )
+@with_zotero_api_lock
 def get_collections(
     limit: int | str | None = None,
     *,
@@ -291,6 +295,7 @@ def get_collections(
         return f"# Zotero Collections\n\n{error_msg}"
 
 
+@with_zotero_api_lock
 def _build_attachment_extra(info):
     """Build extra_fields dict from attachment_info for format_item_result."""
     if not info:
@@ -310,6 +315,7 @@ def _build_attachment_extra(info):
     name="zotero_get_collection_items",
     description="Get all items in a specific Zotero collection. Supports detail='keys_only' (minimal), 'summary' (default, no abstracts), or 'full' (with abstracts). Includes PDF/notes indicators. TIP: To find papers on a specific topic, use zotero_semantic_search instead — it's faster and returns only relevant results."
 )
+@with_zotero_api_lock
 def get_collection_items(
     collection_key: str,
     detail: Literal["keys_only", "summary", "full"] = "summary",
@@ -436,6 +442,7 @@ def get_collection_items(
     name="zotero_get_item_children",
     description="Get all child items (attachments, notes) for a specific Zotero item."
 )
+@with_zotero_api_lock
 def get_item_children(
     item_key: str,
     *,
@@ -550,6 +557,7 @@ def get_item_children(
     name="zotero_get_items_children",
     description="Get child items (attachments, notes) for MULTIPLE Zotero items in one call. Much more efficient than calling get_item_children repeatedly."
 )
+@with_zotero_api_lock
 def get_items_children(
     item_keys: list[str] | str,
     *,
@@ -639,6 +647,7 @@ def get_items_children(
     name="zotero_get_tags",
     description="Get all tags used in your Zotero library."
 )
+@with_zotero_api_lock
 def get_tags(
     limit: int | str | None = None,
     *,
@@ -703,6 +712,7 @@ def get_tags(
     name="zotero_list_libraries",
     description="List all accessible Zotero libraries (user library, group libraries, and RSS feeds). Use this to discover available libraries before switching with zotero_switch_library.",
 )
+@with_zotero_api_lock
 def list_libraries(*, ctx: Context) -> str:
     """
     List all accessible Zotero libraries.
@@ -811,6 +821,7 @@ def list_libraries(*, ctx: Context) -> str:
     name="zotero_switch_library",
     description="Switch the active Zotero library context. All subsequent tool calls will operate on the selected library. Use zotero_list_libraries first to see available options. Pass library_type='default' to reset to the original environment variable configuration.",
 )
+@with_zotero_api_lock
 def switch_library(
     library_id: str,
     library_type: str = "group",
@@ -870,6 +881,7 @@ def switch_library(
         return f"Error switching library: {str(e)}"
 
 
+@with_zotero_api_lock
 def validate_library_switch(library_id: str, library_type: str) -> str | None:
     """Validate a library switch request before applying it.
 
@@ -914,6 +926,7 @@ def validate_library_switch(library_id: str, library_type: str) -> str | None:
     name="zotero_list_feeds",
     description="List all RSS feed subscriptions in your local Zotero installation. Shows feed names, URLs, item counts, and last check times. Local mode only.",
 )
+@with_zotero_api_lock
 def list_feeds(*, ctx: Context) -> str:
     """
     List all RSS feed subscriptions from the local Zotero database.
@@ -962,6 +975,7 @@ def list_feeds(*, ctx: Context) -> str:
     name="zotero_get_feed_items",
     description="Get items from a specific RSS feed by its library ID. Use zotero_list_feeds first to find feed library IDs. Local mode only.",
 )
+@with_zotero_api_lock
 def get_feed_items(
     library_id: int,
     limit: int = 20,
@@ -1035,6 +1049,7 @@ def get_feed_items(
     name="zotero_get_recent",
     description="Get recently added items to your Zotero library."
 )
+@with_zotero_api_lock
 def get_recent(
     limit: int | str = 10,
     *,

--- a/src/zotero_mcp/tools/scite.py
+++ b/src/zotero_mcp/tools/scite.py
@@ -20,6 +20,7 @@ import logging
 from fastmcp import Context
 
 from zotero_mcp import client as _client
+from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp import scite_client as _scite
 from zotero_mcp import utils as _utils
 from zotero_mcp._app import mcp
@@ -33,6 +34,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+@with_zotero_api_lock
 def _extract_doi(item: dict) -> str | None:
     """Extract and normalize DOI from a Zotero item."""
     doi = item.get("data", {}).get("DOI", "")
@@ -46,6 +48,7 @@ def _extract_doi(item: dict) -> str | None:
     return None
 
 
+@with_zotero_api_lock
 def _format_tally_line(tally: dict) -> str:
     """Format a tally dict as a compact inline string."""
     s = tally.get("supporting", 0)
@@ -55,6 +58,7 @@ def _format_tally_line(tally: dict) -> str:
     return f"Supporting: {s} | Contrasting: {c} | Mentioning: {m} (total citing: {total})"
 
 
+@with_zotero_api_lock
 def _format_editorial_notices(notices: list[dict]) -> list[str]:
     """Format editorial notices as warning lines."""
     lines = []
@@ -66,6 +70,7 @@ def _format_editorial_notices(notices: list[dict]) -> list[str]:
     return lines
 
 
+@with_zotero_api_lock
 def enrich_items(items: list[dict]) -> dict[str, dict[str, str]]:
     """Batch-enrich a list of Zotero items with Scite data.
 
@@ -118,6 +123,7 @@ def enrich_items(items: list[dict]) -> dict[str, dict[str, str]]:
         "Provide either a DOI or a Zotero item key. No Scite account needed."
     ),
 )
+@with_zotero_api_lock
 def enrich_item(
     doi: str | None = None,
     item_key: str | None = None,
@@ -199,6 +205,7 @@ def enrich_item(
         "No Scite account needed."
     ),
 )
+@with_zotero_api_lock
 def enrich_search(
     query: str,
     limit: int | str = 10,
@@ -260,6 +267,7 @@ def enrich_search(
         "tag, or check recent items. No Scite account needed."
     ),
 )
+@with_zotero_api_lock
 def check_retractions(
     collection: str | None = None,
     tag: str | None = None,

--- a/src/zotero_mcp/tools/search.py
+++ b/src/zotero_mcp/tools/search.py
@@ -11,6 +11,7 @@ from fastmcp import Context
 
 from zotero_mcp._app import mcp
 from zotero_mcp import client as _client
+from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp import utils as _utils
 from zotero_mcp.tools import _helpers
 
@@ -19,6 +20,7 @@ _search_logger = _logging.getLogger("zotero_mcp.search")
 CASCADE_TIMEOUT = 60  # seconds — total budget for the entire fallback cascade
 
 
+@with_zotero_api_lock
 def _search_with_variants(zot, query: str, qmode: str, limit: int,
                           item_type: str = "-attachment",
                           tag: list[str] | None = None,
@@ -74,6 +76,7 @@ def _search_with_variants(zot, query: str, qmode: str, limit: int,
     name="zotero_search_items",
     description="Search for items in your Zotero library, given a query string. Returns metadata and abstracts. IMPORTANT: Use short, simple queries — 'Author Year' (e.g., 'Brewer 2011') or just the author name (e.g., 'Cladder-Micus'). Do NOT add extra keywords like topic words — this is substring matching, not web search. More words make the search STRICTER, not broader. If no results are found, the tool will automatically retry with simplified queries and semantic search."
 )
+@with_zotero_api_lock
 def search_items(
     query: str,
     qmode: Literal["titleCreatorYear", "everything"] = "titleCreatorYear",
@@ -258,6 +261,7 @@ def search_items(
     description="Search for items in your Zotero library by tag. "
     "Conditions are ANDed, each term supports disjunction (`OR`) and exclusion (`-`)."
 )
+@with_zotero_api_lock
 def search_by_tag(
     tag: list[str],
     item_type: str = "-attachment",
@@ -320,6 +324,7 @@ def search_by_tag(
     description="Look up a Zotero item by its BetterBibTeX citation key (e.g., 'Smith2024'). "
     "Works in local mode via the BetterBibTeX API, or in web mode by searching the Extra field."
 )
+@with_zotero_api_lock
 def search_by_citation_key(
     citekey: str,
     *,
@@ -386,6 +391,7 @@ def search_by_citation_key(
     name="zotero_advanced_search",
     description="Perform an advanced search with multiple criteria."
 )
+@with_zotero_api_lock
 def advanced_search(
     conditions: list[dict[str, str]],
     join_mode: Literal["all", "any"] = "all",
@@ -636,6 +642,7 @@ def advanced_search(
     name="zotero_semantic_search",
     description="Prioritized search tool. Perform semantic search over your Zotero library using AI-powered embeddings. BEST TOOL for finding papers on a specific topic — much more efficient than scanning collection items or reading abstracts. Works across your entire library."
 )
+@with_zotero_api_lock
 def semantic_search(
     query: str,
     limit: int = 10,
@@ -746,6 +753,7 @@ def semantic_search(
         "user has added items directly in Zotero since the last update."
     )
 )
+@with_zotero_api_lock
 def update_search_database(
     force_rebuild: bool = False,
     limit: int | None = None,
@@ -812,6 +820,7 @@ def update_search_database(
     name="zotero_get_search_database_status",
     description="Get status information about the semantic search database."
 )
+@with_zotero_api_lock
 def get_search_database_status(*, ctx: Context) -> str:
     """
     Get semantic search database status.

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -12,6 +12,7 @@ from fastmcp import Context
 
 from zotero_mcp._app import mcp
 from zotero_mcp import client as _client
+from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp import utils as _utils
 from zotero_mcp.tools import _helpers
 
@@ -23,6 +24,7 @@ CROSSREF_TYPE_MAP = _helpers.CROSSREF_TYPE_MAP
     name="zotero_batch_update_tags",
     description="Batch update tags across multiple items matching a search query or tag filter."
 )
+@with_zotero_api_lock
 def batch_update_tags(
     query: str = "",
     add_tags: list[str] | str | None = None,
@@ -215,6 +217,7 @@ def batch_update_tags(
     name="zotero_create_collection",
     description="Create a new collection (project/folder) in your Zotero library."
 )
+@with_zotero_api_lock
 def create_collection(
     name: str,
     parent_collection: str | None = None,
@@ -264,6 +267,7 @@ def create_collection(
     name="zotero_search_collections",
     description="Search for collections by name to find their keys."
 )
+@with_zotero_api_lock
 def search_collections(
     query: str,
     *,
@@ -312,6 +316,7 @@ def search_collections(
     name="zotero_manage_collections",
     description="Add or remove items from collections."
 )
+@with_zotero_api_lock
 def manage_collections(
     item_keys: list[str] | str,
     add_to: list[str] | str | None = None,
@@ -377,6 +382,7 @@ def manage_collections(
     name="zotero_add_by_doi",
     description="Add a paper to your Zotero library by DOI. Fetches metadata from CrossRef."
 )
+@with_zotero_api_lock
 def add_by_doi(
     doi: str,
     collections: list[str] | str | None = None,
@@ -529,6 +535,7 @@ def add_by_doi(
     name="zotero_add_by_url",
     description="Add a paper by URL. Supports DOI URLs, arXiv URLs, and general web pages."
 )
+@with_zotero_api_lock
 def add_by_url(
     url: str,
     collections: list[str] | str | None = None,
@@ -587,6 +594,7 @@ def add_by_url(
         return f"Error adding by URL: {e}"
 
 
+@with_zotero_api_lock
 def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx):
     """Add an arXiv paper by ID. Internal helper for add_by_url."""
     ctx.info(f"Fetching arXiv metadata for: {arxiv_id}")
@@ -688,6 +696,7 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx):
     name="zotero_update_item",
     description="Update metadata for an existing item in your Zotero library."
 )
+@with_zotero_api_lock
 def update_item(
     item_key: str,
     title: str | None = None,
@@ -808,6 +817,7 @@ def update_item(
     name="zotero_find_duplicates",
     description="Find duplicate items in your library by title and/or DOI."
 )
+@with_zotero_api_lock
 def find_duplicates(
     method: Literal["title", "doi", "both"] = "both",
     collection_key: str | None = None,
@@ -918,6 +928,7 @@ def find_duplicates(
         "Dry-run by default — call with confirm=True to execute."
     )
 )
+@with_zotero_api_lock
 def merge_duplicates(
     keeper_key: str,
     duplicate_keys: list[str] | str,
@@ -1120,6 +1131,7 @@ def merge_duplicates(
     name="zotero_get_pdf_outline",
     description="Extract the table of contents / outline from a PDF attachment."
 )
+@with_zotero_api_lock
 def get_pdf_outline(
     item_key: str,
     *,
@@ -1181,6 +1193,7 @@ def get_pdf_outline(
         "File path must be absolute and point to a .pdf or .epub file."
     )
 )
+@with_zotero_api_lock
 def add_from_file(
     file_path: str,
     title: str | None = None,


### PR DESCRIPTION
## Problem

When using `ZOTERO_LOCAL=true` with a moderately large library (~7000 items), paginated operations (`find_duplicates`, `get_collection_items`, `search_by_tag`, and anything using `_paginate()`) consistently time out. The Zotero local API (port 23119) stops responding when hit with rapid back-to-back requests from the pagination loop.

**Reproduction steps:**
1. Configure zotero-mcp with `ZOTERO_LOCAL=true`
2. Have a Zotero library with 5000+ items
3. Call `find_duplicates()` or `get_collection_items()` on a large collection
4. Result: timeout / connection closed / 0 bytes returned

The root cause is that `_paginate()` and the inline pagination in `find_duplicates()` fire 100-item page requests in a tight `while True` loop with no delay between iterations. The Zotero desktop application cannot serve requests fast enough and stops responding.

A simple `curl` to `http://localhost:23119/api/users/0/items?limit=1` returns 0 bytes after 5 seconds when the MCP is simultaneously making rapid paginated requests — confirming the Zotero local API itself is the bottleneck.

## Fix

Add a configurable `page_delay` (default 0.5s) between page fetches in:
- `_paginate()` in `tools/_helpers.py` — the shared pagination helper
- `find_duplicates()` in `tools/write.py` — which has its own inline pagination loop

This gives the Zotero local API time to process each batch before the next request arrives.

## Changes

**`src/zotero_mcp/tools/_helpers.py`:**
- Add `import time`
- Add `page_delay=0.5` parameter to `_paginate()`
- Add `time.sleep(page_delay)` after each page fetch (before next iteration)

**`src/zotero_mcp/tools/write.py`:**
- Add `time.sleep(0.5)` in the `find_duplicates` pagination loop

## Environment

| Component | Version |
|-----------|---------|
| zotero-mcp | 0.2.2 |
| Zotero | 7.0.31 (Flatpak, Flathub stable) |
| OS | Linux (Ubuntu-based, kernel 6.17.x) |
| Library size | ~7000 items |

## Testing

After the patch, `find_duplicates(collection_key=...)` on a collection with ~880 items (including ~400 duplicates) completed successfully and returned 882 duplicate groups. Previously this operation timed out 100% of the time.

## Notes

- The 0.5s default is conservative. Could be made configurable via env var (e.g., `ZOTERO_PAGE_DELAY`) for users with faster Zotero setups.
- The Flatpak build of Zotero may be more susceptible due to sandbox I/O overhead, but the fix benefits any local API usage with large libraries.
- `find_duplicates` has its own inline pagination rather than using `_paginate()` — worth considering refactoring to use the shared helper in a follow-up.