### PR TITLE
fix: append 's' to library_type in write client override

### DIFF
--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -79,7 +79,12 @@ def _get_write_client(ctx):
         override = _client.get_active_library()
         if override:
             web_zot.library_id = override.get("library_id", web_zot.library_id)
-            web_zot.library_type = override.get("library_type", web_zot.library_type)
+            # pyzotero stores library_type with trailing "s" (e.g. "users", "groups")
+            # but the override stores the raw value (e.g. "user", "group"),
+            # so we must append "s" to match pyzotero's internal convention.
+            raw_type = override.get("library_type")
+            if raw_type:
+                web_zot.library_type = raw_type if raw_type.endswith("s") else raw_type + "s"
         return read_zot, web_zot
     raise ValueError(
         "Cannot perform write operations in local-only mode. "


### PR DESCRIPTION
## Summary

- Fixes write operations (e.g. `zotero_add_by_doi`, `zotero_create_collection`) returning **404 errors** after calling `zotero_switch_library` in hybrid mode (local reads + web API writes).

## Root Cause

In `_get_write_client()`, the active library override sets `web_zot.library_type` directly to the raw value from `set_active_library()` (e.g. `"group"` or `"user"`). However, pyzotero's `Zotero.__init__` appends `"s"` to `library_type` internally (`self.library_type = library_type + "s"`), making it `"groups"` or `"users"` for URL construction.

By setting the attribute directly, the constructor's `+ "s"` is bypassed, causing the Zotero API URL to be built as:
- `/group/6287660/items` (404) instead of `/groups/6287660/items` (200)
- `/user/12345/items` (404) instead of `/users/12345/items` (200)

## Fix

Append `"s"` to the raw library type before assigning it to `web_zot.library_type`, matching pyzotero's internal convention.

## Test plan

- [ ] Configure hybrid mode (`ZOTERO_LOCAL=true` + `ZOTERO_API_KEY` + `ZOTERO_LIBRARY_ID`)
- [ ] Call `zotero_switch_library` to switch to a group library
- [ ] Call `zotero_add_by_doi` — should succeed (previously returned 404)
- [ ] Call `zotero_switch_library` back to user library
- [ ] Call `zotero_add_by_doi` — should also succeed