### PR TITLE
feat: add zotero_add_by_isbn (Open Library + Google Books cascade) (#226)

### DIFF
--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -101,6 +101,7 @@ from zotero_mcp.tools.write import (  # noqa: F401
     manage_collections,
     add_by_doi,
     add_by_url,
+    add_by_isbn,
     update_item,
     find_duplicates,
     merge_duplicates,

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -188,6 +188,64 @@ def _normalize_doi(raw):
     return None
 
 
+def _normalize_isbn(raw):
+    """Normalize an ISBN string and validate the checksum.
+
+    Accepts ISBN-10, ISBN-13, and prefixed/URL forms (isbn:, https://isbndb.com/...).
+    Strips hyphens, spaces, and any prefix. Returns the canonical digits-only
+    form (13-digit preferred — ISBN-10 inputs are converted to ISBN-13).
+    Returns None on invalid input or failing checksum.
+    """
+    if not raw:
+        return None
+    s = str(raw).strip()
+    if s.lower().startswith("isbn:"):
+        s = s[5:].strip()
+    if s.lower().startswith("isbn-") or s.lower().startswith("isbn "):
+        s = s[5:].strip()
+    if s.lower().startswith("http://") or s.lower().startswith("https://"):
+        m = re.search(r"/(97[89][\- ]?\d[\- ]?\d{3}[\- ]?\d{5}[\- ]?\d|\d{9}[\dX])",
+                      s, flags=re.IGNORECASE)
+        if not m:
+            return None
+        s = m.group(1)
+    digits = re.sub(r"[\s\-]", "", s)
+    if re.match(r"^\d{9}[\dXx]$", digits):
+        if not _isbn10_checksum_valid(digits):
+            return None
+        return _isbn10_to_isbn13(digits)
+    if re.match(r"^97[89]\d{10}$", digits):
+        if not _isbn13_checksum_valid(digits):
+            return None
+        return digits
+    return None
+
+
+def _isbn10_checksum_valid(s):
+    total = 0
+    for i, ch in enumerate(s):
+        v = 10 if ch in ("X", "x") else int(ch)
+        total += v * (10 - i)
+    return total % 11 == 0
+
+
+def _isbn13_checksum_valid(s):
+    total = 0
+    for i, ch in enumerate(s):
+        v = int(ch)
+        total += v if i % 2 == 0 else v * 3
+    return total % 10 == 0
+
+
+def _isbn10_to_isbn13(isbn10):
+    core = "978" + isbn10[:9]
+    total = 0
+    for i, ch in enumerate(core):
+        total += int(ch) * (1 if i % 2 == 0 else 3)
+    check = (10 - total % 10) % 10
+    return core + str(check)
+
+
 def _normalize_arxiv_id(raw):
     """Normalize an arXiv ID from various input formats."""
     if not raw:

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -710,6 +710,222 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx):
     return f"Failed to create arXiv item: {result}"
 
 
+# ---------------------------------------------------------------------------
+# ISBN lookup — Open Library (primary) + Google Books (fallback) (#226)
+# ---------------------------------------------------------------------------
+
+def _lookup_isbn_openlibrary(isbn, ctx):
+    """Look up book metadata by ISBN on Open Library. Returns a dict of
+    normalized fields, or None on miss / error. Network errors are logged
+    and surfaced as None so the caller can fall through to Google Books.
+    """
+    try:
+        url = (
+            f"https://openlibrary.org/api/books"
+            f"?bibkeys=ISBN:{isbn}&format=json&jscmd=data"
+        )
+        resp = requests.get(
+            url,
+            headers={"User-Agent": "zotero-mcp/1.0 (https://github.com/54yyyu/zotero-mcp)"},
+            timeout=15,
+        )
+        if resp.status_code != 200:
+            return None
+        payload = resp.json() or {}
+        record = payload.get(f"ISBN:{isbn}") or {}
+        if not record:
+            return None
+
+        title = record.get("title", "")
+        if record.get("subtitle"):
+            title = f"{title}: {record['subtitle']}"
+
+        creators = []
+        for author in record.get("authors", []) or []:
+            name = (author.get("name") or "").strip()
+            if not name:
+                continue
+            parts = name.rsplit(" ", 1)
+            if len(parts) == 2:
+                creators.append({
+                    "creatorType": "author",
+                    "firstName": parts[0],
+                    "lastName": parts[1],
+                })
+            else:
+                creators.append({"creatorType": "author", "name": name})
+
+        publisher = ""
+        publishers = record.get("publishers") or []
+        if publishers:
+            publisher = (publishers[0].get("name") or "").strip()
+
+        place = ""
+        places = record.get("publish_places") or []
+        if places:
+            place = (places[0].get("name") or "").strip()
+
+        return {
+            "source": "Open Library",
+            "title": title,
+            "creators": creators,
+            "date": (record.get("publish_date") or "").strip(),
+            "publisher": publisher,
+            "place": place,
+            "num_pages": str(record.get("number_of_pages", "") or "").strip(),
+            "url": (record.get("url") or "").strip(),
+        }
+    except requests.RequestException as e:
+        ctx.info(f"Open Library lookup failed (non-fatal): {e}")
+        return None
+    except Exception as e:
+        ctx.info(f"Open Library parse failed (non-fatal): {e}")
+        return None
+
+
+def _lookup_isbn_google_books(isbn, ctx):
+    """Look up book metadata by ISBN on Google Books. Returns a dict of
+    normalized fields, or None on miss / error."""
+    try:
+        url = f"https://www.googleapis.com/books/v1/volumes?q=isbn:{isbn}"
+        resp = requests.get(
+            url,
+            headers={"User-Agent": "zotero-mcp/1.0 (https://github.com/54yyyu/zotero-mcp)"},
+            timeout=15,
+        )
+        if resp.status_code != 200:
+            return None
+        payload = resp.json() or {}
+        items = payload.get("items") or []
+        if not items:
+            return None
+        info = items[0].get("volumeInfo") or {}
+
+        title = info.get("title", "")
+        if info.get("subtitle"):
+            title = f"{title}: {info['subtitle']}"
+
+        creators = []
+        for name in info.get("authors", []) or []:
+            name = (name or "").strip()
+            if not name:
+                continue
+            parts = name.rsplit(" ", 1)
+            if len(parts) == 2:
+                creators.append({
+                    "creatorType": "author",
+                    "firstName": parts[0],
+                    "lastName": parts[1],
+                })
+            else:
+                creators.append({"creatorType": "author", "name": name})
+
+        return {
+            "source": "Google Books",
+            "title": title,
+            "creators": creators,
+            "date": (info.get("publishedDate") or "").strip(),
+            "publisher": (info.get("publisher") or "").strip(),
+            "place": "",  # Google Books doesn't expose publication place
+            "num_pages": str(info.get("pageCount", "") or "").strip(),
+            "url": (info.get("infoLink") or info.get("canonicalVolumeLink") or "").strip(),
+        }
+    except requests.RequestException as e:
+        ctx.info(f"Google Books lookup failed (non-fatal): {e}")
+        return None
+    except Exception as e:
+        ctx.info(f"Google Books parse failed (non-fatal): {e}")
+        return None
+
+
+@mcp.tool(
+    name="zotero_add_by_isbn",
+    description=(
+        "Add a book to your Zotero library by ISBN. Resolves metadata via "
+        "Open Library (primary) and Google Books (fallback). Accepts ISBN-10, "
+        "ISBN-13, with or without hyphens, or a URL/isbn: prefix. Response "
+        "includes the resolver source so you can audit metadata quality."
+    )
+)
+def add_by_isbn(
+    isbn: str,
+    collections: list[str] | str | None = None,
+    tags: list[str] | str | None = None,
+    *,
+    ctx: Context
+) -> str:
+    try:
+        read_zot, write_zot = _helpers._get_write_client(ctx)
+    except ValueError as e:
+        return str(e)
+
+    try:
+        normalized = _helpers._normalize_isbn(isbn)
+        if not normalized:
+            return (
+                f"Error: '{isbn}' does not appear to be a valid ISBN "
+                "(checksum failed or wrong length)."
+            )
+
+        ctx.info(f"Resolving ISBN {normalized} via Open Library...")
+        meta = _lookup_isbn_openlibrary(normalized, ctx)
+        if not meta:
+            ctx.info("Open Library miss — falling back to Google Books...")
+            meta = _lookup_isbn_google_books(normalized, ctx)
+        if not meta:
+            return (
+                f"ISBN not found on Open Library or Google Books: {normalized}"
+            )
+
+        # Build Zotero book item
+        template = write_zot.item_template("book")
+        item_data = dict(template)
+        if meta.get("title"):
+            item_data["title"] = meta["title"]
+        if meta.get("creators"):
+            item_data["creators"] = meta["creators"]
+        if meta.get("date") and "date" in item_data:
+            item_data["date"] = meta["date"]
+        if meta.get("publisher") and "publisher" in item_data:
+            item_data["publisher"] = meta["publisher"]
+        if meta.get("place") and "place" in item_data:
+            item_data["place"] = meta["place"]
+        if meta.get("num_pages") and "numPages" in item_data:
+            item_data["numPages"] = meta["num_pages"]
+        if meta.get("url") and "url" in item_data:
+            item_data["url"] = meta["url"]
+        if "ISBN" in item_data:
+            item_data["ISBN"] = normalized
+
+        tag_list = _helpers._normalize_str_list_input(tags, "tags")
+        if tag_list:
+            item_data["tags"] = [{"tag": t} for t in tag_list]
+        coll_keys = _helpers._normalize_str_list_input(collections, "collections")
+        if coll_keys:
+            item_data["collections"] = coll_keys
+
+        result = write_zot.create_items([item_data])
+        if isinstance(result, dict) and result.get("success"):
+            item_key = next(iter(result["success"].values()))
+            return (
+                f"Successfully added: **{item_data.get('title', normalized)}**\n\n"
+                f"Item key: `{item_key}`\n"
+                f"Type: book\n"
+                f"ISBN: {normalized}\n"
+                f"Source: {meta['source']}\n\n"
+                "_Note: Open Library and Google Books metadata can be noisy "
+                "(publisher-as-author, concatenated places, off-by-one dates). "
+                "Verify via `zotero_get_item_metadata` after creation. "
+                "Run `zotero_update_search_database` to include this item "
+                "in semantic search._"
+            )
+        return f"Failed to create item: {result}"
+
+    except Exception as e:
+        ctx.error(f"Error adding by ISBN: {e}")
+        return f"Error adding by ISBN: {e}"
+
+
 # Maps Zotero API field names to tool parameter names for user-facing messages
 _UPDATE_ITEM_API_TO_PARAM = {
     "title": "title",

--- a/tests/test_add_by_isbn.py
+++ b/tests/test_add_by_isbn.py
@@ -1,0 +1,307 @@
+"""Tests for zotero_add_by_isbn (#226).
+
+Covers ISBN normalization (10→13 conversion, checksum validation), the
+Open Library → Google Books lookup cascade, and the resulting Zotero book
+item shape.
+"""
+
+import json
+
+import pytest
+import requests
+
+from zotero_mcp import server
+from zotero_mcp.tools import write as _write
+from zotero_mcp.tools._helpers import (
+    _isbn10_to_isbn13,
+    _isbn13_checksum_valid,
+    _normalize_isbn,
+)
+from conftest import DummyContext, FakeZotero
+
+
+# ---------------------------------------------------------------------------
+# ISBN normalization
+# ---------------------------------------------------------------------------
+
+class TestNormalizeIsbn:
+    def test_valid_isbn13(self):
+        # The Pragmatic Programmer 2e
+        assert _normalize_isbn("9780135957059") == "9780135957059"
+
+    def test_valid_isbn13_with_hyphens(self):
+        assert _normalize_isbn("978-0-13-595705-9") == "9780135957059"
+
+    def test_isbn10_converted_to_isbn13(self):
+        # Gödel, Escher, Bach ISBN-10 -> ISBN-13
+        out = _normalize_isbn("0465026567")
+        assert out is not None
+        assert out.startswith("978")
+        assert _isbn13_checksum_valid(out)
+
+    def test_isbn10_x_checksum(self):
+        # ISBN-10 ending in X (checksum 10)
+        assert _normalize_isbn("080442957X") is not None
+
+    def test_invalid_checksum_rejected(self):
+        assert _normalize_isbn("9780135957050") is None  # wrong check digit
+        assert _normalize_isbn("0465026560") is None
+
+    def test_short_string_rejected(self):
+        assert _normalize_isbn("12345") is None
+
+    def test_non_isbn_prefix_stripped(self):
+        assert _normalize_isbn("ISBN: 978-0-13-595705-9") == "9780135957059"
+        assert _normalize_isbn("isbn:9780135957059") == "9780135957059"
+
+    def test_empty_and_none(self):
+        assert _normalize_isbn("") is None
+        assert _normalize_isbn(None) is None
+
+    def test_isbn10_to_isbn13_known_case(self):
+        assert _isbn10_to_isbn13("0465026567") == "9780465026562"
+
+
+# ---------------------------------------------------------------------------
+# Lookup helpers: Open Library and Google Books
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+def _fake_get_factory(responses):
+    """Build a fake requests.get that returns responses keyed by URL substring."""
+    def _fake_get(url, **kwargs):
+        for substring, resp in responses.items():
+            if substring in url:
+                return resp
+        return _FakeResponse(404)
+    return _fake_get
+
+
+OL_PAYLOAD = {
+    "ISBN:9780199735815": {
+        "title": "The Oxford Handbook of Philosophy of Mind",
+        "authors": [{"name": "Brian McLaughlin"}, {"name": "Ansgar Beckermann"}],
+        "publishers": [{"name": "Oxford University Press"}],
+        "publish_places": [{"name": "Oxford"}],
+        "publish_date": "2009",
+        "number_of_pages": 800,
+        "url": "https://openlibrary.org/books/OL24312345M",
+    }
+}
+
+GB_PAYLOAD = {
+    "items": [{
+        "volumeInfo": {
+            "title": "Some Rare Book",
+            "subtitle": "A Subtitle",
+            "authors": ["Jane Doe"],
+            "publisher": "Academic Press",
+            "publishedDate": "2020",
+            "pageCount": 300,
+            "infoLink": "https://books.google.com/books?id=abc",
+        }
+    }]
+}
+
+
+class TestOpenLibraryLookup:
+    def test_hit_returns_normalized_dict(self, monkeypatch):
+        monkeypatch.setattr(
+            _write, "requests",
+            type("R", (), {
+                "get": _fake_get_factory({
+                    "openlibrary.org": _FakeResponse(200, OL_PAYLOAD),
+                }),
+                "RequestException": requests.RequestException,
+            })
+        )
+        meta = _write._lookup_isbn_openlibrary("9780199735815", DummyContext())
+        assert meta is not None
+        assert meta["source"] == "Open Library"
+        assert "Oxford Handbook" in meta["title"]
+        assert len(meta["creators"]) == 2
+        assert meta["creators"][0]["lastName"] == "McLaughlin"
+        assert meta["publisher"] == "Oxford University Press"
+        assert meta["place"] == "Oxford"
+
+    def test_miss_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            _write, "requests",
+            type("R", (), {
+                "get": _fake_get_factory({
+                    "openlibrary.org": _FakeResponse(200, {}),
+                }),
+                "RequestException": requests.RequestException,
+            })
+        )
+        assert _write._lookup_isbn_openlibrary("9999999999999", DummyContext()) is None
+
+
+class TestGoogleBooksLookup:
+    def test_hit_returns_normalized_dict(self, monkeypatch):
+        monkeypatch.setattr(
+            _write, "requests",
+            type("R", (), {
+                "get": _fake_get_factory({
+                    "googleapis.com": _FakeResponse(200, GB_PAYLOAD),
+                }),
+                "RequestException": requests.RequestException,
+            })
+        )
+        meta = _write._lookup_isbn_google_books("9780000000000", DummyContext())
+        assert meta is not None
+        assert meta["source"] == "Google Books"
+        assert "Some Rare Book: A Subtitle" == meta["title"]
+        assert meta["publisher"] == "Academic Press"
+        assert meta["place"] == ""  # Google Books doesn't expose place
+
+    def test_no_items_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            _write, "requests",
+            type("R", (), {
+                "get": _fake_get_factory({
+                    "googleapis.com": _FakeResponse(200, {"items": []}),
+                }),
+                "RequestException": requests.RequestException,
+            })
+        )
+        assert _write._lookup_isbn_google_books("9999999999999", DummyContext()) is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end add_by_isbn
+# ---------------------------------------------------------------------------
+
+class TestAddByIsbnEndToEnd:
+    def test_open_library_hit_creates_book(self, monkeypatch):
+        fake = FakeZotero()
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client",
+            lambda ctx: (fake, fake),
+        )
+        monkeypatch.setattr(
+            _write, "requests",
+            type("R", (), {
+                "get": _fake_get_factory({
+                    "openlibrary.org": _FakeResponse(200, OL_PAYLOAD),
+                }),
+                "RequestException": requests.RequestException,
+            })
+        )
+
+        result = server.add_by_isbn(
+            isbn="978-0-19-973581-5",
+            ctx=DummyContext(),
+        )
+
+        assert "Successfully added" in result
+        assert "Oxford Handbook" in result
+        assert "9780199735815" in result
+        assert "Open Library" in result
+        # Item was passed to create_items with book shape
+        assert len(fake.created) == 1
+        created = fake.created[0]
+        assert created["itemType"] == "book"
+        assert created["ISBN"] == "9780199735815"
+        assert created["publisher"] == "Oxford University Press"
+        assert created["place"] == "Oxford"
+
+    def test_falls_back_to_google_books_on_open_library_miss(self, monkeypatch):
+        fake = FakeZotero()
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client",
+            lambda ctx: (fake, fake),
+        )
+        monkeypatch.setattr(
+            _write, "requests",
+            type("R", (), {
+                "get": _fake_get_factory({
+                    "openlibrary.org": _FakeResponse(200, {}),  # OL miss
+                    "googleapis.com": _FakeResponse(200, GB_PAYLOAD),  # GB hit
+                }),
+                "RequestException": requests.RequestException,
+            })
+        )
+
+        result = server.add_by_isbn(
+            isbn="9780135957059",
+            ctx=DummyContext(),
+        )
+
+        assert "Successfully added" in result
+        assert "Google Books" in result
+
+    def test_both_sources_miss_returns_clear_error(self, monkeypatch):
+        fake = FakeZotero()
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client",
+            lambda ctx: (fake, fake),
+        )
+        monkeypatch.setattr(
+            _write, "requests",
+            type("R", (), {
+                "get": _fake_get_factory({
+                    "openlibrary.org": _FakeResponse(200, {}),
+                    "googleapis.com": _FakeResponse(200, {"items": []}),
+                }),
+                "RequestException": requests.RequestException,
+            })
+        )
+
+        result = server.add_by_isbn(
+            isbn="9780135957059",
+            ctx=DummyContext(),
+        )
+
+        assert "not found" in result.lower()
+        assert len(fake.created) == 0
+
+    def test_invalid_isbn_rejected(self, monkeypatch):
+        fake = FakeZotero()
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client",
+            lambda ctx: (fake, fake),
+        )
+
+        result = server.add_by_isbn(
+            isbn="not-an-isbn",
+            ctx=DummyContext(),
+        )
+
+        assert "not appear to be a valid ISBN" in result
+        assert len(fake.created) == 0
+
+    def test_tags_and_collections_applied(self, monkeypatch):
+        fake = FakeZotero()
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client",
+            lambda ctx: (fake, fake),
+        )
+        monkeypatch.setattr(
+            _write, "requests",
+            type("R", (), {
+                "get": _fake_get_factory({
+                    "openlibrary.org": _FakeResponse(200, OL_PAYLOAD),
+                }),
+                "RequestException": requests.RequestException,
+            })
+        )
+
+        server.add_by_isbn(
+            isbn="9780199735815",
+            tags=["philosophy", "anthology"],
+            collections=["COLL0001"],
+            ctx=DummyContext(),
+        )
+
+        created = fake.created[0]
+        assert {t["tag"] for t in created["tags"]} == {"philosophy", "anthology"}
+        assert created["collections"] == ["COLL0001"]


### PR DESCRIPTION
Closes #226.

## Summary

The creation channels (`zotero_add_by_doi`, `zotero_add_by_url`, `zotero_add_from_file`) all required either an external identifier resolvable via CrossRef, a URL that produces a webpage item, or a local PDF/EPUB. Books with ISBNs had no programmatic path, so filling a reading list of book records forced manual desktop entry.

Add `zotero_add_by_isbn(isbn, collections=, tags=)`:

- **ISBN normalization** accepts ISBN-10, ISBN-13, hyphenated, with `isbn:`/URL prefixes; validates checksum; converts ISBN-10 to canonical ISBN-13 for storage.
- **Lookup cascade**: Open Library primary (no auth, best for trade/academic), Google Books fallback (no auth, 1000/day anonymous, broader edge coverage).
- Builds a Zotero `book` item via `item_template("book")` and maps title/subtitle, creators, publisher, place (Open Library only), date, pages, URL, and the normalized ISBN.
- Returns the resolver source in the response so users can audit metadata quality — Open Library / Google Books records are noisier than CrossRef (publisher-as-author, concatenated cities, off-by-one dates), and a post-hoc cleanup pass is often warranted.
- Same hybrid-mode behavior and tags/collections semantics as `zotero_add_by_doi`.

## Design choices

- **Why Open Library first, Google Books second:** Open Library exposes `publish_places`, which Google Books doesn't. For a Zotero `book`, place is part of the canonical record (bibliographies render it as `address = {...}`). Books that lose the place field when falling through to Google Books are flagged as such in the response so users can manually add it.
- **Why not WorldCat/LoC:** WorldCat needs an institutional OCLC key (infeasible for OSS); LoC's API has noisier structure and worse non-US coverage. Open Library + Google Books hits a reasonable coverage/complexity sweet spot with no external dependency.
- **Why not translation-server** (`translation-server.zotero.org`): that's Zotero's desktop-equivalent translator dispatch, which would give desktop-matching data quality but adds a runtime dependency on a separate server that has gone down in the past. Happy to add it as a third fallback in a follow-up if there's interest.

## Related

The companion request for bibtex / CSL-JSON ingestion ([#241](https://github.com/54yyyu/zotero-mcp/issues/241)) is being handled in [@danmackinlay's PR #247](https://github.com/54yyyu/zotero-mcp/pull/247), which is a more thorough implementation than what I had drafted (shared design, separate tools, LaTeX → unicode, z2csl authoritative map, OA-PDF cascade). This PR is ISBN-only.

## Test plan

- [x] `test_add_by_isbn.py` — 18 tests:
  - ISBN normalization: ISBN-13, hyphenated ISBN-13, ISBN-10→13 conversion, X-checksum, invalid-checksum rejection, short-string rejection, `isbn:`/`ISBN: ` prefix handling, empty/None, a known 10→13 conversion.
  - Open Library lookup: hit returns normalized dict with title/creators/publisher/place; miss returns None.
  - Google Books lookup: hit returns dict; empty `items` returns None.
  - End-to-end: Open Library hit creates book with correct shape; fallback to Google Books on Open Library miss; both-miss returns clear error; invalid ISBN rejected; tags and collections applied.
- [x] Full suite: **387 passed, 3 skipped** (one unrelated chromadb optional import failure in `test_search_improvements.py` excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)