### PR TITLE
feat: add items by BibTeX and CSL JSON (closes #241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`zotero_add_by_bibtex`** — ingest one or more items from a BibTeX string; parses via `bibtexparser` (with LaTeX→unicode conversion), maps to Zotero item format, preserves the citation key in Extra, and attempts an open-access PDF attachment when a DOI is present (#241).
+- **`zotero_add_by_csl_json`** — same for CSL JSON input; accepts a JSON string, a single object, or an array. The CSL `id` is preserved in Extra as the citation key (#241).
+- New `citation_import` module — BibTeX parsing, CSL JSON coercion, and the shared field/type crosswalk (reference: <https://aurimasv.github.io/z2csl/typeMap.xml>).
+- New dependency: `bibtexparser>=1.4,<2`.
+
 ## [0.2.2] - 2026-03-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **`zotero_add_by_bibtex`** — ingest one or more items from a BibTeX string; parses via `bibtexparser` (with LaTeX→unicode conversion), maps to Zotero item format, preserves the citation key in Extra, and attempts an open-access PDF attachment when a DOI is present (#241).
-- **`zotero_add_by_csl_json`** — same for CSL JSON input; accepts a JSON string, a single object, or an array. The CSL `id` is preserved in Extra as the citation key (#241).
+- **`zotero_add_by_bibtex`** — ingest one or more items from a BibTeX string OR a `.bib`/`.bibtex` file path; parses via `bibtexparser` (with LaTeX→unicode conversion), maps to Zotero item format, preserves the citation key in Extra, and attempts an open-access PDF attachment when a DOI is present (#241).
+- **`zotero_add_by_csl_json`** — same for CSL JSON input from an inline string/object/array OR a `.json`/`.csljson` file path. The CSL `id` is preserved in Extra as the citation key (#241).
 - New `citation_import` module — BibTeX parsing, CSL JSON coercion, and the shared field/type crosswalk (reference: <https://aurimasv.github.io/z2csl/typeMap.xml>).
 - New dependency: `bibtexparser>=1.4,<2`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "requests>=2.28.0",
     "fastmcp>=2.14.0",
     "unidecode>=1.3.0",
+    "bibtexparser>=1.4,<2",
 ]
 
 [project.optional-dependencies]

--- a/src/zotero_mcp/citation_import.py
+++ b/src/zotero_mcp/citation_import.py
@@ -1,0 +1,677 @@
+"""Parsers and mappers that convert BibTeX / CSL JSON into Zotero item dicts.
+
+Reference crosswalk for type and field mappings:
+https://aurimasv.github.io/z2csl/typeMap.xml
+
+Entry point functions:
+- ``parse_bibtex(text)`` -> list of parsed entry dicts
+- ``bibtex_entry_to_zotero(entry, template_fn)`` -> Zotero item dict
+- ``csl_json_to_zotero(csl, template_fn)`` -> Zotero item dict
+
+The converters never mutate ``template_fn``'s output; they return a fresh dict
+populated only with fields valid for the resolved Zotero item type. Unmapped
+source fields are preserved as labelled lines in ``extra`` so nothing is lost
+silently.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import bibtexparser
+from bibtexparser.bparser import BibTexParser
+from bibtexparser.customization import convert_to_unicode
+
+# ---------------------------------------------------------------------------
+# Type maps
+# ---------------------------------------------------------------------------
+
+BIBTEX_TYPE_MAP = {
+    "article": "journalArticle",
+    "book": "book",
+    "booklet": "book",
+    "inbook": "bookSection",
+    "incollection": "bookSection",
+    "suppbook": "bookSection",
+    "suppcollection": "bookSection",
+    "inproceedings": "conferencePaper",
+    "conference": "conferencePaper",
+    "proceedings": "book",
+    "phdthesis": "thesis",
+    "mastersthesis": "thesis",
+    "thesis": "thesis",
+    "techreport": "report",
+    "report": "report",
+    "manual": "document",
+    "misc": "document",
+    "unpublished": "manuscript",
+    "patent": "patent",
+    "online": "webpage",
+    "electronic": "webpage",
+    "webpage": "webpage",
+    "software": "computerProgram",
+    "dataset": "document",
+    "artwork": "artwork",
+    "audio": "audioRecording",
+    "video": "videoRecording",
+    "letter": "letter",
+    "standard": "document",
+    "periodical": "journalArticle",
+    "collection": "book",
+}
+
+CSL_TYPE_MAP = {
+    "article-journal": "journalArticle",
+    "article-magazine": "magazineArticle",
+    "article-newspaper": "newspaperArticle",
+    "article": "preprint",
+    "book": "book",
+    "chapter": "bookSection",
+    "paper-conference": "conferencePaper",
+    "thesis": "thesis",
+    "report": "report",
+    "webpage": "webpage",
+    "post-weblog": "blogPost",
+    "post": "forumPost",
+    "patent": "patent",
+    "manuscript": "manuscript",
+    "dataset": "document",
+    "entry-encyclopedia": "encyclopediaArticle",
+    "entry-dictionary": "dictionaryEntry",
+    "speech": "presentation",
+    "interview": "interview",
+    "personal_communication": "letter",
+    "broadcast": "radioBroadcast",
+    "motion_picture": "film",
+    "song": "audioRecording",
+    "map": "map",
+    "legal_case": "case",
+    "legislation": "statute",
+    "bill": "bill",
+    "software": "computerProgram",
+    "figure": "artwork",
+    "graphic": "artwork",
+    "pamphlet": "document",
+    "review": "journalArticle",
+    "review-book": "journalArticle",
+    "treaty": "document",
+}
+
+
+# ---------------------------------------------------------------------------
+# Author / creator parsing
+# ---------------------------------------------------------------------------
+
+_CORP_SUFFIXES = (
+    " inc", " inc.", " llc", " ltd", " ltd.", " corp", " corp.",
+    " gmbh", " ag", " plc", " co.", " co ", " s.a.", " s.a",
+    " university", " universität", " universite", " universidad",
+    " institute", " institut", " academy", " laboratory", " labs",
+    " consortium", " foundation", " association", " society",
+    " organization", " organisation", " committee", " council",
+    " group", " team",
+)
+
+
+def _looks_corporate(name: str) -> bool:
+    lower = " " + name.lower() + " "
+    return any(suffix in lower for suffix in _CORP_SUFFIXES)
+
+
+def _parse_bibtex_author_list(raw: str) -> list[dict[str, str]]:
+    """Split a BibTeX authors string on ' and ' and structure each name."""
+    if not raw:
+        return []
+    # Preserve braces inside { ... } groups: split on " and " only at top level.
+    parts = _split_bibtex_authors(raw)
+    creators = []
+    for part in parts:
+        name = part.strip().strip("{}").strip()
+        if not name:
+            continue
+        if "," in name and name.count(",") == 1 and not _looks_corporate(name):
+            last, first = [x.strip() for x in name.split(",", 1)]
+            creators.append({
+                "creatorType": "author",
+                "firstName": first,
+                "lastName": last,
+            })
+        elif " " in name and not _looks_corporate(name):
+            first, last = name.rsplit(" ", 1)
+            creators.append({
+                "creatorType": "author",
+                "firstName": first.strip(),
+                "lastName": last.strip(),
+            })
+        else:
+            creators.append({"creatorType": "author", "name": name})
+    return creators
+
+
+def _split_bibtex_authors(raw: str) -> list[str]:
+    """Split on ' and ' while respecting brace groups."""
+    out = []
+    buf = []
+    depth = 0
+    i = 0
+    while i < len(raw):
+        ch = raw[i]
+        if ch == "{":
+            depth += 1
+            buf.append(ch)
+        elif ch == "}":
+            depth = max(0, depth - 1)
+            buf.append(ch)
+        elif depth == 0 and raw[i:i + 5].lower() == " and ":
+            out.append("".join(buf))
+            buf = []
+            i += 5
+            continue
+        else:
+            buf.append(ch)
+        i += 1
+    if buf:
+        out.append("".join(buf))
+    return out
+
+
+def _csl_names_to_creators(names: list[dict], creator_type: str) -> list[dict]:
+    out = []
+    for n in names or []:
+        if not isinstance(n, dict):
+            continue
+        if "literal" in n and n["literal"]:
+            out.append({"creatorType": creator_type, "name": str(n["literal"]).strip()})
+        elif "family" in n or "given" in n:
+            entry = {"creatorType": creator_type}
+            given = (n.get("given") or "").strip()
+            family = (n.get("family") or "").strip()
+            if given:
+                entry["firstName"] = given
+            if family:
+                entry["lastName"] = family
+            if "firstName" not in entry and "lastName" not in entry:
+                continue
+            # pyzotero expects both firstName and lastName — fill blanks
+            entry.setdefault("firstName", "")
+            entry.setdefault("lastName", "")
+            out.append(entry)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Date parsing
+# ---------------------------------------------------------------------------
+
+_MONTH_NAMES = {
+    "jan": "01", "january": "01", "feb": "02", "february": "02",
+    "mar": "03", "march": "03", "apr": "04", "april": "04",
+    "may": "05", "jun": "06", "june": "06", "jul": "07", "july": "07",
+    "aug": "08", "august": "08", "sep": "09", "september": "09",
+    "oct": "10", "october": "10", "nov": "11", "november": "11",
+    "dec": "12", "december": "12",
+}
+
+
+def _format_bibtex_date(year: str, month: str, day: str, iso_date: str) -> str:
+    """Build an ISO-ish date string from bibtex fields."""
+    if iso_date:
+        return iso_date.strip()
+    year = (year or "").strip()
+    month = (month or "").strip()
+    day = (day or "").strip()
+    if not year:
+        return ""
+    month_num = _MONTH_NAMES.get(month.lower()[:3]) if month and not month.isdigit() else (
+        month.zfill(2) if month else ""
+    )
+    parts = [year]
+    if month_num:
+        parts.append(month_num)
+        if day and day.isdigit():
+            parts.append(day.zfill(2))
+    return "-".join(parts)
+
+
+def _format_csl_date(issued: Any) -> str:
+    if not isinstance(issued, dict):
+        return ""
+    if "literal" in issued and issued["literal"]:
+        return str(issued["literal"]).strip()
+    dp = issued.get("date-parts")
+    if isinstance(dp, list) and dp and isinstance(dp[0], list):
+        parts = [str(p).strip() for p in dp[0] if str(p).strip()]
+        # Zero-pad month/day
+        if len(parts) >= 2:
+            parts[1] = parts[1].zfill(2)
+        if len(parts) >= 3:
+            parts[2] = parts[2].zfill(2)
+        return "-".join(parts)
+    if "raw" in issued and issued["raw"]:
+        return str(issued["raw"]).strip()
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# BibTeX parsing
+# ---------------------------------------------------------------------------
+
+def parse_bibtex(text: str) -> list[dict]:
+    """Parse a BibTeX string and return a list of structured entries.
+
+    Each entry: ``{"entry_type": str, "citekey": str, "fields": dict}``.
+    Applies ``convert_to_unicode`` so LaTeX accents become unicode.
+    """
+    parser = BibTexParser(common_strings=True)
+    parser.customization = convert_to_unicode
+    parser.ignore_nonstandard_types = False
+    db = bibtexparser.loads(text or "", parser=parser)
+    results = []
+    for e in db.entries:
+        entry_type = (e.get("ENTRYTYPE") or "").lower()
+        citekey = e.get("ID") or ""
+        fields = {k: v for k, v in e.items() if k not in ("ENTRYTYPE", "ID")}
+        results.append({"entry_type": entry_type, "citekey": citekey, "fields": fields})
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Container-field routing
+# ---------------------------------------------------------------------------
+
+def _pick_container_field(zot_type: str, template: dict) -> str | None:
+    """Return the Zotero field name that holds the "container title" for this type."""
+    candidates = {
+        "journalArticle": "publicationTitle",
+        "magazineArticle": "publicationTitle",
+        "newspaperArticle": "publicationTitle",
+        "preprint": "publicationTitle",
+        "bookSection": "bookTitle",
+        "conferencePaper": "proceedingsTitle",
+        "encyclopediaArticle": "encyclopediaTitle",
+        "dictionaryEntry": "dictionaryTitle",
+        "blogPost": "blogTitle",
+        "forumPost": "forumTitle",
+        "radioBroadcast": "programTitle",
+        "tvBroadcast": "programTitle",
+        "podcast": "seriesTitle",
+    }
+    candidate = candidates.get(zot_type)
+    if candidate and candidate in template:
+        return candidate
+    # Fallback: first of a few common names present in template
+    for name in ("publicationTitle", "bookTitle", "proceedingsTitle", "seriesTitle"):
+        if name in template:
+            return name
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Extra-field helpers
+# ---------------------------------------------------------------------------
+
+def _append_extra(template: dict, line: str) -> None:
+    if "extra" not in template:
+        return
+    existing = template.get("extra", "") or ""
+    if existing:
+        template["extra"] = existing.rstrip() + "\n" + line
+    else:
+        template["extra"] = line
+
+
+def _set_if_in_template(template: dict, field: str, value: str) -> bool:
+    """Assign ``value`` to ``field`` iff the template has that field. Returns True if set."""
+    if value is None or value == "":
+        return False
+    if field in template:
+        template[field] = value
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# BibTeX -> Zotero
+# ---------------------------------------------------------------------------
+
+def bibtex_entry_to_zotero(
+    entry: dict,
+    template_fn: Callable[[str], dict],
+) -> dict:
+    """Convert one parsed BibTeX entry dict into a Zotero item dict.
+
+    ``template_fn(item_type)`` must return a pyzotero-style item template for
+    the given Zotero item type (i.e. ``write_zot.item_template``).
+    """
+    entry_type = (entry.get("entry_type") or "").lower()
+    fields = entry.get("fields") or {}
+    citekey = entry.get("citekey") or ""
+
+    # Thesis subtype detection before type lookup
+    zot_type = BIBTEX_TYPE_MAP.get(entry_type, "document")
+    template = dict(template_fn(zot_type))
+
+    # Thesis "type" field (biblatex) distinguishes phd / masters
+    if zot_type == "thesis" and "thesisType" in template:
+        if entry_type == "phdthesis":
+            template["thesisType"] = "PhD thesis"
+        elif entry_type == "mastersthesis":
+            template["thesisType"] = "Master's thesis"
+        elif fields.get("type"):
+            template["thesisType"] = fields["type"]
+
+    # Report type
+    if zot_type == "report" and "reportType" in template and fields.get("type"):
+        template["reportType"] = fields["type"]
+
+    # Title
+    title = (fields.get("title") or "").strip().strip("{}").strip()
+    _set_if_in_template(template, "title", title)
+
+    # Short title
+    _set_if_in_template(template, "shortTitle", (fields.get("shorttitle") or "").strip())
+
+    # Authors / editors / translators
+    authors = _parse_bibtex_author_list(fields.get("author", ""))
+    editors = _parse_bibtex_author_list(fields.get("editor", ""))
+    translators = _parse_bibtex_author_list(fields.get("translator", ""))
+    for e in editors:
+        e["creatorType"] = "editor"
+    for t in translators:
+        t["creatorType"] = "translator"
+    creators = authors + editors + translators
+    if creators and "creators" in template:
+        template["creators"] = creators
+
+    # Date
+    date = _format_bibtex_date(
+        fields.get("year", ""),
+        fields.get("month", ""),
+        fields.get("day", ""),
+        fields.get("date", ""),
+    )
+    _set_if_in_template(template, "date", date)
+
+    # Container title (journal / booktitle / proceedings)
+    container_field = _pick_container_field(zot_type, template)
+    container_value = (
+        fields.get("journaltitle")
+        or fields.get("journal")
+        or fields.get("booktitle")
+        or fields.get("maintitle")
+        or ""
+    ).strip()
+    if container_field and container_value:
+        template[container_field] = container_value
+
+    # Series
+    _set_if_in_template(template, "series", (fields.get("series") or "").strip())
+    _set_if_in_template(template, "seriesNumber", (fields.get("seriesnumber") or "").strip())
+
+    # Standard fields
+    _set_if_in_template(template, "volume", (fields.get("volume") or "").strip())
+    _set_if_in_template(
+        template,
+        "issue",
+        (fields.get("issue") or fields.get("number") or "").strip(),
+    )
+    pages = (fields.get("pages") or "").strip().replace("--", "-")
+    _set_if_in_template(template, "pages", pages)
+    _set_if_in_template(template, "publisher", (fields.get("publisher") or "").strip())
+    _set_if_in_template(
+        template,
+        "place",
+        (fields.get("address") or fields.get("location") or "").strip(),
+    )
+    _set_if_in_template(template, "edition", (fields.get("edition") or "").strip())
+    _set_if_in_template(template, "ISBN", (fields.get("isbn") or "").strip())
+    _set_if_in_template(template, "ISSN", (fields.get("issn") or "").strip())
+    _set_if_in_template(template, "language", (fields.get("language") or "").strip())
+    _set_if_in_template(template, "url", (fields.get("url") or "").strip())
+    _set_if_in_template(template, "DOI", (fields.get("doi") or "").strip())
+    _set_if_in_template(template, "abstractNote", (fields.get("abstract") or "").strip())
+    _set_if_in_template(template, "numPages", (fields.get("pagetotal") or "").strip())
+    _set_if_in_template(template, "numberOfVolumes", (fields.get("volumes") or "").strip())
+
+    # Institution / school fall back to publisher for report / thesis
+    if "publisher" in template and not template["publisher"]:
+        fallback = (
+            fields.get("school")
+            or fields.get("institution")
+            or fields.get("organization")
+            or ""
+        ).strip()
+        if fallback:
+            template["publisher"] = fallback
+
+    # Report/thesis: institution often belongs in "institution" or "university"
+    _set_if_in_template(template, "institution", (fields.get("institution") or "").strip())
+    _set_if_in_template(template, "university", (fields.get("school") or "").strip())
+
+    # Patent fields
+    if zot_type == "patent":
+        _set_if_in_template(template, "patentNumber", (fields.get("number") or "").strip())
+
+    # Keywords -> tags
+    kw = fields.get("keywords") or fields.get("keyword") or ""
+    source_tags = _split_keywords(kw)
+    if source_tags and "tags" in template:
+        template["tags"] = [{"tag": t} for t in source_tags]
+
+    # Citation key preservation
+    if citekey:
+        _append_extra(template, f"Citation Key: {citekey}")
+
+    # Arxiv eprint
+    eprint = (fields.get("eprint") or "").strip()
+    eprint_type = (fields.get("eprinttype") or fields.get("archiveprefix") or "").strip().lower()
+    if eprint and eprint_type in ("arxiv", ""):
+        _append_extra(template, f"arXiv: {eprint}")
+        if "url" in template and not template.get("url"):
+            template["url"] = f"https://arxiv.org/abs/{eprint}"
+
+    # PMID / PMCID
+    for src_key, label in (("pmid", "PMID"), ("pmcid", "PMCID")):
+        val = (fields.get(src_key) or "").strip()
+        if val:
+            _append_extra(template, f"{label}: {val}")
+
+    # Note -> extra
+    note = (fields.get("note") or "").strip()
+    if note:
+        _append_extra(template, note)
+
+    # Preserve anything we didn't map
+    handled = {
+        "title", "shorttitle", "author", "editor", "translator",
+        "year", "month", "day", "date",
+        "journal", "journaltitle", "booktitle", "maintitle",
+        "series", "seriesnumber",
+        "volume", "issue", "number", "pages",
+        "publisher", "address", "location", "edition",
+        "isbn", "issn", "language", "url", "doi", "abstract",
+        "keywords", "keyword", "note",
+        "school", "institution", "organization",
+        "eprint", "eprinttype", "archiveprefix", "primaryclass",
+        "pmid", "pmcid", "type", "pagetotal", "volumes",
+    }
+    for k, v in fields.items():
+        if k.lower() in handled:
+            continue
+        if not v:
+            continue
+        _append_extra(template, f"{k}: {v}")
+
+    return template
+
+
+def _split_keywords(raw: str) -> list[str]:
+    if not raw:
+        return []
+    # Try semicolon first, then comma
+    for sep in (";", ","):
+        if sep in raw:
+            return [p.strip() for p in raw.split(sep) if p.strip()]
+    s = raw.strip()
+    return [s] if s else []
+
+
+# ---------------------------------------------------------------------------
+# CSL JSON -> Zotero
+# ---------------------------------------------------------------------------
+
+def csl_json_to_zotero(
+    csl: dict,
+    template_fn: Callable[[str], dict],
+) -> dict:
+    """Convert one CSL JSON object into a Zotero item dict."""
+    csl_type = (csl.get("type") or "").lower()
+    zot_type = CSL_TYPE_MAP.get(csl_type, "document")
+    template = dict(template_fn(zot_type))
+
+    # Title
+    _set_if_in_template(template, "title", (csl.get("title") or "").strip())
+    _set_if_in_template(template, "shortTitle", (csl.get("title-short") or "").strip())
+
+    # Creators
+    creators = []
+    creators += _csl_names_to_creators(csl.get("author"), "author")
+    creators += _csl_names_to_creators(csl.get("editor"), "editor")
+    creators += _csl_names_to_creators(csl.get("translator"), "translator")
+    if creators and "creators" in template:
+        template["creators"] = creators
+
+    # Date
+    date = _format_csl_date(csl.get("issued"))
+    _set_if_in_template(template, "date", date)
+
+    # Container title
+    container_field = _pick_container_field(zot_type, template)
+    container_value = (csl.get("container-title") or "").strip()
+    if container_field and container_value:
+        template[container_field] = container_value
+
+    # Series
+    _set_if_in_template(template, "series", (csl.get("collection-title") or "").strip())
+    _set_if_in_template(template, "seriesNumber", str(csl.get("collection-number") or "").strip())
+
+    # Common fields
+    _set_if_in_template(template, "volume", str(csl.get("volume") or "").strip())
+    _set_if_in_template(template, "issue", str(csl.get("issue") or "").strip())
+    _set_if_in_template(template, "pages", str(csl.get("page") or "").strip())
+    _set_if_in_template(template, "publisher", (csl.get("publisher") or "").strip())
+    _set_if_in_template(template, "place", (csl.get("publisher-place") or "").strip())
+    _set_if_in_template(template, "edition", str(csl.get("edition") or "").strip())
+    _set_if_in_template(template, "ISBN", (csl.get("ISBN") or "").strip())
+    _set_if_in_template(template, "ISSN", (csl.get("ISSN") or "").strip())
+    _set_if_in_template(template, "DOI", (csl.get("DOI") or "").strip())
+    _set_if_in_template(template, "url", (csl.get("URL") or "").strip())
+    _set_if_in_template(template, "language", (csl.get("language") or "").strip())
+    _set_if_in_template(template, "abstractNote", (csl.get("abstract") or "").strip())
+    _set_if_in_template(template, "numPages", str(csl.get("number-of-pages") or "").strip())
+
+    # Type-specific number fields
+    number = str(csl.get("number") or "").strip()
+    if number:
+        if zot_type == "report":
+            _set_if_in_template(template, "reportNumber", number)
+        elif zot_type == "patent":
+            _set_if_in_template(template, "patentNumber", number)
+        elif zot_type == "bill":
+            _set_if_in_template(template, "billNumber", number)
+        elif zot_type == "case":
+            _set_if_in_template(template, "docketNumber", number)
+        elif zot_type == "statute":
+            _set_if_in_template(template, "publicLawNumber", number)
+
+    # Thesis genre
+    if zot_type == "thesis" and "thesisType" in template:
+        genre = (csl.get("genre") or "").strip()
+        if genre:
+            template["thesisType"] = genre
+
+    # Keywords -> tags
+    keywords = csl.get("keyword") or csl.get("keywords")
+    if isinstance(keywords, list):
+        source_tags = [str(k).strip() for k in keywords if str(k).strip()]
+    elif isinstance(keywords, str):
+        source_tags = _split_keywords(keywords)
+    else:
+        source_tags = []
+    if source_tags and "tags" in template:
+        template["tags"] = [{"tag": t} for t in source_tags]
+
+    # Citation key from `id`
+    citekey = str(csl.get("id") or "").strip()
+    if citekey:
+        _append_extra(template, f"Citation Key: {citekey}")
+
+    # Note
+    note = (csl.get("note") or "").strip()
+    if note:
+        _append_extra(template, note)
+
+    # Preserve unmapped fields
+    handled = {
+        "type", "id", "title", "title-short",
+        "author", "editor", "translator",
+        "issued", "container-title", "collection-title", "collection-number",
+        "volume", "issue", "page", "publisher", "publisher-place",
+        "edition", "ISBN", "ISSN", "DOI", "URL", "language",
+        "abstract", "number-of-pages", "number",
+        "genre", "keyword", "keywords", "note",
+    }
+    for k, v in csl.items():
+        if k in handled:
+            continue
+        if v is None or v == "" or v == [] or v == {}:
+            continue
+        if isinstance(v, (dict, list)):
+            try:
+                v = json.dumps(v, ensure_ascii=False)
+            except (TypeError, ValueError):
+                v = str(v)
+        _append_extra(template, f"{k}: {v}")
+
+    return template
+
+
+# ---------------------------------------------------------------------------
+# Input coercion helpers
+# ---------------------------------------------------------------------------
+
+def coerce_csl_json_input(value: Any) -> list[dict]:
+    """Accept a CSL JSON string, single object, or list; return a list of dicts."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return []
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON: {exc}") from exc
+    if isinstance(value, dict):
+        return [value]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, dict)]
+    raise ValueError("csl_json must be a JSON string, object, or array of objects")
+
+
+def merge_tags(source_tags: list[str], extra_tags: list[str]) -> list[str]:
+    """Merge two tag lists preserving order and deduplicating case-insensitively."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for t in list(source_tags or []) + list(extra_tags or []):
+        t = (t or "").strip()
+        if not t:
+            continue
+        key = t.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(t)
+    return out

--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -106,6 +106,8 @@ from zotero_mcp.tools.write import (  # noqa: F401
     merge_duplicates,
     get_pdf_outline,
     add_from_file,
+    add_by_bibtex,
+    add_by_csl_json,
 )
 from zotero_mcp.tools.connectors import (  # noqa: F401
     chatgpt_connector_search,

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -15,6 +15,7 @@ from fastmcp import Context
 from zotero_mcp._app import mcp
 from zotero_mcp import client as _client
 from zotero_mcp import utils as _utils
+from zotero_mcp import citation_import as _citation_import
 from zotero_mcp.tools import _helpers
 
 # Accessed as _helpers.X so that monkeypatch/mock on the module attribute works.
@@ -1395,3 +1396,224 @@ def add_from_file(
     except Exception as e:
         ctx.error(f"Error adding from file: {e}")
         return f"Error adding from file: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Import-by-citation tools (BibTeX / CSL JSON)
+# ---------------------------------------------------------------------------
+
+def _apply_caller_tags_and_collections(
+    item_data: dict,
+    caller_tags: list[str] | str | None,
+    caller_collections: list[str] | str | None,
+) -> None:
+    """Merge caller tags with any source-tags already in ``item_data`` and set collections."""
+    extra_tags = _helpers._normalize_str_list_input(caller_tags, "tags")
+    source_tags = [t.get("tag", "") for t in item_data.get("tags", []) if t.get("tag")]
+    merged = _citation_import.merge_tags(source_tags, extra_tags)
+    if merged:
+        item_data["tags"] = [{"tag": t} for t in merged]
+
+    coll_keys = _helpers._normalize_str_list_input(caller_collections, "collections")
+    if coll_keys:
+        existing = list(item_data.get("collections") or [])
+        # Preserve order while deduplicating
+        seen = set(existing)
+        for k in coll_keys:
+            if k not in seen:
+                existing.append(k)
+                seen.add(k)
+        item_data["collections"] = existing
+
+
+def _create_and_attach(
+    write_zot,
+    item_data: dict,
+    attach_mode: str,
+    ctx: Context,
+) -> dict:
+    """Create one Zotero item and, if it has a DOI, try to attach an OA PDF.
+
+    Returns a dict ``{"ok": bool, "key": str|None, "doi": str|None,
+    "pdf_status": str|None, "error": str|None, "title": str}``.
+    """
+    title = item_data.get("title") or "(untitled)"
+    try:
+        result = write_zot.create_items([item_data])
+    except Exception as e:
+        return {"ok": False, "key": None, "doi": None, "pdf_status": None,
+                "error": str(e), "title": title}
+
+    if not (isinstance(result, dict) and result.get("success")):
+        return {"ok": False, "key": None, "doi": None, "pdf_status": None,
+                "error": f"create_items failed: {result}", "title": title}
+
+    item_key = next(iter(result["success"].values()))
+    doi_raw = item_data.get("DOI") or ""
+    doi = _helpers._normalize_doi(doi_raw) if doi_raw else None
+
+    pdf_status = None
+    if doi:
+        try:
+            pdf_status = _helpers._try_attach_oa_pdf(
+                write_zot, item_key, doi, ctx, attach_mode=attach_mode
+            )
+        except Exception as e:
+            pdf_status = f"OA PDF attach failed: {e}"
+
+    return {"ok": True, "key": item_key, "doi": doi, "pdf_status": pdf_status,
+            "error": None, "title": title}
+
+
+def _format_batch_result(header: str, results: list[dict]) -> str:
+    """Render a per-entry markdown summary for add_by_bibtex / add_by_csl_json."""
+    ok_count = sum(1 for r in results if r["ok"])
+    lines = [header, ""]
+    if len(results) == 1:
+        r = results[0]
+        if r["ok"]:
+            lines.append(f"Successfully added: **{r['title']}**")
+            lines.append("")
+            lines.append(f"Item key: `{r['key']}`")
+            if r["doi"]:
+                lines.append(f"DOI: {r['doi']}")
+            if r["pdf_status"]:
+                lines.append(f"PDF: {r['pdf_status']}")
+        else:
+            lines.append(f"Failed to add **{r['title']}**: {r['error']}")
+    else:
+        lines.append(f"Added {ok_count}/{len(results)} items.")
+        lines.append("")
+        for i, r in enumerate(results, 1):
+            if r["ok"]:
+                line = f"{i}. `{r['key']}` — {r['title']}"
+                if r["doi"]:
+                    line += f" (DOI: {r['doi']})"
+                if r["pdf_status"]:
+                    line += f" [{r['pdf_status']}]"
+                lines.append(line)
+            else:
+                lines.append(f"{i}. ❌ {r['title']}: {r['error']}")
+    lines.append("")
+    lines.append(
+        "_Note: To include new items in semantic search, run "
+        "zotero_update_search_database._"
+    )
+    return "\n".join(lines)
+
+
+@mcp.tool(
+    name="zotero_add_by_bibtex",
+    description=(
+        "Add one or more items to Zotero from a BibTeX string. "
+        "Supports multiple @entries in a single call. "
+        "The citation key from each entry is preserved in the Extra field. "
+        "If an entry has a DOI, an open-access PDF attachment is attempted."
+    )
+)
+def add_by_bibtex(
+    bibtex: str,
+    collections: list[str] | str | None = None,
+    tags: list[str] | str | None = None,
+    attach_mode: str = "auto",
+    *,
+    ctx: Context
+) -> str:
+    try:
+        _read_zot, write_zot = _helpers._get_write_client(ctx)
+    except ValueError as e:
+        return str(e)
+
+    try:
+        if not (bibtex or "").strip():
+            return "Error: No BibTeX provided."
+
+        try:
+            entries = _citation_import.parse_bibtex(bibtex)
+        except Exception as e:
+            return f"Error parsing BibTeX: {e}"
+
+        if not entries:
+            return "Error: No valid @entries found in the BibTeX input."
+
+        ctx.info(f"Parsed {len(entries)} BibTeX entries")
+
+        results = []
+        for entry in entries:
+            try:
+                item_data = _citation_import.bibtex_entry_to_zotero(
+                    entry, write_zot.item_template
+                )
+            except Exception as e:
+                results.append({
+                    "ok": False, "key": None, "doi": None, "pdf_status": None,
+                    "error": f"conversion failed: {e}",
+                    "title": entry.get("citekey") or "(unknown)",
+                })
+                continue
+
+            _apply_caller_tags_and_collections(item_data, tags, collections)
+            results.append(_create_and_attach(write_zot, item_data, attach_mode, ctx))
+
+        return _format_batch_result("# zotero_add_by_bibtex", results)
+
+    except Exception as e:
+        ctx.error(f"Error adding by BibTeX: {e}")
+        return f"Error adding by BibTeX: {e}"
+
+
+@mcp.tool(
+    name="zotero_add_by_csl_json",
+    description=(
+        "Add one or more items to Zotero from CSL JSON input. "
+        "Accepts a JSON string, a single object, or an array of objects. "
+        "The `id` field is preserved in the Extra field as the Citation Key. "
+        "If an entry has a DOI, an open-access PDF attachment is attempted."
+    )
+)
+def add_by_csl_json(
+    csl_json: str | list | dict,
+    collections: list[str] | str | None = None,
+    tags: list[str] | str | None = None,
+    attach_mode: str = "auto",
+    *,
+    ctx: Context
+) -> str:
+    try:
+        _read_zot, write_zot = _helpers._get_write_client(ctx)
+    except ValueError as e:
+        return str(e)
+
+    try:
+        try:
+            entries = _citation_import.coerce_csl_json_input(csl_json)
+        except ValueError as e:
+            return f"Error: {e}"
+
+        if not entries:
+            return "Error: No valid CSL JSON objects provided."
+
+        ctx.info(f"Processing {len(entries)} CSL JSON entries")
+
+        results = []
+        for entry in entries:
+            try:
+                item_data = _citation_import.csl_json_to_zotero(
+                    entry, write_zot.item_template
+                )
+            except Exception as e:
+                results.append({
+                    "ok": False, "key": None, "doi": None, "pdf_status": None,
+                    "error": f"conversion failed: {e}",
+                    "title": str(entry.get("id") or entry.get("title") or "(unknown)"),
+                })
+                continue
+
+            _apply_caller_tags_and_collections(item_data, tags, collections)
+            results.append(_create_and_attach(write_zot, item_data, attach_mode, ctx))
+
+        return _format_batch_result("# zotero_add_by_csl_json", results)
+
+    except Exception as e:
+        ctx.error(f"Error adding by CSL JSON: {e}")
+        return f"Error adding by CSL JSON: {e}"

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1402,6 +1402,43 @@ def add_from_file(
 # Import-by-citation tools (BibTeX / CSL JSON)
 # ---------------------------------------------------------------------------
 
+_CITATION_FILE_MAX_BYTES = 10 * 1024 * 1024  # 10 MB — generous for citation files
+
+
+def _read_citation_file(file_path: str, allowed_exts: set[str]) -> str:
+    """Read a citation file as UTF-8 text with the same safety checks as add_from_file.
+
+    Raises ValueError on any check failure. Returns the file contents.
+    """
+    if os.path.islink(file_path):
+        raise ValueError("Symlinks are not allowed for security reasons.")
+    if not os.path.isabs(file_path):
+        raise ValueError("file_path must be an absolute path.")
+    resolved = os.path.realpath(file_path)
+    if not os.path.isfile(resolved):
+        raise ValueError(f"File not found: {file_path}")
+
+    ext = os.path.splitext(resolved)[1].lower()
+    if ext not in allowed_exts:
+        raise ValueError(
+            f"Unsupported file extension '{ext}'. "
+            f"Allowed: {', '.join(sorted(allowed_exts))}"
+        )
+
+    size = os.path.getsize(resolved)
+    if size > _CITATION_FILE_MAX_BYTES:
+        raise ValueError(
+            f"File is too large ({size} bytes). "
+            f"Maximum {_CITATION_FILE_MAX_BYTES} bytes."
+        )
+
+    try:
+        with open(resolved, encoding="utf-8") as f:
+            return f.read()
+    except UnicodeDecodeError as e:
+        raise ValueError(f"File is not valid UTF-8: {e}") from e
+
+
 def _apply_caller_tags_and_collections(
     item_data: dict,
     caller_tags: list[str] | str | None,
@@ -1505,14 +1542,17 @@ def _format_batch_result(header: str, results: list[dict]) -> str:
 @mcp.tool(
     name="zotero_add_by_bibtex",
     description=(
-        "Add one or more items to Zotero from a BibTeX string. "
-        "Supports multiple @entries in a single call. "
+        "Add one or more items to Zotero from BibTeX. "
+        "Provide EITHER `bibtex` (inline string) OR `file_path` "
+        "(absolute path to a .bib / .bibtex file) — not both. "
+        "Supports multiple @entries per call. "
         "The citation key from each entry is preserved in the Extra field. "
         "If an entry has a DOI, an open-access PDF attachment is attempted."
     )
 )
 def add_by_bibtex(
-    bibtex: str,
+    bibtex: str | None = None,
+    file_path: str | None = None,
     collections: list[str] | str | None = None,
     tags: list[str] | str | None = None,
     attach_mode: str = "auto",
@@ -1525,8 +1565,20 @@ def add_by_bibtex(
         return str(e)
 
     try:
-        if not (bibtex or "").strip():
-            return "Error: No BibTeX provided."
+        bibtex_provided = bool((bibtex or "").strip())
+        if bibtex_provided and file_path:
+            return "Error: Provide either `bibtex` or `file_path`, not both."
+        if not bibtex_provided and not file_path:
+            return "Error: Must provide `bibtex` (inline string) or `file_path`."
+
+        if file_path:
+            try:
+                bibtex = _read_citation_file(
+                    file_path, allowed_exts={".bib", ".bibtex"}
+                )
+            except ValueError as e:
+                return f"Error: {e}"
+            ctx.info(f"Loaded BibTeX from {file_path} ({len(bibtex)} bytes)")
 
         try:
             entries = _citation_import.parse_bibtex(bibtex)
@@ -1565,14 +1617,16 @@ def add_by_bibtex(
 @mcp.tool(
     name="zotero_add_by_csl_json",
     description=(
-        "Add one or more items to Zotero from CSL JSON input. "
-        "Accepts a JSON string, a single object, or an array of objects. "
+        "Add one or more items to Zotero from CSL JSON. "
+        "Provide EITHER `csl_json` (inline — a JSON string, object, or array) "
+        "OR `file_path` (absolute path to a .json / .csljson file) — not both. "
         "The `id` field is preserved in the Extra field as the Citation Key. "
         "If an entry has a DOI, an open-access PDF attachment is attempted."
     )
 )
 def add_by_csl_json(
-    csl_json: str | list | dict,
+    csl_json: str | list | dict | None = None,
+    file_path: str | None = None,
     collections: list[str] | str | None = None,
     tags: list[str] | str | None = None,
     attach_mode: str = "auto",
@@ -1585,6 +1639,21 @@ def add_by_csl_json(
         return str(e)
 
     try:
+        csl_provided = csl_json not in (None, "", [], {})
+        if csl_provided and file_path:
+            return "Error: Provide either `csl_json` or `file_path`, not both."
+        if not csl_provided and not file_path:
+            return "Error: Must provide `csl_json` (inline) or `file_path`."
+
+        if file_path:
+            try:
+                csl_json = _read_citation_file(
+                    file_path, allowed_exts={".json", ".csljson"}
+                )
+            except ValueError as e:
+                return f"Error: {e}"
+            ctx.info(f"Loaded CSL JSON from {file_path} ({len(csl_json)} bytes)")
+
         try:
             entries = _citation_import.coerce_csl_json_input(csl_json)
         except ValueError as e:

--- a/tests/test_add_by_bibtex.py
+++ b/tests/test_add_by_bibtex.py
@@ -1,0 +1,224 @@
+"""Integration tests for the zotero_add_by_bibtex MCP tool."""
+
+from conftest import FakeZotero
+
+from zotero_mcp import server
+
+
+class FakeZoteroWithAttach(FakeZotero):
+    """FakeZotero + attachment_both stub (for OA PDF attempts)."""
+
+    def __init__(self):
+        super().__init__()
+        self.attachments = []
+
+    def attachment_both(self, files, parentid=None, **kwargs):
+        self.attachments.append({"files": files, "parentid": parentid})
+        return {"success": {"0": "ATCH0001"}, "successful": {}, "failed": {}}
+
+
+def _patch_hybrid(monkeypatch):
+    """Install a write-capable FakeZotero; return it."""
+    fake = FakeZoteroWithAttach()
+    monkeypatch.setattr(
+        "zotero_mcp.tools._helpers._get_write_client",
+        lambda ctx: (fake, fake),
+    )
+    return fake
+
+
+def _disable_oa_pdf(monkeypatch):
+    """Disable network lookups in _try_attach_oa_pdf for tests that create DOIs."""
+    monkeypatch.setattr(
+        "zotero_mcp.tools._helpers._try_attach_oa_pdf",
+        lambda *args, **kwargs: "no open-access PDF found (stubbed)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path: single entry
+# ---------------------------------------------------------------------------
+
+class TestSingleEntry:
+    def test_creates_journal_article(self, monkeypatch, dummy_ctx):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        bib = """
+        @article{smith2020,
+          title={Hello},
+          author={Smith, John},
+          journal={Nature},
+          year={2020},
+          doi={10.1234/x},
+        }
+        """
+        result = server.add_by_bibtex(bibtex=bib, ctx=dummy_ctx)
+
+        assert len(fake.created) == 1
+        created = fake.created[0]
+        assert created["itemType"] == "journalArticle"
+        assert created["title"] == "Hello"
+        assert created["publicationTitle"] == "Nature"
+        assert created["DOI"] == "10.1234/x"
+        assert "Citation Key: smith2020" in created["extra"]
+        assert "Successfully added" in result
+        assert "KEY0000" in result
+
+    def test_citekey_preserved_in_extra(self, monkeypatch, dummy_ctx):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+        bib = "@book{MyCite2021, title={B}, author={A, B}, publisher={P}, year=2021}"
+
+        server.add_by_bibtex(bibtex=bib, ctx=dummy_ctx)
+
+        assert "Citation Key: MyCite2021" in fake.created[0]["extra"]
+
+
+# ---------------------------------------------------------------------------
+# Multiple entries
+# ---------------------------------------------------------------------------
+
+class TestMultipleEntries:
+    def test_creates_multiple_items(self, monkeypatch, dummy_ctx):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        bib = """
+        @article{a, title={A}, author={X, Y}, year={2020}, doi={10.1234/a}}
+        @book{b, title={B}, author={P, Q}, publisher={Pub}, year={2021}}
+        """
+        result = server.add_by_bibtex(bibtex=bib, ctx=dummy_ctx)
+
+        assert len(fake.created) == 2
+        assert fake.created[0]["itemType"] == "journalArticle"
+        assert fake.created[1]["itemType"] == "book"
+        assert "Added 2/2 items" in result
+
+
+# ---------------------------------------------------------------------------
+# Caller tags and collections are merged with source tags
+# ---------------------------------------------------------------------------
+
+class TestTagsAndCollections:
+    def test_caller_tags_merged_with_source_keywords(self, monkeypatch, dummy_ctx):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        bib = """
+        @article{x, title={T}, author={A, B}, year={2020},
+          keywords={source1, source2}}
+        """
+        server.add_by_bibtex(bibtex=bib, tags=["caller1", "source1"], ctx=dummy_ctx)
+
+        tags = [t["tag"] for t in fake.created[0]["tags"]]
+        # source1 should only appear once (case-insensitive dedup)
+        assert tags == ["source1", "source2", "caller1"]
+
+    def test_collections_applied(self, monkeypatch, dummy_ctx):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        bib = "@article{x, title={T}, author={A, B}, year={2020}}"
+        server.add_by_bibtex(
+            bibtex=bib,
+            collections=["COL001", "COL002"],
+            ctx=dummy_ctx,
+        )
+
+        assert fake.created[0]["collections"] == ["COL001", "COL002"]
+
+
+# ---------------------------------------------------------------------------
+# DOI triggers OA PDF attempt; no DOI skips it
+# ---------------------------------------------------------------------------
+
+class TestOaPdfAttempt:
+    def test_doi_triggers_oa_attempt(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        called = {"count": 0, "doi": None}
+
+        def stub(write_zot, item_key, doi, ctx, **kwargs):
+            called["count"] += 1
+            called["doi"] = doi
+            return "stubbed attempt"
+
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._try_attach_oa_pdf", stub
+        )
+
+        bib = "@article{a, title={T}, author={A, B}, year=2020, doi={10.1234/x}}"
+        server.add_by_bibtex(bibtex=bib, ctx=dummy_ctx)
+
+        assert called["count"] == 1
+        assert called["doi"] == "10.1234/x"
+
+    def test_no_doi_no_oa_attempt(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        called = {"count": 0}
+
+        def stub(*args, **kwargs):
+            called["count"] += 1
+            return "stubbed"
+
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._try_attach_oa_pdf", stub
+        )
+
+        bib = "@book{b, title={T}, author={A, B}, publisher={P}, year=2020}"
+        server.add_by_bibtex(bibtex=bib, ctx=dummy_ctx)
+
+        assert called["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+class TestErrorPaths:
+    def test_empty_bibtex(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        result = server.add_by_bibtex(bibtex="", ctx=dummy_ctx)
+        assert "No BibTeX" in result
+
+    def test_no_valid_entries(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        result = server.add_by_bibtex(bibtex="this is not bibtex", ctx=dummy_ctx)
+        assert "No valid @entries" in result
+
+    def test_local_only_mode_rejected(self, monkeypatch, dummy_ctx):
+        def raise_local(ctx):
+            raise ValueError("Cannot perform write operations in local-only mode.")
+
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client", raise_local
+        )
+        result = server.add_by_bibtex(bibtex="@a{x, title=T}", ctx=dummy_ctx)
+        assert "local-only" in result.lower()
+
+    def test_partial_failure_continues(self, monkeypatch, dummy_ctx):
+        """If one entry fails conversion, others should still be created."""
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        # Monkeypatch create_items to fail on the second call
+        call_count = {"n": 0}
+        original_create = fake.create_items
+
+        def flaky_create(items, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise RuntimeError("simulated write failure")
+            return original_create(items, **kwargs)
+
+        fake.create_items = flaky_create
+
+        bib = """
+        @article{a, title={A}, author={X, Y}, year={2020}}
+        @article{b, title={B}, author={P, Q}, year={2020}}
+        @article{c, title={C}, author={R, S}, year={2020}}
+        """
+        result = server.add_by_bibtex(bibtex=bib, ctx=dummy_ctx)
+
+        assert "Added 2/3 items" in result
+        assert "simulated write failure" in result

--- a/tests/test_add_by_bibtex.py
+++ b/tests/test_add_by_bibtex.py
@@ -172,6 +172,69 @@ class TestOaPdfAttempt:
 
 
 # ---------------------------------------------------------------------------
+# file_path ingestion
+# ---------------------------------------------------------------------------
+
+class TestFilePath:
+    def test_reads_bib_file(self, monkeypatch, dummy_ctx, tmp_path):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        bib_file = tmp_path / "refs.bib"
+        bib_file.write_text(
+            "@article{a, title={T}, author={A, B}, year=2020, doi={10.1234/x}}",
+            encoding="utf-8",
+        )
+
+        result = server.add_by_bibtex(file_path=str(bib_file), ctx=dummy_ctx)
+
+        assert len(fake.created) == 1
+        assert fake.created[0]["title"] == "T"
+        assert "Successfully added" in result
+
+    def test_reads_bibtex_extension(self, monkeypatch, dummy_ctx, tmp_path):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        f = tmp_path / "refs.bibtex"
+        f.write_text("@book{b, title={B}, author={P, Q}, publisher={Pub}, year=2020}",
+                     encoding="utf-8")
+
+        server.add_by_bibtex(file_path=str(f), ctx=dummy_ctx)
+        assert len(fake.created) == 1
+
+    def test_rejects_wrong_extension(self, monkeypatch, dummy_ctx, tmp_path):
+        _patch_hybrid(monkeypatch)
+        f = tmp_path / "refs.txt"
+        f.write_text("@article{a, title={T}, year=2020}", encoding="utf-8")
+
+        result = server.add_by_bibtex(file_path=str(f), ctx=dummy_ctx)
+        assert "Unsupported file extension" in result
+
+    def test_rejects_missing_file(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        result = server.add_by_bibtex(
+            file_path="/absolutely/no/such/file.bib", ctx=dummy_ctx,
+        )
+        assert "not found" in result.lower()
+
+    def test_rejects_relative_path(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        result = server.add_by_bibtex(file_path="refs.bib", ctx=dummy_ctx)
+        assert "absolute" in result.lower()
+
+    def test_rejects_symlink(self, monkeypatch, dummy_ctx, tmp_path):
+        _patch_hybrid(monkeypatch)
+        target = tmp_path / "real.bib"
+        target.write_text("@article{a, title={T}, year=2020}", encoding="utf-8")
+        link = tmp_path / "linked.bib"
+        link.symlink_to(target)
+
+        result = server.add_by_bibtex(file_path=str(link), ctx=dummy_ctx)
+        assert "symlink" in result.lower()
+
+
+# ---------------------------------------------------------------------------
 # Error paths
 # ---------------------------------------------------------------------------
 
@@ -179,7 +242,19 @@ class TestErrorPaths:
     def test_empty_bibtex(self, monkeypatch, dummy_ctx):
         _patch_hybrid(monkeypatch)
         result = server.add_by_bibtex(bibtex="", ctx=dummy_ctx)
-        assert "No BibTeX" in result
+        assert "Must provide" in result
+
+    def test_neither_bibtex_nor_file_path(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        result = server.add_by_bibtex(ctx=dummy_ctx)
+        assert "Must provide" in result
+
+    def test_both_bibtex_and_file_path_rejected(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        result = server.add_by_bibtex(
+            bibtex="@a{x}", file_path="/tmp/x.bib", ctx=dummy_ctx,
+        )
+        assert "not both" in result
 
     def test_no_valid_entries(self, monkeypatch, dummy_ctx):
         _patch_hybrid(monkeypatch)

--- a/tests/test_add_by_csl_json.py
+++ b/tests/test_add_by_csl_json.py
@@ -1,0 +1,207 @@
+"""Integration tests for the zotero_add_by_csl_json MCP tool."""
+
+import json
+
+from conftest import FakeZotero
+
+from zotero_mcp import server
+
+
+class FakeZoteroWithAttach(FakeZotero):
+    def __init__(self):
+        super().__init__()
+        self.attachments = []
+
+    def attachment_both(self, files, parentid=None, **kwargs):
+        self.attachments.append({"files": files, "parentid": parentid})
+        return {"success": {"0": "ATCH0001"}, "successful": {}, "failed": {}}
+
+
+def _patch_hybrid(monkeypatch):
+    fake = FakeZoteroWithAttach()
+    monkeypatch.setattr(
+        "zotero_mcp.tools._helpers._get_write_client",
+        lambda ctx: (fake, fake),
+    )
+    return fake
+
+
+def _disable_oa_pdf(monkeypatch):
+    monkeypatch.setattr(
+        "zotero_mcp.tools._helpers._try_attach_oa_pdf",
+        lambda *args, **kwargs: "no open-access PDF found (stubbed)",
+    )
+
+
+SAMPLE_ARTICLE = {
+    "type": "article-journal",
+    "id": "X2020",
+    "title": "A Paper",
+    "author": [{"given": "John", "family": "Smith"}],
+    "issued": {"date-parts": [[2020, 3, 15]]},
+    "container-title": "Nature",
+    "volume": "42",
+    "issue": "7",
+    "page": "1-10",
+    "DOI": "10.1234/x",
+}
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+class TestHappyPath:
+    def test_single_dict_input(self, monkeypatch, dummy_ctx):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        result = server.add_by_csl_json(csl_json=SAMPLE_ARTICLE, ctx=dummy_ctx)
+
+        assert len(fake.created) == 1
+        created = fake.created[0]
+        assert created["itemType"] == "journalArticle"
+        assert created["title"] == "A Paper"
+        assert created["DOI"] == "10.1234/x"
+        assert created["date"] == "2020-03-15"
+        assert "Citation Key: X2020" in created["extra"]
+        assert "Successfully added" in result
+
+    def test_json_string_input(self, monkeypatch, dummy_ctx):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        result = server.add_by_csl_json(
+            csl_json=json.dumps(SAMPLE_ARTICLE), ctx=dummy_ctx,
+        )
+
+        assert len(fake.created) == 1
+        assert fake.created[0]["title"] == "A Paper"
+        assert "Successfully added" in result
+
+    def test_list_of_objects(self, monkeypatch, dummy_ctx):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        entries = [SAMPLE_ARTICLE, {"type": "book", "title": "B",
+                                     "author": [{"family": "A"}]}]
+        result = server.add_by_csl_json(csl_json=entries, ctx=dummy_ctx)
+
+        assert len(fake.created) == 2
+        assert fake.created[0]["itemType"] == "journalArticle"
+        assert fake.created[1]["itemType"] == "book"
+        assert "Added 2/2" in result
+
+    def test_json_string_array(self, monkeypatch, dummy_ctx):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        server.add_by_csl_json(
+            csl_json=json.dumps([SAMPLE_ARTICLE, SAMPLE_ARTICLE]),
+            ctx=dummy_ctx,
+        )
+
+        assert len(fake.created) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tags and collections
+# ---------------------------------------------------------------------------
+
+class TestTagsAndCollections:
+    def test_caller_tags_merged(self, monkeypatch, dummy_ctx):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        csl = dict(SAMPLE_ARTICLE)
+        csl["keyword"] = ["source1", "source2"]
+
+        server.add_by_csl_json(
+            csl_json=csl, tags=["caller1", "source1"], ctx=dummy_ctx,
+        )
+
+        tags = [t["tag"] for t in fake.created[0]["tags"]]
+        assert tags == ["source1", "source2", "caller1"]
+
+    def test_collections_applied(self, monkeypatch, dummy_ctx):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        server.add_by_csl_json(
+            csl_json=SAMPLE_ARTICLE,
+            collections=["COL001"],
+            ctx=dummy_ctx,
+        )
+
+        assert fake.created[0]["collections"] == ["COL001"]
+
+
+# ---------------------------------------------------------------------------
+# DOI -> OA PDF
+# ---------------------------------------------------------------------------
+
+class TestOaPdfAttempt:
+    def test_doi_triggers_attempt(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        called = {"count": 0, "doi": None}
+
+        def stub(write_zot, item_key, doi, ctx, **kwargs):
+            called["count"] += 1
+            called["doi"] = doi
+            return "stubbed"
+
+        monkeypatch.setattr("zotero_mcp.tools._helpers._try_attach_oa_pdf", stub)
+
+        server.add_by_csl_json(csl_json=SAMPLE_ARTICLE, ctx=dummy_ctx)
+
+        assert called["count"] == 1
+        assert called["doi"] == "10.1234/x"
+
+    def test_no_doi_no_attempt(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        called = {"count": 0}
+
+        def stub(*args, **kwargs):
+            called["count"] += 1
+            return "stubbed"
+
+        monkeypatch.setattr("zotero_mcp.tools._helpers._try_attach_oa_pdf", stub)
+
+        server.add_by_csl_json(
+            csl_json={"type": "book", "title": "B",
+                      "author": [{"family": "A"}]},
+            ctx=dummy_ctx,
+        )
+
+        assert called["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+class TestErrorPaths:
+    def test_invalid_json_string(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        result = server.add_by_csl_json(csl_json="{not valid json", ctx=dummy_ctx)
+        assert "Invalid JSON" in result
+
+    def test_empty_list(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        result = server.add_by_csl_json(csl_json=[], ctx=dummy_ctx)
+        assert "No valid CSL JSON" in result
+
+    def test_empty_string(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        result = server.add_by_csl_json(csl_json="", ctx=dummy_ctx)
+        assert "No valid CSL JSON" in result
+
+    def test_local_only_mode_rejected(self, monkeypatch, dummy_ctx):
+        def raise_local(ctx):
+            raise ValueError("Cannot perform write operations in local-only mode.")
+
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client", raise_local
+        )
+        result = server.add_by_csl_json(csl_json=SAMPLE_ARTICLE, ctx=dummy_ctx)
+        assert "local-only" in result.lower()

--- a/tests/test_add_by_csl_json.py
+++ b/tests/test_add_by_csl_json.py
@@ -177,6 +177,65 @@ class TestOaPdfAttempt:
 
 
 # ---------------------------------------------------------------------------
+# file_path ingestion
+# ---------------------------------------------------------------------------
+
+class TestFilePath:
+    def test_reads_json_file(self, monkeypatch, dummy_ctx, tmp_path):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        f = tmp_path / "refs.json"
+        f.write_text(json.dumps(SAMPLE_ARTICLE), encoding="utf-8")
+
+        result = server.add_by_csl_json(file_path=str(f), ctx=dummy_ctx)
+
+        assert len(fake.created) == 1
+        assert fake.created[0]["title"] == "A Paper"
+        assert "Successfully added" in result
+
+    def test_reads_csljson_extension(self, monkeypatch, dummy_ctx, tmp_path):
+        fake = _patch_hybrid(monkeypatch)
+        _disable_oa_pdf(monkeypatch)
+
+        f = tmp_path / "refs.csljson"
+        f.write_text(json.dumps([SAMPLE_ARTICLE, SAMPLE_ARTICLE]), encoding="utf-8")
+
+        server.add_by_csl_json(file_path=str(f), ctx=dummy_ctx)
+        assert len(fake.created) == 2
+
+    def test_rejects_wrong_extension(self, monkeypatch, dummy_ctx, tmp_path):
+        _patch_hybrid(monkeypatch)
+        f = tmp_path / "refs.bib"
+        f.write_text(json.dumps(SAMPLE_ARTICLE), encoding="utf-8")
+
+        result = server.add_by_csl_json(file_path=str(f), ctx=dummy_ctx)
+        assert "Unsupported file extension" in result
+
+    def test_rejects_missing_file(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        result = server.add_by_csl_json(
+            file_path="/absolutely/no/such/file.json", ctx=dummy_ctx,
+        )
+        assert "not found" in result.lower()
+
+    def test_rejects_relative_path(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        result = server.add_by_csl_json(file_path="refs.json", ctx=dummy_ctx)
+        assert "absolute" in result.lower()
+
+    def test_rejects_symlink(self, monkeypatch, dummy_ctx, tmp_path):
+        _patch_hybrid(monkeypatch)
+        target = tmp_path / "real.json"
+        target.write_text(json.dumps(SAMPLE_ARTICLE), encoding="utf-8")
+        link = tmp_path / "linked.json"
+        link.symlink_to(target)
+
+        result = server.add_by_csl_json(file_path=str(link), ctx=dummy_ctx)
+        assert "symlink" in result.lower()
+
+
+# ---------------------------------------------------------------------------
 # Error paths
 # ---------------------------------------------------------------------------
 
@@ -189,12 +248,24 @@ class TestErrorPaths:
     def test_empty_list(self, monkeypatch, dummy_ctx):
         _patch_hybrid(monkeypatch)
         result = server.add_by_csl_json(csl_json=[], ctx=dummy_ctx)
-        assert "No valid CSL JSON" in result
+        assert "Must provide" in result
 
     def test_empty_string(self, monkeypatch, dummy_ctx):
         _patch_hybrid(monkeypatch)
         result = server.add_by_csl_json(csl_json="", ctx=dummy_ctx)
-        assert "No valid CSL JSON" in result
+        assert "Must provide" in result
+
+    def test_neither_csl_nor_file_path(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        result = server.add_by_csl_json(ctx=dummy_ctx)
+        assert "Must provide" in result
+
+    def test_both_csl_and_file_path_rejected(self, monkeypatch, dummy_ctx):
+        _patch_hybrid(monkeypatch)
+        result = server.add_by_csl_json(
+            csl_json=SAMPLE_ARTICLE, file_path="/tmp/x.json", ctx=dummy_ctx,
+        )
+        assert "not both" in result
 
     def test_local_only_mode_rejected(self, monkeypatch, dummy_ctx):
         def raise_local(ctx):

--- a/tests/test_citation_import.py
+++ b/tests/test_citation_import.py
@@ -1,0 +1,438 @@
+"""Unit tests for zotero_mcp.citation_import (parse + converters)."""
+
+import pytest
+
+from zotero_mcp.citation_import import (
+    _format_bibtex_date,
+    _format_csl_date,
+    _parse_bibtex_author_list,
+    bibtex_entry_to_zotero,
+    coerce_csl_json_input,
+    csl_json_to_zotero,
+    merge_tags,
+    parse_bibtex,
+)
+
+# ---------------------------------------------------------------------------
+# Template fixture — mirrors the subset of Zotero's item_template() we need
+# ---------------------------------------------------------------------------
+
+def make_template(item_type: str) -> dict:
+    base = {
+        "itemType": item_type,
+        "title": "",
+        "creators": [],
+        "tags": [],
+        "collections": [],
+        "relations": {},
+        "date": "",
+        "abstractNote": "",
+        "url": "",
+        "DOI": "",
+        "extra": "",
+        "shortTitle": "",
+        "language": "",
+    }
+    article_fields = {
+        "publicationTitle": "",
+        "volume": "",
+        "issue": "",
+        "pages": "",
+        "ISSN": "",
+        "publisher": "",
+        "series": "",
+        "seriesText": "",
+        "journalAbbreviation": "",
+    }
+    if item_type in ("journalArticle", "preprint",
+                     "magazineArticle", "newspaperArticle"):
+        base.update(article_fields)
+    if item_type == "conferencePaper":
+        base.update(article_fields)
+        base.update({"proceedingsTitle": "", "conferenceName": "",
+                     "place": "", "ISBN": ""})
+    if item_type == "bookSection":
+        base.update({
+            "bookTitle": "", "publisher": "", "place": "", "ISBN": "",
+            "pages": "", "edition": "", "volume": "", "ISSN": "",
+            "series": "", "seriesNumber": "", "numberOfVolumes": "",
+        })
+    if item_type == "book":
+        base.update({
+            "publisher": "", "place": "", "ISBN": "", "numPages": "",
+            "edition": "", "volume": "", "ISSN": "", "series": "",
+            "seriesNumber": "", "numberOfVolumes": "",
+        })
+    if item_type == "thesis":
+        base.update({
+            "thesisType": "", "university": "", "place": "", "numPages": "",
+        })
+    if item_type == "report":
+        base.update({
+            "reportNumber": "", "reportType": "", "institution": "",
+            "place": "", "pages": "", "seriesTitle": "",
+        })
+    if item_type == "webpage":
+        base.update({"websiteTitle": "", "websiteType": "", "accessDate": ""})
+    if item_type == "patent":
+        base.update({"patentNumber": "", "place": "", "country": "",
+                     "issuingAuthority": "", "pages": ""})
+    if item_type == "document":
+        base.update({"publisher": ""})
+    return base
+
+
+# ---------------------------------------------------------------------------
+# parse_bibtex
+# ---------------------------------------------------------------------------
+
+class TestParseBibtex:
+    def test_parses_single_article(self):
+        bib = """
+        @article{smith2020,
+          title = {Hello World},
+          author = {Smith, John},
+          journal = {Nature},
+          year = {2020},
+        }
+        """
+        entries = parse_bibtex(bib)
+        assert len(entries) == 1
+        e = entries[0]
+        assert e["entry_type"] == "article"
+        assert e["citekey"] == "smith2020"
+        assert e["fields"]["title"] == "Hello World"
+        assert e["fields"]["author"] == "Smith, John"
+
+    def test_parses_multiple_entries(self):
+        bib = """
+        @article{a, title={A}, author={X, Y}, year={2020}}
+        @book{b, title={B}, author={P, Q}, year={2021}, publisher={Pub}}
+        """
+        entries = parse_bibtex(bib)
+        assert len(entries) == 2
+        assert entries[0]["entry_type"] == "article"
+        assert entries[1]["entry_type"] == "book"
+
+    def test_empty_input_returns_empty_list(self):
+        assert parse_bibtex("") == []
+        assert parse_bibtex("   ") == []
+
+    def test_unicode_conversion(self):
+        """LaTeX accents should be converted to unicode."""
+        bib = r"@article{a, title={Caf{\'e}}, author={Doe, J}, year=2020}"
+        entries = parse_bibtex(bib)
+        assert entries[0]["fields"]["title"] == "Café"
+
+
+# ---------------------------------------------------------------------------
+# Author parsing
+# ---------------------------------------------------------------------------
+
+class TestAuthorParsing:
+    def test_last_first_format(self):
+        c = _parse_bibtex_author_list("Smith, John")
+        assert c == [{"creatorType": "author", "firstName": "John", "lastName": "Smith"}]
+
+    def test_first_last_format(self):
+        c = _parse_bibtex_author_list("John Smith")
+        assert c == [{"creatorType": "author", "firstName": "John", "lastName": "Smith"}]
+
+    def test_multiple_authors_split_on_and(self):
+        c = _parse_bibtex_author_list("Smith, John and Jane Doe")
+        assert len(c) == 2
+        assert c[0]["lastName"] == "Smith"
+        assert c[1]["lastName"] == "Doe"
+
+    def test_corporate_author_with_llc(self):
+        c = _parse_bibtex_author_list("{Acme Consortium, LLC}")
+        assert c == [{"creatorType": "author", "name": "Acme Consortium, LLC"}]
+
+    def test_corporate_author_with_inc_suffix(self):
+        c = _parse_bibtex_author_list("Google Inc")
+        assert c == [{"creatorType": "author", "name": "Google Inc"}]
+
+    def test_brace_protected_author_with_and(self):
+        """`{Smith and Jones, Ltd}` should NOT be split on ' and '."""
+        c = _parse_bibtex_author_list("{Smith and Jones, Ltd}")
+        assert len(c) == 1
+        assert c[0].get("name") == "Smith and Jones, Ltd"
+
+    def test_empty_input(self):
+        assert _parse_bibtex_author_list("") == []
+
+    def test_single_word_author(self):
+        c = _parse_bibtex_author_list("Cher")
+        assert c == [{"creatorType": "author", "name": "Cher"}]
+
+
+# ---------------------------------------------------------------------------
+# Date parsing
+# ---------------------------------------------------------------------------
+
+class TestDateParsing:
+    def test_year_only(self):
+        assert _format_bibtex_date("2020", "", "", "") == "2020"
+
+    def test_year_month_name(self):
+        assert _format_bibtex_date("2020", "March", "", "") == "2020-03"
+
+    def test_year_month_number(self):
+        assert _format_bibtex_date("2020", "3", "", "") == "2020-03"
+
+    def test_year_month_day(self):
+        assert _format_bibtex_date("2020", "mar", "5", "") == "2020-03-05"
+
+    def test_iso_date_overrides(self):
+        assert _format_bibtex_date("2020", "mar", "5", "1999-12-31") == "1999-12-31"
+
+    def test_empty_year(self):
+        assert _format_bibtex_date("", "mar", "", "") == ""
+
+    def test_csl_date_parts(self):
+        assert _format_csl_date({"date-parts": [[2020, 3, 15]]}) == "2020-03-15"
+
+    def test_csl_date_literal(self):
+        assert _format_csl_date({"literal": "circa 1920"}) == "circa 1920"
+
+    def test_csl_date_raw(self):
+        assert _format_csl_date({"raw": "2019-05"}) == "2019-05"
+
+    def test_csl_date_year_only(self):
+        assert _format_csl_date({"date-parts": [[2020]]}) == "2020"
+
+
+# ---------------------------------------------------------------------------
+# bibtex_entry_to_zotero
+# ---------------------------------------------------------------------------
+
+class TestBibtexToZotero:
+    def test_article_basic(self):
+        bib = """
+        @article{s20,
+          title={A Paper},
+          author={Smith, John and Doe, Jane},
+          journal={Nature},
+          year={2020},
+          volume={42},
+          number={7},
+          pages={1--10},
+          doi={10.1/x},
+        }
+        """
+        item = bibtex_entry_to_zotero(parse_bibtex(bib)[0], make_template)
+        assert item["itemType"] == "journalArticle"
+        assert item["title"] == "A Paper"
+        assert item["publicationTitle"] == "Nature"
+        assert item["volume"] == "42"
+        assert item["issue"] == "7"
+        assert item["pages"] == "1-10"  # normalized from --
+        assert item["DOI"] == "10.1/x"
+        assert len(item["creators"]) == 2
+        assert "Citation Key: s20" in item["extra"]
+
+    def test_inproceedings_uses_proceedings_title(self):
+        bib = """
+        @inproceedings{d19,
+          title={ML Paper},
+          author={Doe, J},
+          booktitle={Proc. ICML},
+          year={2019},
+        }
+        """
+        item = bibtex_entry_to_zotero(parse_bibtex(bib)[0], make_template)
+        assert item["itemType"] == "conferencePaper"
+        assert item["proceedingsTitle"] == "Proc. ICML"
+
+    def test_inbook_uses_book_title(self):
+        bib = """
+        @incollection{k, title={Chapter}, author={Kim, K},
+          booktitle={Big Book}, year={2020}, publisher={Pub}}
+        """
+        item = bibtex_entry_to_zotero(parse_bibtex(bib)[0], make_template)
+        assert item["itemType"] == "bookSection"
+        assert item["bookTitle"] == "Big Book"
+
+    def test_phdthesis_sets_thesis_type(self):
+        bib = "@phdthesis{t, title={Diss}, author={A, B}, school={MIT}, year={2020}}"
+        item = bibtex_entry_to_zotero(parse_bibtex(bib)[0], make_template)
+        assert item["itemType"] == "thesis"
+        assert item["thesisType"] == "PhD thesis"
+        # "school" should populate university
+        assert item["university"] == "MIT"
+
+    def test_keywords_become_tags(self):
+        bib = "@article{x, title={T}, author={A, B}, year={2020}, keywords={alpha, beta, gamma}}"
+        item = bibtex_entry_to_zotero(parse_bibtex(bib)[0], make_template)
+        tag_names = [t["tag"] for t in item["tags"]]
+        assert tag_names == ["alpha", "beta", "gamma"]
+
+    def test_keywords_semicolon_separated(self):
+        bib = "@article{x, title={T}, author={A, B}, year={2020}, keywords={alpha; beta}}"
+        item = bibtex_entry_to_zotero(parse_bibtex(bib)[0], make_template)
+        tag_names = [t["tag"] for t in item["tags"]]
+        assert tag_names == ["alpha", "beta"]
+
+    def test_unknown_field_goes_to_extra(self):
+        bib = "@article{x, title={T}, author={A, B}, year={2020}, funding={NSF-123}}"
+        item = bibtex_entry_to_zotero(parse_bibtex(bib)[0], make_template)
+        assert "funding: NSF-123" in item["extra"]
+
+    def test_note_appended_to_extra(self):
+        bib = "@article{x, title={T}, author={A, B}, year={2020}, note={See also...}}"
+        item = bibtex_entry_to_zotero(parse_bibtex(bib)[0], make_template)
+        assert "See also..." in item["extra"]
+
+    def test_misc_maps_to_document(self):
+        bib = "@misc{x, title={T}, author={A, B}, year={2020}}"
+        item = bibtex_entry_to_zotero(parse_bibtex(bib)[0], make_template)
+        assert item["itemType"] == "document"
+
+    def test_arxiv_eprint(self):
+        bib = "@article{x, title={T}, author={A, B}, year={2020}, eprint={2010.12345}, eprinttype={arxiv}}"
+        item = bibtex_entry_to_zotero(parse_bibtex(bib)[0], make_template)
+        assert "arXiv: 2010.12345" in item["extra"]
+        assert item["url"] == "https://arxiv.org/abs/2010.12345"
+
+
+# ---------------------------------------------------------------------------
+# csl_json_to_zotero
+# ---------------------------------------------------------------------------
+
+class TestCslJsonToZotero:
+    def test_article_journal(self):
+        csl = {
+            "type": "article-journal",
+            "id": "X2020",
+            "title": "Hello",
+            "author": [{"given": "John", "family": "Smith"}],
+            "issued": {"date-parts": [[2020, 3, 15]]},
+            "container-title": "Nature",
+            "volume": "42",
+            "issue": "7",
+            "page": "1-10",
+            "DOI": "10.1/x",
+        }
+        item = csl_json_to_zotero(csl, make_template)
+        assert item["itemType"] == "journalArticle"
+        assert item["title"] == "Hello"
+        assert item["publicationTitle"] == "Nature"
+        assert item["date"] == "2020-03-15"
+        assert item["DOI"] == "10.1/x"
+        assert item["creators"][0]["firstName"] == "John"
+        assert item["creators"][0]["lastName"] == "Smith"
+        assert "Citation Key: X2020" in item["extra"]
+
+    def test_chapter_uses_book_title(self):
+        csl = {
+            "type": "chapter", "title": "C",
+            "author": [{"family": "K"}],
+            "container-title": "Big Book",
+            "publisher": "Pub",
+            "issued": {"date-parts": [[2020]]},
+        }
+        item = csl_json_to_zotero(csl, make_template)
+        assert item["itemType"] == "bookSection"
+        assert item["bookTitle"] == "Big Book"
+
+    def test_paper_conference(self):
+        csl = {
+            "type": "paper-conference", "title": "P",
+            "author": [{"family": "A"}],
+            "container-title": "ICML 2020",
+            "issued": {"date-parts": [[2020]]},
+        }
+        item = csl_json_to_zotero(csl, make_template)
+        assert item["itemType"] == "conferencePaper"
+        assert item["proceedingsTitle"] == "ICML 2020"
+
+    def test_literal_author(self):
+        csl = {
+            "type": "article-journal", "title": "t",
+            "author": [{"literal": "Acme Corp."}],
+        }
+        item = csl_json_to_zotero(csl, make_template)
+        assert item["creators"][0]["name"] == "Acme Corp."
+
+    def test_editor_as_creator(self):
+        csl = {
+            "type": "book", "title": "t",
+            "editor": [{"given": "E", "family": "Edit"}],
+        }
+        item = csl_json_to_zotero(csl, make_template)
+        assert item["creators"][0]["creatorType"] == "editor"
+
+    def test_keyword_list(self):
+        csl = {"type": "article-journal", "title": "t",
+               "keyword": ["alpha", "beta"]}
+        item = csl_json_to_zotero(csl, make_template)
+        assert [t["tag"] for t in item["tags"]] == ["alpha", "beta"]
+
+    def test_unknown_type_falls_back_to_document(self):
+        csl = {"type": "song-and-dance", "title": "t"}
+        item = csl_json_to_zotero(csl, make_template)
+        assert item["itemType"] == "document"
+
+    def test_unmapped_field_to_extra(self):
+        csl = {"type": "article-journal", "title": "t",
+               "custom-field": "custom-value"}
+        item = csl_json_to_zotero(csl, make_template)
+        assert "custom-field: custom-value" in item["extra"]
+
+    def test_report_number(self):
+        csl = {"type": "report", "title": "t", "number": "R-42"}
+        item = csl_json_to_zotero(csl, make_template)
+        assert item["reportNumber"] == "R-42"
+
+
+# ---------------------------------------------------------------------------
+# coerce_csl_json_input
+# ---------------------------------------------------------------------------
+
+class TestCoerceCslInput:
+    def test_accepts_json_string(self):
+        out = coerce_csl_json_input('[{"type":"article-journal","title":"t"}]')
+        assert out == [{"type": "article-journal", "title": "t"}]
+
+    def test_accepts_single_object_string(self):
+        out = coerce_csl_json_input('{"type":"book","title":"t"}')
+        assert out == [{"type": "book", "title": "t"}]
+
+    def test_accepts_dict(self):
+        out = coerce_csl_json_input({"type": "book"})
+        assert out == [{"type": "book"}]
+
+    def test_accepts_list(self):
+        out = coerce_csl_json_input([{"type": "book"}, {"type": "article-journal"}])
+        assert len(out) == 2
+
+    def test_empty_string_returns_empty(self):
+        assert coerce_csl_json_input("") == []
+        assert coerce_csl_json_input("   ") == []
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            coerce_csl_json_input("{not valid")
+
+    def test_wrong_type_raises(self):
+        with pytest.raises(ValueError):
+            coerce_csl_json_input(42)
+
+
+# ---------------------------------------------------------------------------
+# merge_tags
+# ---------------------------------------------------------------------------
+
+class TestMergeTags:
+    def test_merges_and_preserves_order(self):
+        assert merge_tags(["a", "b"], ["c"]) == ["a", "b", "c"]
+
+    def test_deduplicates_case_insensitive(self):
+        assert merge_tags(["Alpha"], ["alpha", "beta"]) == ["Alpha", "beta"]
+
+    def test_strips_whitespace(self):
+        assert merge_tags(["  a  ", ""], [" b "]) == ["a", "b"]
+
+    def test_empty_inputs(self):
+        assert merge_tags([], []) == []
+        assert merge_tags(None, None) == []


### PR DESCRIPTION
Closes #241.

## Summary

Adds two new MCP tools that ingest pre-existing citation records directly — LLMs emit both formats fluently, and this avoids a CrossRef round-trip for items the caller already has metadata for.

- `zotero_add_by_bibtex` — parses one or more `@entries` via `bibtexparser` (with LaTeX → unicode), maps to Zotero item format, preserves the citation key in `Extra`, and attempts an open-access PDF attachment when a DOI is present. Accepts inline `bibtex` string OR an absolute `file_path` to a `.bib`/`.bibtex` file.
- `zotero_add_by_csl_json` — same for CSL JSON input; accepts inline JSON (string, object, or array) OR an absolute `file_path` to a `.json`/`.csljson` file. Preserves the CSL `id` as the citation key.

Both tools share the existing hybrid-mode write-client pattern (`_get_write_client`), reuse `_try_attach_oa_pdf` for the OA-PDF cascade, and report per-entry status (one success doesn't mask another entry's failure).

## Design notes

- **Direct BibTeX→Zotero and CSL→Zotero maps**, not a shared BibTeX→CSL→Zotero funnel. Considered the funnel for code reuse but rejected: BibTeX→CSL is itself non-trivial and lossy (drops citekey, `note`, `eprint*`, etc.). With `bibtexparser` doing the LaTeX work, a direct map costs little more code and preserves more.
- **Authoritative crosswalk**: [z2csl type/field map](https://aurimasv.github.io/z2csl/typeMap.xml). Unmapped source fields land in `Extra` as labelled lines rather than silently disappearing.
- **Corporate authors** detected via suffix heuristics (`Inc`, `LLC`, `University`, `Consortium`, …) and `{brace-protected}` groups are preserved as single-name creators (not split on `" and "`).
- **file_path security** mirrors `zotero_add_from_file`: reject symlinks, require absolute path, UTF-8 decode, 10MB cap, per-tool extension whitelist.
- **New dep**: `bibtexparser>=1.4,<2` (core). v1.x is deliberate — v2 has an incompatible API and is still stabilising.
- **Not implemented, deliberately**: a dependency on [Zotero translation-server](https://github.com/zotero/translation-server) (would require a Docker sidecar) and Better-BibTeX JSON-RPC (no import endpoint).

## Test plan

- [x] 52 unit tests for parsers / converters: `tests/test_citation_import.py`
- [x] 39 integration tests for the tools (FakeZotero, hybrid-mode guard, DOI-triggered OA attempt, tag merge, file_path ingestion + mutex, error paths): `tests/test_add_by_bibtex.py`, `tests/test_add_by_csl_json.py`
- [x] Full suite passes: `uv run pytest` — **526 passed**
- [ ] Manual smoke test against a real Zotero library: ingest a 2-entry BibTeX (one with DOI, one without) and a CSL JSON object; verify items appear, OA PDF is attached for the DOI entry, citation key lands in `Extra`, source keywords merge with caller tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)