### PR TITLE
fix: parameterize LIMIT clause in get_items_with_text

### DIFF
--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -593,7 +593,8 @@ class LocalZoteroReader:
         """
 
         if limit:
-            query += f" LIMIT {limit}"
+            query += " LIMIT ?"
+            params.append(limit)
 
         cursor = conn.execute(query, params)
         items = []


### PR DESCRIPTION
## Summary

The `LIMIT {limit}` value in `LocalZoteroReader.get_items_with_text` was interpolated into SQL via f-string. The value currently comes from internal code only (CLI `--limit` or a zero default), so no injection is exploitable today — but the pattern is brittle: a future caller that routes an LLM- or user-controlled limit becomes a surprise hole.

Switches to a `?` placeholder and appends the value to the existing `params` list. No behavior change.

## Test plan

- [x] `tests/test_local_db.py` passes (11 tests)
- [x] Full suite: 435 passing