### PR TITLE
Accept stringified/dict tag filters + add zotero_delete_item (#237, #227)

### DIFF
--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -102,6 +102,7 @@ from zotero_mcp.tools.write import (  # noqa: F401
     add_by_doi,
     add_by_url,
     update_item,
+    delete_item,
     find_duplicates,
     merge_duplicates,
     get_pdf_outline,

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -147,6 +147,55 @@ def _normalize_str_list_input(value, field_name="value"):
     raise ValueError(f"{field_name} must be a list of strings or a string")
 
 
+def _normalize_tag_filter(value):
+    """Normalize a tag-filter argument into a list[str] for pyzotero.
+
+    Accepts every shape we've seen clients produce:
+    - None / empty                 → []
+    - ["a", "b"]                   → ["a", "b"]   (canonical)
+    - [{"tag": "a"}, {"tag": "b"}] → ["a", "b"]   (common LLM mis-shape)
+    - "a"                          → ["a"]
+    - '["a", "b"]'                 → ["a", "b"]   (JSON list of strings)
+    - '[{"tag": "a"}]'             → ["a"]        (JSON list of dicts, #237)
+
+    MCP runtimes sometimes stringify array arguments before they reach the
+    pydantic validator, and agents sometimes pass the dict-shape that Zotero
+    uses INSIDE an item (``{"tag": "X"}``) rather than the bare-string form
+    pyzotero's ``tag=`` parameter expects. Either path ended up rejected
+    upstream of the search logic. This normalizer collapses them all.
+    """
+    def _extract(v):
+        if isinstance(v, dict):
+            for key in ("tag", "name", "value"):
+                if key in v and str(v[key]).strip():
+                    return str(v[key]).strip()
+            return ""
+        return str(v).strip()
+
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [s for s in (_extract(v) for v in value) if s]
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return []
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return [raw]
+        if isinstance(parsed, list):
+            return [s for s in (_extract(v) for v in parsed) if s]
+        if isinstance(parsed, dict):
+            s = _extract(parsed)
+            return [s] if s else []
+        if isinstance(parsed, str):
+            s = parsed.strip()
+            return [s] if s else []
+        return []
+    return []
+
+
 def _resolve_collection_names(zot, names, ctx=None):
     """Resolve collection names to keys (case-insensitive)."""
     if not names:

--- a/src/zotero_mcp/tools/search.py
+++ b/src/zotero_mcp/tools/search.py
@@ -79,7 +79,7 @@ def search_items(
     qmode: Literal["titleCreatorYear", "everything"] = "titleCreatorYear",
     item_type: str = "-attachment",  # Exclude attachments by default
     limit: int | str | None = 10,
-    tag: list[str] | None = None,
+    tag: list[str] | list[dict] | str | None = None,
     collection_key: str | None = None,
     *,
     ctx: Context
@@ -92,7 +92,11 @@ def search_items(
         qmode: Query mode (titleCreatorYear or everything)
         item_type: Type of items to search for. Use "-attachment" to exclude attachments.
         limit: Maximum number of results to return
-        tag: List of tags conditions to filter by
+        tag: Tag filter. Accepts ["tagA", "tagB"] (preferred), a bare string
+            "tagA", a JSON-string list '["tagA", "tagB"]', or the dict-shape
+            [{"tag": "tagA"}] sometimes emitted by clients that confuse the
+            filter form with Zotero's stored-tag form. All are normalized
+            internally to the list[str] form pyzotero expects.
         collection_key: Optional collection key to scope the search to a specific collection.
             When provided, bypasses the fallback cascade and searches the collection directly.
         ctx: MCP context
@@ -104,11 +108,12 @@ def search_items(
         if not query.strip():
             return "Error: Search query cannot be empty"
 
+        # Normalize tag across every wire shape clients produce (#237).
+        tag = _helpers._normalize_tag_filter(tag)
+
         tag_condition_str = ""
         if tag:
             tag_condition_str = f" with tags: '{', '.join(tag)}'"
-        else:
-            tag = []
 
         ctx.info(f"Searching Zotero for '{query}'{tag_condition_str}")
         zot = _client.get_zotero_client()
@@ -277,7 +282,7 @@ def search_items(
     "Conditions are ANDed, each term supports disjunction (`OR`) and exclusion (`-`)."
 )
 def search_by_tag(
-    tag: list[str],
+    tag: list[str] | list[dict] | str,
     item_type: str = "-attachment",
     limit: int | str | None = 10,
     collection_key: str | None = None,
@@ -307,6 +312,8 @@ def search_by_tag(
         Markdown-formatted search results
     """
     try:
+        # Normalize tag across every wire shape clients produce (#237).
+        tag = _helpers._normalize_tag_filter(tag)
         if not tag:
             return "Error: Tag cannot be empty"
 

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -904,6 +904,86 @@ def update_item(
 
 
 @mcp.tool(
+    name="zotero_delete_item",
+    description=(
+        "Move a Zotero item to the Trash. Works for any item type (book, "
+        "journalArticle, webpage, attachment, etc.). For notes, use "
+        "zotero_delete_note — identical mechanism, constrained to notes "
+        "for safety. Trashed items are recoverable from Zotero's Trash — "
+        "empty the Trash in the Zotero UI for permanent deletion. "
+        "By default refuses to trash notes; set allow_note=True to override."
+    )
+)
+def delete_item(
+    item_key: str,
+    allow_note: bool = False,
+    *,
+    ctx: Context
+) -> str:
+    """
+    Move a Zotero item to the Trash.
+
+    Args:
+        item_key: Zotero item key/ID to trash
+        allow_note: If True, permits trashing note items. Default False
+            directs callers to zotero_delete_note for notes (which has the
+            same mechanism but is explicit about what it affects).
+        ctx: MCP context
+
+    Returns:
+        Confirmation message, or an error if the item cannot be trashed.
+    """
+    try:
+        _, write_zot = _helpers._get_write_client(ctx)
+    except ValueError as e:
+        return str(e)
+
+    try:
+        ctx.info(f"Trashing item {item_key}")
+
+        try:
+            item = write_zot.item(item_key)
+        except Exception:
+            return f"Error: No item found with key: {item_key}"
+
+        data = item.get("data", {})
+        item_type = data.get("itemType", "unknown")
+
+        if item_type == "note" and not allow_note:
+            return (
+                f"Error: Item {item_key} is a note. Use zotero_delete_note "
+                "for notes, or pass allow_note=True to override."
+            )
+
+        # pyzotero's delete_item() permanently destroys items, and update_item()
+        # strips the "deleted" field. Send a direct PATCH with {"deleted": 1}
+        # to move the item to Zotero's Trash (recoverable by the user).
+        from pyzotero.zotero import build_url
+        url = build_url(
+            write_zot.endpoint,
+            f"/{write_zot.library_type}/{write_zot.library_id}/items/{item_key}",
+        )
+        resp = write_zot.client.patch(
+            url=url,
+            headers={"If-Unmodified-Since-Version": str(item["version"])},
+            content=json.dumps({"deleted": 1}),
+        )
+        if resp.status_code in (200, 204):
+            return (
+                f"Successfully trashed item {item_key} "
+                f"(type={item_type}, recoverable from Zotero's Trash)"
+            )
+        return (
+            f"Failed to trash item {item_key} (HTTP {resp.status_code}): "
+            f"{resp.text[:200]}"
+        )
+
+    except Exception as e:
+        ctx.error(f"Error trashing item: {str(e)}")
+        return f"Error trashing item: {str(e)}"
+
+
+@mcp.tool(
     name="zotero_find_duplicates",
     description="Find duplicate items in your library by title and/or DOI."
 )

--- a/tests/test_delete_item.py
+++ b/tests/test_delete_item.py
@@ -1,0 +1,188 @@
+"""Tests for zotero_delete_item — Trash wrapper for any item type (#227).
+
+zotero_delete_note handles notes; the Zotero Web API supports trashing any
+item type via PATCH {"deleted": 1}. This test file covers the generic
+delete_item tool that wraps that mechanism for books, journalArticles,
+webpages, attachments, and so on.
+"""
+
+import pytest
+
+from zotero_mcp import server
+from conftest import DummyContext
+
+
+class _FakePatchResponse:
+    def __init__(self, status_code, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeHttpxClient:
+    def __init__(self, status_code=204, text=""):
+        self._status_code = status_code
+        self._text = text
+        self.calls = []
+
+    def patch(self, url, headers, content):
+        self.calls.append({"url": url, "headers": headers, "content": content})
+        return _FakePatchResponse(self._status_code, self._text)
+
+
+class _FakeZoteroForDelete:
+    def __init__(self, items, patch_status=204):
+        self._items = items
+        self.endpoint = "https://api.zotero.org"
+        self.library_type = "users"
+        self.library_id = "12345"
+        self.client = _FakeHttpxClient(status_code=patch_status)
+
+    def item(self, key):
+        if key not in self._items:
+            raise KeyError(key)
+        return self._items[key]
+
+
+def _book_item(key="BOOK0001", version=42):
+    return {
+        "key": key,
+        "version": version,
+        "data": {
+            "key": key, "version": version, "itemType": "book",
+            "title": "Some Book",
+        },
+    }
+
+
+def _note_item(key="NOTE0001", version=3):
+    return {
+        "key": key,
+        "version": version,
+        "data": {
+            "key": key, "version": version, "itemType": "note",
+            "note": "<p>text</p>",
+        },
+    }
+
+
+def _article_item(key="ART00001", version=7):
+    return {
+        "key": key,
+        "version": version,
+        "data": {
+            "key": key, "version": version, "itemType": "journalArticle",
+            "title": "A Paper",
+        },
+    }
+
+
+class TestDeleteItemSuccess:
+    def test_trashes_book(self, monkeypatch):
+        fake = _FakeZoteroForDelete({"BOOK0001": _book_item()})
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.delete_item(item_key="BOOK0001", ctx=DummyContext())
+
+        assert "Successfully trashed" in result
+        assert "book" in result
+        assert len(fake.client.calls) == 1
+        call = fake.client.calls[0]
+        assert "BOOK0001" in call["url"]
+        assert call["headers"]["If-Unmodified-Since-Version"] == "42"
+        assert '"deleted": 1' in call["content"]
+
+    def test_trashes_journal_article(self, monkeypatch):
+        fake = _FakeZoteroForDelete({"ART00001": _article_item()})
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.delete_item(item_key="ART00001", ctx=DummyContext())
+
+        assert "Successfully trashed" in result
+        assert "journalArticle" in result
+
+
+class TestDeleteItemNotesSafety:
+    def test_refuses_note_by_default(self, monkeypatch):
+        """Notes are redirected to zotero_delete_note for explicitness."""
+        fake = _FakeZoteroForDelete({"NOTE0001": _note_item()})
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.delete_item(item_key="NOTE0001", ctx=DummyContext())
+
+        assert "is a note" in result
+        assert "zotero_delete_note" in result
+        assert fake.client.calls == []
+
+    def test_allow_note_override(self, monkeypatch):
+        """Explicit opt-in permits trashing a note through delete_item."""
+        fake = _FakeZoteroForDelete({"NOTE0001": _note_item()})
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.delete_item(
+            item_key="NOTE0001", allow_note=True, ctx=DummyContext()
+        )
+
+        assert "Successfully trashed" in result
+        assert len(fake.client.calls) == 1
+
+
+class TestDeleteItemErrors:
+    def test_missing_item_key(self, monkeypatch):
+        fake = _FakeZoteroForDelete({})
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.delete_item(item_key="ZZZZZZZZ", ctx=DummyContext())
+
+        assert "No item found" in result
+        assert fake.client.calls == []
+
+    def test_http_failure_reports(self, monkeypatch):
+        fake = _FakeZoteroForDelete({"BOOK0001": _book_item()}, patch_status=412)
+        fake.client._text = "Precondition failed"
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.delete_item(item_key="BOOK0001", ctx=DummyContext())
+
+        assert "Failed to trash" in result
+        assert "412" in result
+
+    def test_local_only_mode_rejected(self, monkeypatch):
+        def _raise(ctx):
+            raise ValueError(
+                "Cannot perform write operations in local-only mode. "
+                "Add ZOTERO_API_KEY and ZOTERO_LIBRARY_ID to enable hybrid mode."
+            )
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client", _raise)
+
+        result = server.delete_item(item_key="BOOK0001", ctx=DummyContext())
+
+        assert "local-only" in result.lower() or "Cannot perform write" in result
+
+
+class TestDeleteItemPatchShape:
+    """The PATCH url/headers/content must match Zotero's write-API contract."""
+
+    def test_url_targets_correct_library(self, monkeypatch):
+        fake = _FakeZoteroForDelete({"BOOK0001": _book_item()})
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        server.delete_item(item_key="BOOK0001", ctx=DummyContext())
+
+        url = fake.client.calls[0]["url"]
+        assert "/users/12345/items/BOOK0001" in url
+
+    def test_version_header_matches_fetched_version(self, monkeypatch):
+        fake = _FakeZoteroForDelete({"BOOK0001": _book_item(version=99)})
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        server.delete_item(item_key="BOOK0001", ctx=DummyContext())
+
+        assert fake.client.calls[0]["headers"]["If-Unmodified-Since-Version"] == "99"

--- a/tests/test_tag_filter_normalization.py
+++ b/tests/test_tag_filter_normalization.py
@@ -1,0 +1,165 @@
+"""Regression tests for #237 — tag-filter argument normalization.
+
+Clients produce several wire shapes for the `tag` argument depending on the
+MCP runtime path: bare strings, JSON-string lists, lists of strings, lists
+of dicts of the form {"tag": "X"} (the shape Zotero uses for stored tags,
+which agents sometimes confuse with the filter shape). pyzotero's `tag=`
+parameter wants list[str] — the normalizer collapses all inputs to that.
+"""
+
+import pytest
+
+from zotero_mcp.tools._helpers import _normalize_tag_filter
+
+
+class TestNormalizeTagFilter:
+    def test_none_returns_empty_list(self):
+        assert _normalize_tag_filter(None) == []
+
+    def test_empty_string_returns_empty_list(self):
+        assert _normalize_tag_filter("") == []
+        assert _normalize_tag_filter("   ") == []
+
+    def test_bare_string(self):
+        assert _normalize_tag_filter("FIXME") == ["FIXME"]
+
+    def test_list_of_strings(self):
+        assert _normalize_tag_filter(["a", "b"]) == ["a", "b"]
+
+    def test_list_of_dicts_with_tag_key(self):
+        """The #237 primary case — LLM sends Zotero's stored-tag dict shape."""
+        assert _normalize_tag_filter([{"tag": "FIXME"}]) == ["FIXME"]
+        assert _normalize_tag_filter(
+            [{"tag": "a"}, {"tag": "b"}]
+        ) == ["a", "b"]
+
+    def test_list_of_dicts_with_name_key(self):
+        """Accept {'name': 'X'} as a fallback shape some clients emit."""
+        assert _normalize_tag_filter([{"name": "FIXME"}]) == ["FIXME"]
+
+    def test_json_string_list_of_strings(self):
+        """Pydantic serialization stringifies arrays — this is the exact
+        wire shape in the #237 bug report."""
+        assert _normalize_tag_filter('["a", "b"]') == ["a", "b"]
+
+    def test_json_string_list_of_dicts(self):
+        """The #237 bug's literal failing input: list-of-dicts stringified."""
+        assert _normalize_tag_filter('[{"tag": "FIXME"}]') == ["FIXME"]
+
+    def test_json_string_single_dict(self):
+        assert _normalize_tag_filter('{"tag": "FIXME"}') == ["FIXME"]
+
+    def test_mixed_list(self):
+        """Heterogeneous list: dicts and bare strings interleaved."""
+        assert _normalize_tag_filter(
+            [{"tag": "a"}, "b", {"name": "c"}]
+        ) == ["a", "b", "c"]
+
+    def test_empty_dict_ignored(self):
+        assert _normalize_tag_filter([{}]) == []
+
+    def test_dict_with_no_recognized_key_ignored(self):
+        assert _normalize_tag_filter([{"foo": "bar"}]) == []
+
+    def test_empty_string_inside_list_ignored(self):
+        assert _normalize_tag_filter(["", "real", "   "]) == ["real"]
+
+    def test_whitespace_trimmed(self):
+        assert _normalize_tag_filter([" a ", {"tag": " b "}]) == ["a", "b"]
+
+    def test_non_json_string_treated_as_single_tag(self):
+        """A bare string that looks like a tag, not JSON."""
+        assert _normalize_tag_filter("my-tag") == ["my-tag"]
+
+
+class _SearchableFake:
+    """Minimal pyzotero stub with the methods search_items needs."""
+
+    def __init__(self):
+        self.last_params = {}
+        self._items_to_return = []
+
+    def add_parameters(self, **kwargs):
+        self.last_params = kwargs
+
+    def items(self):
+        return list(self._items_to_return)
+
+    def collection(self, key):
+        return {"key": key}
+
+    def collection_items(self, *args, **kwargs):
+        return list(self._items_to_return)
+
+
+class TestSearchItemsIntegration:
+    """End-to-end: search_items should accept the problematic shapes without
+    raising a pydantic validation error AND actually pass the normalized
+    list[str] through to pyzotero's ``tag=`` parameter."""
+
+    def _patch(self, monkeypatch, fake):
+        monkeypatch.setattr(
+            "zotero_mcp.tools.search._client.get_zotero_client",
+            lambda: fake,
+        )
+
+    def test_search_items_accepts_dict_shape_tag(self, monkeypatch):
+        """The exact failing call from the #237 bug report."""
+        from zotero_mcp import server
+        from conftest import DummyContext
+
+        fake = _SearchableFake()
+        self._patch(monkeypatch, fake)
+
+        result = server.search_items(
+            query="whatever",
+            tag=[{"tag": "FIXME"}],
+            ctx=DummyContext(),
+        )
+        # Normalized to list[str] before hitting pyzotero
+        assert fake.last_params.get("tag") == ["FIXME"]
+        # No pydantic explosion; search ran to a clean "no results"
+        assert "FIXME" in result
+
+    def test_search_items_accepts_json_string_tag(self, monkeypatch):
+        """The stringified form the MCP serialization layer produces."""
+        from zotero_mcp import server
+        from conftest import DummyContext
+
+        fake = _SearchableFake()
+        self._patch(monkeypatch, fake)
+
+        result = server.search_items(
+            query="whatever",
+            tag='[{"tag": "FIXME"}]',
+            ctx=DummyContext(),
+        )
+        assert fake.last_params.get("tag") == ["FIXME"]
+        assert "FIXME" in result
+
+    def test_search_items_accepts_canonical_list_of_strings(self, monkeypatch):
+        """Regression guard: canonical shape must still work."""
+        from zotero_mcp import server
+        from conftest import DummyContext
+
+        fake = _SearchableFake()
+        self._patch(monkeypatch, fake)
+
+        result = server.search_items(
+            query="whatever",
+            tag=["a", "b"],
+            ctx=DummyContext(),
+        )
+        assert fake.last_params.get("tag") == ["a", "b"]
+        assert "a, b" in result
+
+    def test_search_items_no_tag(self, monkeypatch):
+        """Regression guard: tag omitted entirely should not pass tag= to API."""
+        from zotero_mcp import server
+        from conftest import DummyContext
+
+        fake = _SearchableFake()
+        self._patch(monkeypatch, fake)
+
+        server.search_items(query="whatever", ctx=DummyContext())
+        assert "tag" not in fake.last_params or not fake.last_params.get("tag")


### PR DESCRIPTION
Two small fixes in one branch — two commits, squash or rebase-merge both work.

## Commits

| Issue | Commit | What it does |
|---|---|---|
| [#237](https://github.com/54yyyu/zotero-mcp/issues/237) | \`fix: accept tag filter in any wire shape on search tools\` | Search tools' \`tag\` parameter blew up under pydantic validation when clients sent \`'[{\"tag\":\"FIXME\"}]'\` (stringified list-of-dicts) or other common mis-shapes. Normalize all inputs to \`list[str]\` before pyzotero sees them. |
| [#227](https://github.com/54yyyu/zotero-mcp/issues/227) | \`feat: add zotero_delete_item for non-note item types\` | \`zotero_delete_note\` handled notes only; no wrapper existed for the Zotero Web API's generic trash endpoint. Add \`zotero_delete_item\` mirroring the delete_note trash mechanism, with a safety guard against accidentally trashing notes (configurable via \`allow_note=True\`). |

## #237 — Tag-filter normalization

The MCP serialization layer sometimes stringifies array arguments before they reach the pydantic validator:

\`\`\`
tag Input should be a valid list
    input_value='[{\"tag\": \"FIXME\"}]', input_type=str
\`\`\`

And agents sometimes pass Zotero's stored-tag dict shape (\`[{\"tag\": \"X\"}]\`) rather than the bare-string form pyzotero's \`tag=\` parameter expects. Both paths ended up rejected upstream of the search logic, rendering the tag-filter enumeration path unusable — every caller fell back to client-side filtering, O(n) instead of O(k).

Added \`_normalize_tag_filter(value)\` to \`tools/_helpers.py\` that collapses every observed shape to \`list[str]\`:

- \`list[str]\` → canonical passthrough
- \`list[dict]\` with \`{tag|name|value: X}\` → extract X
- bare string \`\"X\"\` → \`[\"X\"]\`
- JSON string of list-of-strings → parsed
- JSON string of list-of-dicts → parsed + extracted (the #237 case)
- \`None\` / empty / whitespace → \`[]\`

Widened \`tag\` on \`search_items\` and \`search_by_tag\` to \`list[str] | list[dict] | str | None\` and normalize first thing.

## #227 — Generic item deletion

Mirrors \`zotero_delete_note\`'s trash-via-PATCH mechanism for any item type. Safety guard redirects callers to \`zotero_delete_note\` when the target is a note, unless \`allow_note=True\` is passed. Item is recoverable from the Zotero UI Trash (no permanent destruction).

## Test plan

- [x] \`test_tag_filter_normalization.py\` — 19 tests: all shapes of \`_normalize_tag_filter\` covered, plus integration tests that assert the normalized \`list[str]\` is what pyzotero's \`tag=\` parameter actually receives.
- [x] \`test_delete_item.py\` — 9 tests: book/journalArticle trash, note-safety guard, \`allow_note\` override, missing-key error, HTTP failure reporting, local-only mode rejection, PATCH url/version-header shape.
- [x] Full suite: **397 passed, 3 skipped** (one unrelated chromadb optional import failure in \`test_search_improvements.py\` excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)