### PR TITLE
feat: add update/delete annotation tools + tags on create

### DIFF
--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -93,6 +93,8 @@ from zotero_mcp.tools.annotations import (  # noqa: F401
     delete_note,
     create_annotation,
     create_area_annotation,
+    update_annotation,
+    delete_annotation,
 )
 from zotero_mcp.tools.write import (  # noqa: F401
     batch_update_tags,

--- a/src/zotero_mcp/tools/annotations.py
+++ b/src/zotero_mcp/tools/annotations.py
@@ -1094,7 +1094,7 @@ def delete_note(
         "Parameters: attachment_key (the key of the PDF/EPUB attachment, not the parent item), "
         "page (integer, 1-indexed — page 1 is the first page), "
         "text (exact text to highlight), color (hex, default yellow #ffd400), "
-        "comment (optional note on the highlight). "
+        "comment (optional note on the highlight), tags (optional list of tag strings). "
         "Requires PyMuPDF: pip install zotero-mcp-server[pdf]"
     )
 )
@@ -1104,6 +1104,7 @@ def create_annotation(
     text: str,
     comment: str | None = None,
     color: str = "#ffd400",
+    tags: list[str] | str | None = None,
     *,
     ctx: Context
 ) -> str:
@@ -1324,7 +1325,11 @@ def create_annotation(
                 char_position = position_data.get("char_position", chapter * 1000)
                 sort_index = f"{chapter:05d}|{char_position:08d}"
 
-            # Prepare the annotation data
+            tag_list = (
+                _helpers._normalize_str_list_input(tags, "tags")
+                if tags is not None else []
+            )
+
             annotation_data = {
                 "itemType": "annotation",
                 "parentItem": attachment_key,
@@ -1334,6 +1339,7 @@ def create_annotation(
                 "annotationColor": color,
                 "annotationSortIndex": sort_index,
                 "annotationPosition": annotation_position,
+                "tags": [{"tag": t} for t in tag_list],
             }
             # Only add pageLabel if not empty (EPUB should not have it)
             if page_label:
@@ -1393,6 +1399,7 @@ def create_area_annotation(
     height: float,
     comment: str | None = None,
     color: str = "#ffd400",
+    tags: list[str] | str | None = None,
     *,
     ctx: Context
 ) -> str:
@@ -1529,6 +1536,11 @@ def create_area_annotation(
                 position_data["rects"],
             )
 
+            tag_list = (
+                _helpers._normalize_str_list_input(tags, "tags")
+                if tags is not None else []
+            )
+
             annotation_data = {
                 "itemType": "annotation",
                 "parentItem": attachment_key,
@@ -1538,6 +1550,7 @@ def create_area_annotation(
                 "annotationSortIndex": position_data["sort_index"],
                 "annotationPosition": annotation_position,
                 "annotationPageLabel": page_label,
+                "tags": [{"tag": t} for t in tag_list],
             }
 
             ctx.info("Creating area annotation via Web API...")
@@ -1566,3 +1579,152 @@ def create_area_annotation(
     except Exception as e:
         ctx.error(f"Error creating area annotation: {str(e)}")
         return f"Error creating area annotation: {str(e)}"
+
+
+@mcp.tool(
+    name="zotero_update_annotation",
+    description=(
+        "Update an existing Zotero annotation. Editable fields: text (highlight text), "
+        "comment, color (hex like '#ffd400'), and tags. "
+        "Tags can be replaced wholesale via `tags`, or edited incrementally via "
+        "`add_tags`/`remove_tags` (mutually exclusive with `tags`). "
+        "Position/page/sortIndex are anchored to the PDF/EPUB geometry and are not editable."
+    )
+)
+def update_annotation(
+    annotation_key: str,
+    text: str | None = None,
+    comment: str | None = None,
+    color: str | None = None,
+    tags: list[str] | str | None = None,
+    add_tags: list[str] | str | None = None,
+    remove_tags: list[str] | str | None = None,
+    *,
+    ctx: Context
+) -> str:
+    try:
+        if tags is not None and (add_tags is not None or remove_tags is not None):
+            return (
+                "Error: Cannot use 'tags' (replace all) together with "
+                "'add_tags'/'remove_tags' (incremental). Use one approach or the other."
+            )
+
+        ctx.info(f"Updating annotation {annotation_key}")
+
+        zot, err = _get_note_write_client("updating annotations")
+        if err:
+            return err
+
+        try:
+            item = zot.item(annotation_key)
+        except Exception:
+            return f"Error: No item found with key: {annotation_key}"
+
+        data = item.get("data", {})
+        if data.get("itemType") != "annotation":
+            return (
+                f"Error: Item {annotation_key} is not an annotation "
+                f"(itemType={data.get('itemType')})"
+            )
+
+        changes = []
+        if text is not None:
+            data["annotationText"] = text
+            changes.append("- **text**: updated")
+        if comment is not None:
+            data["annotationComment"] = comment
+            changes.append("- **comment**: updated")
+        if color is not None:
+            data["annotationColor"] = color
+            changes.append(f"- **color**: {color}")
+
+        if tags is not None:
+            tag_list = _helpers._normalize_str_list_input(tags, "tags")
+            data["tags"] = [{"tag": t} for t in tag_list]
+            changes.append(f"- **tags**: replaced with {tag_list}")
+        elif add_tags is not None or remove_tags is not None:
+            existing = {t["tag"] for t in data.get("tags", [])}
+            if add_tags is not None:
+                to_add = _helpers._normalize_str_list_input(add_tags, "add_tags")
+                existing.update(to_add)
+                changes.append(f"- **tags**: added {to_add}")
+            if remove_tags is not None:
+                to_remove = set(
+                    _helpers._normalize_str_list_input(remove_tags, "remove_tags")
+                )
+                existing -= to_remove
+                changes.append(f"- **tags**: removed {list(to_remove)}")
+            data["tags"] = [{"tag": t} for t in sorted(existing)]
+
+        if not changes:
+            return "No changes to apply."
+
+        resp = zot.update_item(item)
+        if _helpers._handle_write_response(resp, ctx):
+            return (
+                f"Successfully updated annotation `{annotation_key}`:\n\n"
+                + "\n".join(changes)
+            )
+        return f"Failed to update annotation {annotation_key}"
+
+    except ValueError as e:
+        return f"Input error: {e}"
+    except Exception as e:
+        ctx.error(f"Error updating annotation: {e}")
+        return f"Error updating annotation: {e}"
+
+
+@mcp.tool(
+    name="zotero_delete_annotation",
+    description=(
+        "Move a Zotero annotation to the Trash. Trashed annotations are recoverable "
+        "from Zotero's Trash — empty the Trash in the Zotero UI for permanent deletion."
+    )
+)
+def delete_annotation(
+    annotation_key: str,
+    *,
+    ctx: Context
+) -> str:
+    try:
+        ctx.info(f"Trashing annotation {annotation_key}")
+
+        zot, err = _get_note_write_client("deleting annotations")
+        if err:
+            return err
+
+        try:
+            item = zot.item(annotation_key)
+        except Exception:
+            return f"Error: No item found with key: {annotation_key}"
+
+        data = item.get("data", {})
+        if data.get("itemType") != "annotation":
+            return (
+                f"Error: Item {annotation_key} is not an annotation "
+                f"(itemType={data.get('itemType')})"
+            )
+
+        from pyzotero.zotero import build_url
+        url = build_url(
+            zot.endpoint,
+            f"/{zot.library_type}/{zot.library_id}/items/{annotation_key}",
+        )
+        resp = zot.client.patch(
+            url=url,
+            headers={"If-Unmodified-Since-Version": str(item["version"])},
+            content=json.dumps({"deleted": 1}),
+        )
+        if resp.status_code in (200, 204):
+            return (
+                f"Successfully trashed annotation {annotation_key} "
+                "(recoverable from Zotero's Trash)"
+            )
+        return (
+            f"Failed to trash annotation {annotation_key} "
+            f"(HTTP {resp.status_code}): {resp.text[:200]}"
+        )
+
+    except Exception as e:
+        ctx.error(f"Error trashing annotation: {str(e)}")
+        return f"Error trashing annotation: {str(e)}"

--- a/tests/test_server_annotation_crud.py
+++ b/tests/test_server_annotation_crud.py
@@ -1,0 +1,263 @@
+"""Tests for zotero_update_annotation and zotero_delete_annotation,
+and for the `tags` parameter on zotero_create_annotation."""
+
+from zotero_mcp import server
+
+
+class DummyContext:
+    def info(self, *_args, **_kwargs):
+        return None
+
+    def error(self, *_args, **_kwargs):
+        return None
+
+    def warning(self, *_args, **_kwargs):
+        return None
+
+
+class FakeZoteroForAnnotationUpdate:
+    def __init__(self, items):
+        self._items = items
+        self.updated = []
+
+    def item(self, key):
+        if key not in self._items:
+            raise KeyError(key)
+        return self._items[key]
+
+    def update_item(self, item):
+        self.updated.append(item)
+        return {"success": True}
+
+
+def _annotation_item(key, *, text="old text", comment="", color="#ffd400", tags=None):
+    return {
+        "key": key,
+        "version": 1,
+        "data": {
+            "key": key,
+            "version": 1,
+            "itemType": "annotation",
+            "annotationType": "highlight",
+            "parentItem": "ATTACH01",
+            "annotationText": text,
+            "annotationComment": comment,
+            "annotationColor": color,
+            "annotationSortIndex": "00000|000000|00000",
+            "annotationPosition": "{}",
+            "tags": [{"tag": t} for t in (tags or [])],
+        },
+    }
+
+
+def _patch_client(monkeypatch, fake):
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: False)
+
+
+def test_update_annotation_updates_text_comment_color(monkeypatch):
+    fake = FakeZoteroForAnnotationUpdate(
+        {"ANNO0001": _annotation_item("ANNO0001", text="old", comment="", color="#ffd400")}
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = server.update_annotation(
+        annotation_key="ANNO0001",
+        text="new highlight",
+        comment="a thought",
+        color="#ff0000",
+        ctx=DummyContext(),
+    )
+
+    assert "Successfully updated" in result
+    data = fake.updated[0]["data"]
+    assert data["annotationText"] == "new highlight"
+    assert data["annotationComment"] == "a thought"
+    assert data["annotationColor"] == "#ff0000"
+
+
+def test_update_annotation_replaces_tags(monkeypatch):
+    fake = FakeZoteroForAnnotationUpdate(
+        {"ANNO0001": _annotation_item("ANNO0001", tags=["old1", "old2"])}
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = server.update_annotation(
+        annotation_key="ANNO0001",
+        tags=["fresh"],
+        ctx=DummyContext(),
+    )
+
+    assert "Successfully updated" in result
+    assert fake.updated[0]["data"]["tags"] == [{"tag": "fresh"}]
+
+
+def test_update_annotation_adds_and_removes_tags(monkeypatch):
+    fake = FakeZoteroForAnnotationUpdate(
+        {"ANNO0001": _annotation_item("ANNO0001", tags=["keep", "drop"])}
+    )
+    _patch_client(monkeypatch, fake)
+
+    result = server.update_annotation(
+        annotation_key="ANNO0001",
+        add_tags=["new"],
+        remove_tags=["drop"],
+        ctx=DummyContext(),
+    )
+
+    assert "Successfully updated" in result
+    final_tags = {t["tag"] for t in fake.updated[0]["data"]["tags"]}
+    assert final_tags == {"keep", "new"}
+
+
+def test_update_annotation_rejects_tags_with_add_tags(monkeypatch):
+    fake = FakeZoteroForAnnotationUpdate({"ANNO0001": _annotation_item("ANNO0001")})
+    _patch_client(monkeypatch, fake)
+
+    # Can't use both 'tags' and 'add_tags' in one call.
+    result = server.update_annotation(
+        annotation_key="ANNO0001",
+        tags=["a"],
+        add_tags=["b"],
+        ctx=DummyContext(),
+    )
+
+    assert "Cannot use 'tags'" in result
+    assert fake.updated == []
+
+
+def test_update_annotation_no_changes(monkeypatch):
+    fake = FakeZoteroForAnnotationUpdate({"ANNO0001": _annotation_item("ANNO0001")})
+    _patch_client(monkeypatch, fake)
+
+    result = server.update_annotation(
+        annotation_key="ANNO0001", ctx=DummyContext()
+    )
+
+    assert "No changes" in result
+    assert fake.updated == []
+
+
+def test_update_annotation_rejects_non_annotation(monkeypatch):
+    note = {
+        "key": "NOTE0001",
+        "version": 1,
+        "data": {"key": "NOTE0001", "version": 1, "itemType": "note", "note": "x"},
+    }
+    fake = FakeZoteroForAnnotationUpdate({"NOTE0001": note})
+    _patch_client(monkeypatch, fake)
+
+    result = server.update_annotation(
+        annotation_key="NOTE0001", text="x", ctx=DummyContext()
+    )
+
+    assert "is not an annotation" in result
+    assert fake.updated == []
+
+
+def test_update_annotation_missing_key(monkeypatch):
+    fake = FakeZoteroForAnnotationUpdate({})
+    _patch_client(monkeypatch, fake)
+
+    result = server.update_annotation(
+        annotation_key="ZZZZZZZZ", text="x", ctx=DummyContext()
+    )
+
+    assert "No item found" in result
+    assert fake.updated == []
+
+
+class FakePatchResponse:
+    def __init__(self, status_code=204, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+class FakeHttpxClient:
+    def __init__(self, status_code=204, text=""):
+        self._status_code = status_code
+        self._text = text
+        self.calls = []
+
+    def patch(self, url, headers, content):
+        self.calls.append({"url": url, "headers": headers, "content": content})
+        return FakePatchResponse(self._status_code, self._text)
+
+
+class FakeZoteroForAnnotationDelete:
+    def __init__(self, items, patch_status=204):
+        self._items = items
+        self.endpoint = "https://api.zotero.org"
+        self.library_type = "users"
+        self.library_id = "12345"
+        self.client = FakeHttpxClient(status_code=patch_status)
+
+    def item(self, key):
+        if key not in self._items:
+            raise KeyError(key)
+        return self._items[key]
+
+
+def test_delete_annotation_trashes_via_patch(monkeypatch):
+    fake = FakeZoteroForAnnotationDelete(
+        {"ANNO0001": _annotation_item("ANNO0001")}
+    )
+    # Version lives at item top level in the delete path.
+    fake._items["ANNO0001"]["version"] = 42
+    _patch_client(monkeypatch, fake)
+
+    result = server.delete_annotation(
+        annotation_key="ANNO0001", ctx=DummyContext()
+    )
+
+    assert "Successfully trashed" in result
+    assert len(fake.client.calls) == 1
+    call = fake.client.calls[0]
+    assert "ANNO0001" in call["url"]
+    assert call["headers"]["If-Unmodified-Since-Version"] == "42"
+    assert '"deleted": 1' in call["content"]
+
+
+def test_delete_annotation_rejects_non_annotation(monkeypatch):
+    note = {
+        "key": "NOTE0001",
+        "version": 1,
+        "data": {"key": "NOTE0001", "version": 1, "itemType": "note", "note": ""},
+    }
+    fake = FakeZoteroForAnnotationDelete({"NOTE0001": note})
+    _patch_client(monkeypatch, fake)
+
+    result = server.delete_annotation(
+        annotation_key="NOTE0001", ctx=DummyContext()
+    )
+
+    assert "is not an annotation" in result
+    assert fake.client.calls == []
+
+
+def test_delete_annotation_missing_key(monkeypatch):
+    fake = FakeZoteroForAnnotationDelete({})
+    _patch_client(monkeypatch, fake)
+
+    result = server.delete_annotation(
+        annotation_key="ZZZZZZZZ", ctx=DummyContext()
+    )
+
+    assert "No item found" in result
+    assert fake.client.calls == []
+
+
+def test_delete_annotation_http_error(monkeypatch):
+    fake = FakeZoteroForAnnotationDelete(
+        {"ANNO0001": _annotation_item("ANNO0001")}, patch_status=412
+    )
+    fake._items["ANNO0001"]["version"] = 5
+    fake.client._text = "Precondition failed"
+    _patch_client(monkeypatch, fake)
+
+    result = server.delete_annotation(
+        annotation_key="ANNO0001", ctx=DummyContext()
+    )
+
+    assert "Failed to trash" in result
+    assert "412" in result


### PR DESCRIPTION
## Summary

Rounds out annotation CRUD so it matches what notes and items already expose. Before this PR the MCP server could create and read annotations but had no way to edit or delete them — this closes the gap.

### New tools

- **`zotero_update_annotation`** — edit `text` (annotationText), `comment`, `color`, and `tags`. Tags support both replace-all (`tags=[...]`) and incremental (`add_tags`/`remove_tags`) modes, mutually exclusive — same shape as `zotero_update_item`. Position/sortIndex/pageLabel are intentionally *not* editable since they're anchored to the PDF/EPUB geometry.
- **`zotero_delete_annotation`** — soft-delete via direct PATCH `{\"deleted\": 1}`, mirroring `zotero_delete_note`. Goes to Zotero's Trash and is recoverable from the UI.

### Symmetry fix

- `zotero_create_annotation` and `zotero_create_area_annotation` now accept an optional `tags` parameter, matching `zotero_create_note`.

## Test plan

- [x] 11 new unit tests in `tests/test_server_annotation_crud.py` covering update (text/comment/color, replace tags, add/remove tags, mutex rejection, no-op, non-annotation, missing key) and delete (happy-path PATCH, non-annotation, missing key, HTTP error)
- [x] Hand-tested against a real Zotero library:
  - created a highlight annotation with a tag, then deleted it
  - created an area annotation with a tag, then deleted it
  - updated an existing highlight's color and tags, then reverted
- [x] Full test suite passes (two pre-existing unrelated failures on main: missing \`chromadb\` optional dep, a pre-existing \`create_note\` test)