### PR TITLE
feat: add update_annotation and delete_annotation tools

### DIFF
--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -91,6 +91,8 @@ from zotero_mcp.tools.annotations import (  # noqa: F401
     create_note,
     update_note,
     delete_note,
+    update_annotation,
+    delete_annotation,
     create_annotation,
     create_area_annotation,
 )

--- a/src/zotero_mcp/tools/annotations.py
+++ b/src/zotero_mcp/tools/annotations.py
@@ -1088,6 +1088,125 @@ def delete_note(
 
 
 @mcp.tool(
+    name="zotero_update_annotation",
+    description="Update an existing Zotero annotation's comment, color, or text. Only the fields you provide will be changed."
+)
+def update_annotation(
+    item_key: str,
+    comment: str | None = None,
+    color: str | None = None,
+    text: str | None = None,
+    *,
+    ctx: Context
+) -> str:
+    """
+    Update an existing Zotero annotation.
+
+    Args:
+        item_key: Zotero item key/ID of the annotation to update
+        comment: New comment text (replaces existing comment)
+        color: New highlight color in hex format (e.g. "#ff6666")
+        text: New annotation text (replaces existing annotationText)
+        ctx: MCP context
+
+    Returns:
+        Confirmation message
+    """
+    try:
+        ctx.info(f"Updating annotation {item_key}")
+
+        zot, err = _get_note_write_client("updating annotations")
+        if err:
+            return err
+
+        try:
+            item = zot.item(item_key)
+        except Exception:
+            return f"Error: No item found with key: {item_key}"
+
+        data = item.get("data", {})
+        if data.get("itemType") != "annotation":
+            return f"Error: Item {item_key} is not an annotation (itemType={data.get('itemType')})"
+
+        if comment is None and color is None and text is None:
+            return "Error: No fields to update. Provide at least one of: comment, color, text."
+
+        changes = []
+        if comment is not None:
+            data["annotationComment"] = comment
+            changes.append(f"comment={'(cleared)' if not comment else repr(comment[:50])}")
+        if color is not None:
+            data["annotationColor"] = color
+            changes.append(f"color={color}")
+        if text is not None:
+            data["annotationText"] = text
+            changes.append(f"text={repr(text[:50])}")
+
+        resp = zot.update_item(item)
+        if _helpers._handle_write_response(resp, ctx):
+            return f"Successfully updated annotation {item_key}: {', '.join(changes)}"
+        return f"Failed to update annotation {item_key}"
+
+    except Exception as e:
+        ctx.error(f"Error updating annotation: {str(e)}")
+        return f"Error updating annotation: {str(e)}"
+
+
+@mcp.tool(
+    name="zotero_delete_annotation",
+    description="Move a Zotero annotation to the Trash. Trashed annotations are recoverable from Zotero's Trash — empty the Trash in the Zotero UI for permanent deletion."
+)
+def delete_annotation(
+    item_key: str,
+    *,
+    ctx: Context
+) -> str:
+    """
+    Move a Zotero annotation to the Trash.
+
+    Args:
+        item_key: Zotero item key/ID of the annotation to trash
+        ctx: MCP context
+
+    Returns:
+        Confirmation message
+    """
+    try:
+        ctx.info(f"Trashing annotation {item_key}")
+
+        zot, err = _get_note_write_client("deleting annotations")
+        if err:
+            return err
+
+        try:
+            item = zot.item(item_key)
+        except Exception:
+            return f"Error: No item found with key: {item_key}"
+
+        data = item.get("data", {})
+        if data.get("itemType") != "annotation":
+            return f"Error: Item {item_key} is not an annotation (itemType={data.get('itemType')})"
+
+        from pyzotero.zotero import build_url
+        url = build_url(
+            zot.endpoint,
+            f"/{zot.library_type}/{zot.library_id}/items/{item_key}",
+        )
+        resp = zot.client.patch(
+            url=url,
+            headers={"If-Unmodified-Since-Version": str(item["version"])},
+            content=json.dumps({"deleted": 1}),
+        )
+        if resp.status_code in (200, 204):
+            return f"Successfully trashed annotation {item_key} (recoverable from Zotero's Trash)"
+        return f"Failed to trash annotation {item_key} (HTTP {resp.status_code}): {resp.text[:200]}"
+
+    except Exception as e:
+        ctx.error(f"Error trashing annotation: {str(e)}")
+        return f"Error trashing annotation: {str(e)}"
+
+
+@mcp.tool(
     name="zotero_create_annotation",
     description=(
         "Create a highlight annotation on a PDF or EPUB attachment with optional comment. "

--- a/tests/test_annotation_crud.py
+++ b/tests/test_annotation_crud.py
@@ -1,0 +1,257 @@
+"""Tests for update_annotation and delete_annotation tools."""
+
+import json
+
+from zotero_mcp import server
+
+
+class DummyContext:
+    def info(self, *_args, **_kwargs):
+        return None
+
+    def error(self, *_args, **_kwargs):
+        return None
+
+    def warning(self, *_args, **_kwargs):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _annotation_item(key, text="highlighted text", comment="my comment",
+                     color="#ffd400", anno_type="highlight", parent="ATT0001",
+                     version=10):
+    return {
+        "key": key,
+        "version": version,
+        "data": {
+            "key": key,
+            "version": version,
+            "itemType": "annotation",
+            "parentItem": parent,
+            "annotationType": anno_type,
+            "annotationText": text,
+            "annotationComment": comment,
+            "annotationColor": color,
+            "tags": [],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fake Zotero clients
+# ---------------------------------------------------------------------------
+
+class FakeZoteroForAnnotationUpdate:
+    def __init__(self, items):
+        self._items = items
+        self.updated = []
+
+    def item(self, key):
+        if key not in self._items:
+            raise KeyError(key)
+        return self._items[key]
+
+    def update_item(self, item):
+        self.updated.append(item)
+        return {"success": True}
+
+
+class FakePatchResponse:
+    def __init__(self, status_code=204, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+class FakeHttpxClient:
+    def __init__(self, status_code=204, text=""):
+        self._status_code = status_code
+        self._text = text
+        self.calls = []
+
+    def patch(self, url, headers, content):
+        self.calls.append({"url": url, "headers": headers, "content": content})
+        return FakePatchResponse(self._status_code, self._text)
+
+
+class FakeZoteroForAnnotationDelete:
+    def __init__(self, items, patch_status=204):
+        self._items = items
+        self.endpoint = "https://api.zotero.org"
+        self.library_type = "users"
+        self.library_id = "12345"
+        self.client = FakeHttpxClient(status_code=patch_status)
+
+    def item(self, key):
+        if key not in self._items:
+            raise KeyError(key)
+        return self._items[key]
+
+
+# ---------------------------------------------------------------------------
+# update_annotation tests
+# ---------------------------------------------------------------------------
+
+def test_update_annotation_comment(monkeypatch):
+    anno = _annotation_item("ANNO0001", comment="old comment")
+    fake = FakeZoteroForAnnotationUpdate({"ANNO0001": anno})
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: False)
+
+    result = server.update_annotation(
+        item_key="ANNO0001", comment="new comment", ctx=DummyContext()
+    )
+
+    assert "Successfully updated" in result
+    assert fake.updated[0]["data"]["annotationComment"] == "new comment"
+
+
+def test_update_annotation_color(monkeypatch):
+    anno = _annotation_item("ANNO0001", color="#ffd400")
+    fake = FakeZoteroForAnnotationUpdate({"ANNO0001": anno})
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: False)
+
+    result = server.update_annotation(
+        item_key="ANNO0001", color="#ff6666", ctx=DummyContext()
+    )
+
+    assert "Successfully updated" in result
+    assert fake.updated[0]["data"]["annotationColor"] == "#ff6666"
+
+
+def test_update_annotation_text(monkeypatch):
+    anno = _annotation_item("ANNO0001", text="old text")
+    fake = FakeZoteroForAnnotationUpdate({"ANNO0001": anno})
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: False)
+
+    result = server.update_annotation(
+        item_key="ANNO0001", text="new text", ctx=DummyContext()
+    )
+
+    assert "Successfully updated" in result
+    assert fake.updated[0]["data"]["annotationText"] == "new text"
+
+
+def test_update_annotation_multiple_fields(monkeypatch):
+    anno = _annotation_item("ANNO0001")
+    fake = FakeZoteroForAnnotationUpdate({"ANNO0001": anno})
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: False)
+
+    result = server.update_annotation(
+        item_key="ANNO0001", comment="updated", color="#a28ae5", ctx=DummyContext()
+    )
+
+    assert "Successfully updated" in result
+    data = fake.updated[0]["data"]
+    assert data["annotationComment"] == "updated"
+    assert data["annotationColor"] == "#a28ae5"
+
+
+def test_update_annotation_no_fields_error(monkeypatch):
+    anno = _annotation_item("ANNO0001")
+    fake = FakeZoteroForAnnotationUpdate({"ANNO0001": anno})
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: False)
+
+    result = server.update_annotation(
+        item_key="ANNO0001", ctx=DummyContext()
+    )
+
+    assert "No fields to update" in result
+    assert fake.updated == []
+
+
+def test_update_annotation_rejects_non_annotation(monkeypatch):
+    note = {
+        "key": "NOTE0001",
+        "version": 1,
+        "data": {"key": "NOTE0001", "version": 1, "itemType": "note", "note": "<p>x</p>"},
+    }
+    fake = FakeZoteroForAnnotationUpdate({"NOTE0001": note})
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: False)
+
+    result = server.update_annotation(
+        item_key="NOTE0001", comment="x", ctx=DummyContext()
+    )
+
+    assert "is not an annotation" in result
+    assert fake.updated == []
+
+
+def test_update_annotation_missing_key(monkeypatch):
+    fake = FakeZoteroForAnnotationUpdate({})
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: False)
+
+    result = server.update_annotation(
+        item_key="ZZZZZZZZ", comment="x", ctx=DummyContext()
+    )
+
+    assert "No item found" in result
+    assert fake.updated == []
+
+
+# ---------------------------------------------------------------------------
+# delete_annotation tests
+# ---------------------------------------------------------------------------
+
+def test_delete_annotation_trashes_via_patch(monkeypatch):
+    anno = _annotation_item("ANNO0001", version=42)
+    fake = FakeZoteroForAnnotationDelete({"ANNO0001": anno})
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: False)
+
+    result = server.delete_annotation(item_key="ANNO0001", ctx=DummyContext())
+
+    assert "Successfully trashed" in result
+    assert len(fake.client.calls) == 1
+    call = fake.client.calls[0]
+    assert "ANNO0001" in call["url"]
+    assert call["headers"]["If-Unmodified-Since-Version"] == "42"
+    assert '"deleted": 1' in call["content"]
+
+
+def test_delete_annotation_rejects_non_annotation(monkeypatch):
+    note = {
+        "key": "NOTE0001",
+        "version": 1,
+        "data": {"key": "NOTE0001", "version": 1, "itemType": "note", "note": ""},
+    }
+    fake = FakeZoteroForAnnotationDelete({"NOTE0001": note})
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: False)
+
+    result = server.delete_annotation(item_key="NOTE0001", ctx=DummyContext())
+
+    assert "is not an annotation" in result
+    assert fake.client.calls == []
+
+
+def test_delete_annotation_missing_key(monkeypatch):
+    fake = FakeZoteroForAnnotationDelete({})
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: False)
+
+    result = server.delete_annotation(item_key="ZZZZZZZZ", ctx=DummyContext())
+
+    assert "No item found" in result
+    assert fake.client.calls == []
+
+
+def test_delete_annotation_http_error(monkeypatch):
+    anno = _annotation_item("ANNO0001", version=5)
+    fake = FakeZoteroForAnnotationDelete({"ANNO0001": anno}, patch_status=412)
+    fake.client._text = "Precondition failed"
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: False)
+
+    result = server.delete_annotation(item_key="ANNO0001", ctx=DummyContext())
+
+    assert "Failed to trash" in result
+    assert "412" in result


### PR DESCRIPTION
### Summary

Add `zotero_update_annotation` and `zotero_delete_annotation` MCP tools to complement the existing annotation CRUD operations. Previously, annotations could be created and read but not updated or deleted.

### Changes

- **`zotero_update_annotation`** — Update an existing annotation's `comment`, `color`, or `text` fields individually or in combination. Uses `zot.update_item()` (same pattern as `update_note`).
- **`zotero_delete_annotation`** — Move an annotation to Zotero's Trash via a direct PATCH with `{"deleted": 1}` (same pattern as `delete_note`). Recoverable from Zotero's Trash UI.
- Both tools validate that the target item is actually an `annotation` (rejects notes, articles, etc.)
- Exported new functions in `server.py`
- Added 11 unit tests covering: comment/color/text updates, multi-field updates, no-fields error, type rejection, missing key, trash via PATCH, and HTTP error handling

### Notes

- These tools do **not** require PDF download (unlike `create_annotation`), so they work regardless of storage backend (Zotero Cloud, WebDAV, or linked files).
- Follows the same `_get_note_write_client` pattern used by `update_note`/`delete_note`.

### Verification

```
$ python -m pytest tests/test_annotation_crud.py -v
11 passed

$ python -m pytest tests/ --ignore=tests/test_fulltext_local_mode.py --ignore=tests/test_semantic_search_quality.py --ignore=tests/test_semantic_stats.py -q
412 passed, 1 failed (pre-existing)
```