### PR TITLE
fix: isolate PDF-extraction subprocess env from API keys

### DIFF
--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -297,12 +297,27 @@ class LocalZoteroReader:
             "sys.stdout.write(extract_text(sys.argv[1], maxpages=int(sys.argv[2])) or '')"
         )
 
+        # Strip API keys from the child's environment: pdfminer does not need
+        # them, and leaking them via crash dumps or /proc/<pid>/environ is
+        # needless exposure. Keep the rest of the env so the interpreter still
+        # finds system libraries, temp dirs, locale, etc.
+        child_env = os.environ.copy()
+        for _k in (
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "ZOTERO_API_KEY",
+        ):
+            child_env.pop(_k, None)
+
         try:
             result = subprocess.run(
                 [sys.executable, "-c", script, str(file_path), str(maxpages)],
                 capture_output=True,
                 text=True,
                 timeout=timeout,
+                env=child_env,
             )
             if result.returncode == 0:
                 return result.stdout


### PR DESCRIPTION
## Summary

The pdfminer.six child process spawned by `_extract_text_from_pdf` previously inherited the parent's full environment via `subprocess.run`'s default `env=None`. pdfminer does not read `OPENAI_API_KEY`, `GEMINI_API_KEY`, etc. — but any crash dump, core file, or `/proc/<pid>/environ` snapshot of the child would still capture them.

Strips a small allowlist of API-key env vars before handing the environment off to the child. Everything else is preserved so `PATH`, `TMPDIR`, `LANG`, locale, and temp-file locations behave exactly as before.

## Test plan

- [x] `tests/test_local_db.py` / `test_pdf_cascade.py` / `test_fulltext_local_mode.py` pass (29 tests)
- [x] Full suite: 435 passing, same count as `main`
- [x] Manual: PDF extraction still produces text via `zotero-mcp update-db --fulltext`