### PR TITLE
fix: add access_date and place to zotero_update_item (#240, #238)

### DIFF
--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -714,6 +714,7 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx):
 _UPDATE_ITEM_API_TO_PARAM = {
     "title": "title",
     "date": "date",
+    "accessDate": "access_date",
     "publicationTitle": "publication_title",
     "abstractNote": "abstract",
     "DOI": "doi",
@@ -723,6 +724,7 @@ _UPDATE_ITEM_API_TO_PARAM = {
     "issue": "issue",
     "pages": "pages",
     "publisher": "publisher",
+    "place": "place",
     "ISSN": "issn",
     "language": "language",
     "shortTitle": "short_title",
@@ -746,6 +748,7 @@ def update_item(
     title: str | None = None,
     creators: list[dict] | str | None = None,
     date: str | None = None,
+    access_date: str | None = None,
     publication_title: str | None = None,
     abstract: str | None = None,
     tags: list[str] | str | None = None,
@@ -760,6 +763,7 @@ def update_item(
     issue: str | None = None,
     pages: str | None = None,
     publisher: str | None = None,
+    place: str | None = None,
     issn: str | None = None,
     language: str | None = None,
     short_title: str | None = None,
@@ -795,6 +799,8 @@ def update_item(
             field_updates["title"] = title
         if date is not None:
             field_updates["date"] = date
+        if access_date is not None:
+            field_updates["accessDate"] = access_date
         if publication_title is not None:
             field_updates["publicationTitle"] = publication_title
         if abstract is not None:
@@ -813,6 +819,8 @@ def update_item(
             field_updates["pages"] = pages
         if publisher is not None:
             field_updates["publisher"] = publisher
+        if place is not None:
+            field_updates["place"] = place
         if issn is not None:
             field_updates["ISSN"] = issn
         if language is not None:

--- a/tests/test_update_item.py
+++ b/tests/test_update_item.py
@@ -47,6 +47,33 @@ def _make_item(key="ABCD1234", version=10, title="Original Title",
     }
 
 
+def _make_webpage_item(key="WEBP1234", version=10, title="A Web Page",
+                      access_date="", url="https://example.com",
+                      tags=None, collections=None, extra=""):
+    """Build a realistic Zotero webpage item dict (supports accessDate)."""
+    return {
+        "key": key,
+        "version": version,
+        "data": {
+            "key": key,
+            "version": version,
+            "itemType": "webpage",
+            "title": title,
+            "creators": [],
+            "date": "",
+            "accessDate": access_date,
+            "abstractNote": "",
+            "url": url,
+            "language": "",
+            "shortTitle": "",
+            "tags": [{"tag": t} for t in (tags or [])],
+            "collections": list(collections or []),
+            "extra": extra,
+            "relations": {},
+        },
+    }
+
+
 def _make_book_item(key="BOOK1234", version=10, title="Original Book",
                     tags=None, collections=None, extra="",
                     publisher="", edition="", isbn="", volume="",
@@ -749,6 +776,56 @@ class TestUpdateItemNewFields:
 
         assert fake.update_calls[0]["data"]["ISBN"] == "978-0-123456-78-9"
         assert "978-0-123456-78-9" in result
+
+    def test_update_access_date_on_webpage(self, monkeypatch):
+        """accessDate should be writable on webpage items (issue #240)."""
+        item = _make_webpage_item()
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="WEBP1234",
+            access_date="2026-04-21",
+            ctx=DummyContext(),
+        )
+
+        assert fake.update_calls[0]["data"]["accessDate"] == "2026-04-21"
+        assert "2026-04-21" in result
+
+    def test_update_place_on_book(self, monkeypatch):
+        """place should be writable on book items (issue #238 round-trip)."""
+        item = _make_book_item()
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="BOOK1234",
+            place="Cambridge, MA",
+            ctx=DummyContext(),
+        )
+
+        assert fake.update_calls[0]["data"]["place"] == "Cambridge, MA"
+        assert "Cambridge, MA" in result
+
+    def test_access_date_skipped_on_book(self, monkeypatch):
+        """accessDate is not valid for books — should be in skip warning."""
+        item = _make_book_item()
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="BOOK1234",
+            access_date="2026-04-21",
+            ctx=DummyContext(),
+        )
+
+        # No update should happen (accessDate not in book schema)
+        assert len(fake.update_calls) == 0
+        assert "access_date" in result
+        assert "book" in result.lower()
 
     def test_update_book_title_on_book_section(self, monkeypatch):
         item = _make_book_section_item()


### PR DESCRIPTION
## Summary

`zotero_update_item`'s parameter schema omitted two native Zotero fields that are required for common write workflows:

- `accessDate` (#240): needed to close webpage/document items under CSL bibliography rules; previously could only be written via an Extra-field workaround (`Accessed: YYYY-MM-DD`), leaving the native Info-pane field empty and requiring manual desktop migration.
- `place` (#238): publication city; previously no programmatic write path existed for book/bookSection/thesis items, breaking read-write round-trip parity with the corresponding read-side fix in PR #243.

Both are accepted as optional parameters, routed to their native camelCase Zotero API fields (`accessDate`, `place`), and validated by the existing skip-warning mechanism so callers attempting to write either on an incompatible item type get a clear error rather than a silent drop.

Closes #240. Completes the round-trip half of #238 (read side handled separately).

## Test plan

- [x] `test_update_access_date_on_webpage` — accessDate writes through on webpage
- [x] `test_update_place_on_book` — place writes through on book
- [x] `test_access_date_skipped_on_book` — writing accessDate on book produces snake_case `access_date` skip warning
- [x] Full suite: 374 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)