### PR TITLE
fix: non-blocking server lifespan to prevent MCP startup timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest fastmcp pyzotero python-dotenv markitdown[pdf] chromadb unidecode
+          python -m pip install pytest pytest-asyncio fastmcp pyzotero python-dotenv markitdown[pdf] chromadb unidecode
           python -m pip install -e . --no-deps
       - name: Run tests
         run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ all = [
 dev = [
     "zotero-mcp-server[all]",
     "pytest>=7.0.0",
+    "pytest-asyncio>=0.21",
     "ruff>=0.9.0",
 ]
 

--- a/src/zotero_mcp/_app.py
+++ b/src/zotero_mcp/_app.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 import sys
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastmcp import FastMCP
@@ -21,44 +21,51 @@ logging.basicConfig(
 )
 
 
+def _sync_semantic_update() -> None:
+    """Check for and run semantic search auto-update (called in a worker thread)."""
+    from zotero_mcp.semantic_search import create_semantic_search
+
+    config_path = Path.home() / ".config" / "zotero-mcp" / "config.json"
+    if not config_path.exists():
+        return
+
+    search = create_semantic_search(str(config_path))
+    if not search.should_update_database():
+        return
+
+    sys.stderr.write("Auto-updating semantic search database...\n")
+    stats = search.update_database(extract_fulltext=is_local_mode())
+    sys.stderr.write(
+        f"Database update completed: {stats.get('processed_items', 0)} items processed\n"
+    )
+
+
 @asynccontextmanager
 async def server_lifespan(server: FastMCP):
-    """Manage server startup and shutdown lifecycle."""
+    """Manage server startup and shutdown lifecycle.
+
+    Semantic search initialization (ChromaDB + embedding model) is
+    offloaded to a worker thread so it cannot block the event loop.
+    The previous synchronous call prevented FastMCP from responding
+    to the MCP ``initialize`` request within the 60-second client
+    timeout.
+
+    On shutdown the worker thread is left to finish on its own —
+    ``asyncio.to_thread`` threads cannot be interrupted, and
+    ChromaDB (SQLite WAL) is crash-safe, so an unfinished update
+    simply resumes on the next startup.
+    """
     sys.stderr.write("Starting Zotero MCP server...\n")
-    background_task: asyncio.Task | None = None
 
-    # Check for semantic search auto-update on startup
-    try:
-        from zotero_mcp.semantic_search import create_semantic_search
+    async def _background_update():
+        try:
+            await asyncio.to_thread(_sync_semantic_update)
+        except Exception as e:
+            sys.stderr.write(f"Warning: Could not check semantic search auto-update: {e}\n")
 
-        config_path = Path.home() / ".config" / "zotero-mcp" / "config.json"
-
-        if config_path.exists():
-            search = create_semantic_search(str(config_path))
-
-            if search.should_update_database():
-                sys.stderr.write("Auto-updating semantic search database...\n")
-
-                async def background_update():
-                    try:
-                        stats = await asyncio.to_thread(
-                            search.update_database, extract_fulltext=is_local_mode()
-                        )
-                        sys.stderr.write(f"Database update completed: {stats.get('processed_items', 0)} items processed\n")
-                    except Exception as e:
-                        sys.stderr.write(f"Background database update failed: {e}\n")
-
-                background_task = asyncio.create_task(background_update())
-
-    except Exception as e:
-        sys.stderr.write(f"Warning: Could not check semantic search auto-update: {e}\n")
+    asyncio.create_task(_background_update())
 
     yield {}
-
-    if background_task and not background_task.done():
-        background_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await background_task
 
     sys.stderr.write("Shutting down Zotero MCP server...\n")
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,0 +1,57 @@
+"""Tests for server lifespan — verifies startup is non-blocking."""
+
+import asyncio
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from zotero_mcp._app import server_lifespan
+
+
+@pytest.mark.asyncio
+async def test_lifespan_yields_before_sync_update_completes():
+    """The lifespan must yield (allow request handling) while the
+    background semantic update is still running."""
+    entered = threading.Event()
+    proceed = threading.Event()
+
+    def slow_update():
+        entered.set()
+        proceed.wait(timeout=5)
+
+    with patch("zotero_mcp._app._sync_semantic_update", slow_update):
+        async with server_lifespan(None) as ctx:
+            assert ctx == {}
+            # Yield to the event loop so the background task can start.
+            await asyncio.sleep(0.1)
+            assert entered.is_set(), \
+                "_sync_semantic_update was never called in the background"
+        proceed.set()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_yields_when_update_raises():
+    """Exceptions in the background update must not prevent the server
+    from starting."""
+
+    def exploding_update():
+        raise RuntimeError("ChromaDB exploded")
+
+    with patch("zotero_mcp._app._sync_semantic_update", exploding_update):
+        async with server_lifespan(None) as ctx:
+            assert ctx == {}
+            await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_lifespan_yields_when_config_missing():
+    """When no config exists, the background task completes instantly
+    and the lifespan still yields normally."""
+
+    def noop_update():
+        pass
+
+    with patch("zotero_mcp._app._sync_semantic_update", noop_update):
+        async with server_lifespan(None) as ctx:
+            assert ctx == {}


### PR DESCRIPTION
## Summary

- `create_semantic_search()` ran synchronously in `server_lifespan()` before `yield {}`, blocking the asyncio event loop and preventing FastMCP from responding to the MCP `initialize` request. With a large ChromaDB database (10K+ items) this regularly exceeded the 60-second client timeout, causing repeated disconnects on every startup.
- Move the entire semantic search initialization + auto-update into `asyncio.to_thread()` via a fire-and-forget background task so the lifespan yields immediately and the server can respond to `initialize` in <1 second.
- On shutdown the worker thread is left to finish on its own — `asyncio.to_thread` threads cannot be interrupted, and ChromaDB (SQLite WAL) is crash-safe, so an unfinished update simply resumes on the next startup.

## Evidence

MCP server logs (`~/Library/Logs/Claude/mcp-server-zotero.log`) show 40+ occurrences of this pattern from Feb–Mar 2026:

1. Client sends `initialize` (requestId:0)
2. Lifespan blocks on `create_semantic_search()` (ChromaDB + embedding model init)
3. 60 seconds later: `McpError: MCP error -32001: Request timed out`
4. Server transport closed, server dies, restarts, repeat

When `OPENAI_API_KEY` was not set, `create_semantic_search()` failed fast with an exception and the server started in ~5 seconds — confirming the synchronous init was the bottleneck.

## Test plan

- [x] 3 new tests in `tests/test_lifespan.py` (lifespan yields while update runs, yields when update raises, yields when config missing)
- [x] 404 passed, 1 pre-existing failure (missing chromadb in dev venv)
- [x] Integration test: `echo '{"jsonrpc":"2.0","method":"initialize",...,"id":0}' | timeout 5 zotero-mcp serve` returns response in <1 second
- [x] Changed CI (pytest across Python 3.10–3.12) — added `pytest-asyncio` to the CI workflow and the pyproject.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)