### PR TITLE
Add WebDAV attachment fallback and raw metadata output

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ zotero-mcp setup --no-local --api-key YOUR_API_KEY --library-id YOUR_LIBRARY_ID
 - `ZOTERO_API_KEY`: Your Zotero API key (for web API)
 - `ZOTERO_LIBRARY_ID`: Your Zotero library ID (for web API)
 - `ZOTERO_LIBRARY_TYPE`: The type of library (user or group, default: user)
+- `ZOTERO_WEBDAV_URL`: Optional WebDAV folder URL for direct attachment downloads in remote mode
+- `ZOTERO_WEBDAV_USERNAME`: Optional WebDAV username
+- `ZOTERO_WEBDAV_PASSWORD`: Optional WebDAV password
 
 **Semantic Search:**
 - `ZOTERO_EMBEDDING_MODEL`: Embedding model to use (default, openai, gemini)
@@ -354,7 +357,7 @@ The first time you use PDF annotation features, the necessary tools will be auto
 - `zotero_search_by_tag`: Search your library using custom tag filters
 
 ### 📚 Content Tools
-- `zotero_get_item_metadata`: Get detailed metadata (supports BibTeX export via `format="bibtex"`)
+- `zotero_get_item_metadata`: Get detailed metadata (supports `format="markdown"`, `format="json"` for complete raw Zotero metadata, and `format="bibtex"`)
 - `zotero_get_item_fulltext`: Get full text content
 - `zotero_get_item_children`: Get attachments and notes
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -185,7 +185,7 @@ zotero-mcp serve --transport sse --host localhost --port 8000
 When connected to Claude Desktop or another MCP client, you'll have access to these tools:
 
 - **zotero_search_items**: Search your library by title, creator, or content
-- **zotero_get_item_metadata**: Get detailed information about a specific item
+- **zotero_get_item_metadata**: Get detailed information about a specific item, including complete raw metadata via `format="json"`
 - **zotero_get_item_fulltext**: Get the full text content of an item
 - **zotero_get_collections**: List all collections in your library
 - **zotero_get_collection_items**: Get all items in a specific collection

--- a/src/zotero_mcp/cli.py
+++ b/src/zotero_mcp/cli.py
@@ -31,7 +31,18 @@ def obfuscate_config_for_display(config):
         return config
 
     obfuscated = config.copy()
-    sensitive_keys = ["ZOTERO_API_KEY", "ZOTERO_LIBRARY_ID", "API_KEY", "LIBRARY_ID"]
+    sensitive_keys = [
+        "ZOTERO_API_KEY",
+        "ZOTERO_LIBRARY_ID",
+        "ZOTERO_WEBDAV_URL",
+        "ZOTERO_WEBDAV_USERNAME",
+        "ZOTERO_WEBDAV_PASSWORD",
+        "API_KEY",
+        "LIBRARY_ID",
+        "WEBDAV_URL",
+        "WEBDAV_USERNAME",
+        "WEBDAV_PASSWORD",
+    ]
 
     for key in sensitive_keys:
         if key in obfuscated:

--- a/src/zotero_mcp/client.py
+++ b/src/zotero_mcp/client.py
@@ -12,6 +12,10 @@ from markitdown import MarkItDown
 from pyzotero import zotero
 
 from zotero_mcp.utils import format_creators
+from zotero_mcp.webdav import (
+    WebDAVNotConfiguredError,
+    download_attachment_from_webdav,
+)
 
 # Load environment variables
 load_dotenv()
@@ -46,6 +50,15 @@ class AttachmentDetails:
     title: str
     filename: str
     content_type: str
+
+
+@dataclass
+class AttachmentDownloadResult:
+    """Result of downloading an attachment from one of the supported sources."""
+
+    path: Path | None
+    source: str | None
+    errors: list[str]
 
 
 def get_zotero_client() -> zotero.Zotero:
@@ -409,6 +422,83 @@ def get_attachment_details(
         pass
 
     return None
+
+
+def download_attachment_file(
+    attachment_key: str,
+    destination_dir: str | Path,
+    filename: str | None = None,
+    *,
+    local_client: zotero.Zotero | None = None,
+    web_client: zotero.Zotero | None = None,
+    enable_webdav: bool = True,
+) -> AttachmentDownloadResult:
+    """
+    Download an attachment using the best available source.
+
+    The fallback order is:
+    1. local Zotero API (works with local storage or desktop-managed WebDAV)
+    2. Direct WebDAV access via environment variables
+    3. Zotero Web API (works with Zotero cloud storage)
+    """
+    destination = Path(destination_dir)
+    destination.mkdir(parents=True, exist_ok=True)
+    target_name = Path(filename or f"{attachment_key}.bin").name
+    target_path = destination / target_name
+    errors: list[str] = []
+
+    def _cleanup_target() -> None:
+        if target_path.exists() and target_path.stat().st_size == 0:
+            target_path.unlink()
+
+    def _try_dump(label: str, zot_client: zotero.Zotero | None) -> AttachmentDownloadResult | None:
+        if zot_client is None:
+            return None
+
+        try:
+            zot_client.dump(attachment_key, filename=target_name, path=str(destination))
+            if target_path.exists() and target_path.stat().st_size > 0:
+                return AttachmentDownloadResult(
+                    path=target_path,
+                    source=label,
+                    errors=errors,
+                )
+            errors.append(f"{label}: file was not created")
+        except Exception as exc:
+            errors.append(f"{label}: {exc}")
+        finally:
+            _cleanup_target()
+
+        return None
+
+    local_result = _try_dump("Local Zotero", local_client)
+    if local_result:
+        return local_result
+
+    if enable_webdav:
+        try:
+            webdav_path = download_attachment_from_webdav(
+                attachment_key,
+                destination,
+                expected_filename=target_name,
+            )
+            if webdav_path.exists() and webdav_path.stat().st_size > 0:
+                return AttachmentDownloadResult(
+                    path=webdav_path,
+                    source="WebDAV",
+                    errors=errors,
+                )
+            errors.append("WebDAV: downloaded file was empty")
+        except WebDAVNotConfiguredError:
+            pass
+        except Exception as exc:
+            errors.append(f"WebDAV: {exc}")
+
+    web_result = _try_dump("Web API", web_client)
+    if web_result:
+        return web_result
+
+    return AttachmentDownloadResult(path=None, source=None, errors=errors)
 
 
 def convert_to_markdown(file_path: str | Path) -> str:

--- a/src/zotero_mcp/tools/annotations.py
+++ b/src/zotero_mcp/tools/annotations.py
@@ -20,6 +20,40 @@ _WEB_API_ENV_VARS = (
 )
 
 
+def _download_attachment_for_processing(
+    attachment_key: str,
+    filename: str,
+    tmpdir: str,
+    *,
+    local_client,
+    web_client,
+    ctx: Context,
+) -> tuple[str | None, str | None]:
+    """Download an attachment for PDF/EPUB processing and return (path, error)."""
+    download = _client.download_attachment_file(
+        attachment_key,
+        tmpdir,
+        filename,
+        local_client=local_client,
+        web_client=web_client,
+    )
+    if download.path and download.path.exists():
+        ctx.info(f"Attachment downloaded via {download.source}")
+        return str(download.path), None
+
+    error_details = "\n".join(f"  - {err}" for err in download.errors) or "  - No download source succeeded"
+    return (
+        None,
+        "Error: Could not download attachment.\n\n"
+        f"Attempted sources:\n{error_details}\n\n"
+        "Possible solutions:\n"
+        "- **Zotero Cloud Storage**: Ensure file syncing is enabled in Zotero preferences\n"
+        "- **WebDAV Storage**: Configure ZOTERO_WEBDAV_URL, ZOTERO_WEBDAV_USERNAME, and "
+        "ZOTERO_WEBDAV_PASSWORD in the MCP env file, or run local Zotero with remote access enabled\n"
+        "- **Linked files**: Linked attachments (not imported) cannot be accessed remotely"
+    )
+
+
 def _get_note_write_client(op_description: str):
     """Return (client, None) or (None, error_msg) for note-write operations.
 
@@ -1112,7 +1146,7 @@ def create_annotation(
 
     This tool handles multiple storage configurations:
     - Zotero Cloud Storage: Downloads file via Web API
-    - WebDAV Storage: Downloads file via local Zotero (requires Zotero desktop running)
+    - WebDAV Storage: Downloads file via local Zotero or direct WebDAV access
     - Annotations are always created via the Web API (required for write operations)
 
     Args:
@@ -1186,45 +1220,16 @@ def create_annotation(
         # Download the PDF to a temporary location
         # Strategy: Try multiple sources in order of likelihood to succeed
         with tempfile.TemporaryDirectory() as tmpdir:
-            file_path = os.path.join(tmpdir, filename)
-            ctx.info(f"Downloading PDF to {file_path}")
-
-            download_errors = []
-            downloaded = False
-
-            # Source 1: Try local Zotero first (works for WebDAV and local storage)
-            if local_client and not downloaded:
-                try:
-                    ctx.info("Trying local Zotero (WebDAV/local storage)...")
-                    local_client.dump(attachment_key, filename=filename, path=tmpdir)
-                    if os.path.exists(file_path) and os.path.getsize(file_path) > 0:
-                        downloaded = True
-                        ctx.info("PDF downloaded via local Zotero")
-                except Exception as e:
-                    download_errors.append(f"Local Zotero: {e}")
-
-            # Source 2: Try Web API (works for Zotero Cloud Storage)
-            if not downloaded:
-                try:
-                    ctx.info("Trying Zotero Web API (cloud storage)...")
-                    web_client.dump(attachment_key, filename=filename, path=tmpdir)
-                    if os.path.exists(file_path) and os.path.getsize(file_path) > 0:
-                        downloaded = True
-                        ctx.info("PDF downloaded via Web API")
-                except Exception as e:
-                    download_errors.append(f"Web API: {e}")
-
-            if not downloaded:
-                error_details = "\n".join(f"  - {err}" for err in download_errors)
-                return (
-                    f"Error: Could not download PDF attachment.\n\n"
-                    f"Attempted sources:\n{error_details}\n\n"
-                    "Possible solutions:\n"
-                    "- **Zotero Cloud Storage**: Ensure file syncing is enabled in Zotero preferences\n"
-                    "- **WebDAV Storage**: Ensure Zotero desktop is running with "
-                    "'Allow other applications to communicate with Zotero' enabled\n"
-                    "- **Linked files**: Linked attachments (not imported) cannot be accessed remotely"
-                )
+            file_path, error_message = _download_attachment_for_processing(
+                attachment_key,
+                filename,
+                tmpdir,
+                local_client=local_client,
+                web_client=web_client,
+                ctx=ctx,
+            )
+            if error_message:
+                return error_message
 
             # Verify the file is valid
             if file_type == "pdf":
@@ -1478,43 +1483,16 @@ def create_area_annotation(
             return f"Error: No attachment found with key: {attachment_key} ({e})"
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            file_path = os.path.join(tmpdir, filename)
-            ctx.info(f"Downloading PDF to {file_path}")
-
-            download_errors = []
-            downloaded = False
-
-            if local_client and not downloaded:
-                try:
-                    ctx.info("Trying local Zotero (WebDAV/local storage)...")
-                    local_client.dump(attachment_key, filename=filename, path=tmpdir)
-                    if os.path.exists(file_path) and os.path.getsize(file_path) > 0:
-                        downloaded = True
-                        ctx.info("PDF downloaded via local Zotero")
-                except Exception as e:
-                    download_errors.append(f"Local Zotero: {e}")
-
-            if not downloaded:
-                try:
-                    ctx.info("Trying Zotero Web API (cloud storage)...")
-                    web_client.dump(attachment_key, filename=filename, path=tmpdir)
-                    if os.path.exists(file_path) and os.path.getsize(file_path) > 0:
-                        downloaded = True
-                        ctx.info("PDF downloaded via Web API")
-                except Exception as e:
-                    download_errors.append(f"Web API: {e}")
-
-            if not downloaded:
-                error_details = "\n".join(f"  - {err}" for err in download_errors)
-                return (
-                    f"Error: Could not download PDF attachment.\n\n"
-                    f"Attempted sources:\n{error_details}\n\n"
-                    "Possible solutions:\n"
-                    "- **Zotero Cloud Storage**: Ensure file syncing is enabled in Zotero preferences\n"
-                    "- **WebDAV Storage**: Ensure Zotero desktop is running with "
-                    "'Allow other applications to communicate with Zotero' enabled\n"
-                    "- **Linked files**: Linked attachments (not imported) cannot be accessed remotely"
-                )
+            file_path, error_message = _download_attachment_for_processing(
+                attachment_key,
+                filename,
+                tmpdir,
+                local_client=local_client,
+                web_client=web_client,
+                ctx=ctx,
+            )
+            if error_message:
+                return error_message
 
             if not verify_pdf_attachment(file_path):
                 return "Error: Downloaded file is not a valid PDF"

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -18,12 +18,12 @@ from zotero_mcp.tools import _helpers
 
 @mcp.tool(
     name="zotero_get_item_metadata",
-    description="Get detailed metadata for a specific Zotero item by its key. If the metadata and abstract don't contain the specific information you need, use zotero_get_item_fulltext to read the full paper — but note that fulltext retrieval is resource-intensive and should not be used for searching; use zotero_search_items or zotero_semantic_search instead."
+    description="Get detailed metadata for a specific Zotero item by its key. Supports format='markdown' for a readable summary, format='json' for the complete raw Zotero item record, and format='bibtex' for citation export. If the metadata and abstract don't contain the specific information you need, use zotero_get_item_fulltext to read the full paper — but note that fulltext retrieval is resource-intensive and should not be used for searching; use zotero_search_items or zotero_semantic_search instead."
 )
 def get_item_metadata(
     item_key: str,
     include_abstract: bool = True,
-    format: Literal["markdown", "bibtex"] = "markdown",
+    format: Literal["markdown", "bibtex", "json"] = "markdown",
     *,
     ctx: Context
 ) -> str:
@@ -33,11 +33,12 @@ def get_item_metadata(
     Args:
         item_key: Zotero item key/ID
         include_abstract: Whether to include the abstract in the output (markdown format only)
-        format: Output format - 'markdown' for detailed metadata or 'bibtex' for BibTeX citation
+        format: Output format - 'markdown' for a readable summary, 'json' for
+            the complete raw Zotero item, or 'bibtex' for BibTeX citation
         ctx: MCP context
 
     Returns:
-        Formatted item metadata (markdown or BibTeX)
+        Formatted item metadata
     """
     _ret_logger = _logging.getLogger("zotero_mcp.retrieval")
     try:
@@ -50,10 +51,11 @@ def get_item_metadata(
         if not item:
             return f"No item found with key: {item_key}"
 
+        if format == "json":
+            return json.dumps(item, ensure_ascii=False, indent=2, sort_keys=True)
         if format == "bibtex":
             return _client.generate_bibtex(item)
-        else:
-            return _client.format_item_metadata(item, include_abstract)
+        return _client.format_item_metadata(item, include_abstract)
 
     except Exception as e:
         ctx.error(f"Error fetching item metadata: {str(e)}")
@@ -170,21 +172,30 @@ def get_item_fulltext(
         try:
             ctx.info(f"Attempting to download and convert attachment {attachment.key}")
 
-            # Download the file to a temporary location
-
             with tempfile.TemporaryDirectory() as tmpdir:
-                file_path = os.path.join(tmpdir, attachment.filename or f"{attachment.key}.pdf")
-                zot.dump(attachment.key, filename=os.path.basename(file_path), path=tmpdir)
+                download = _client.download_attachment_file(
+                    attachment.key,
+                    tmpdir,
+                    attachment.filename or f"{attachment.key}.pdf",
+                    local_client=_client.get_local_zotero_client(),
+                    web_client=None if _utils.is_local_mode() else zot,
+                )
 
-                if os.path.exists(file_path):
-                    ctx.info(f"Downloaded file to {file_path}, converting to markdown")
-                    converted_text = _client.convert_to_markdown(file_path)
+                if download.path and download.path.exists():
+                    ctx.info(f"Downloaded file via {download.source} to {download.path}, converting to markdown")
+                    converted_text = _client.convert_to_markdown(download.path)
                     return _helpers._prepend_size_warning(
                         f"{metadata}\n\n---\n\n## Full Text\n\n{converted_text}",
                         "Consider using zotero_semantic_search to find specific content instead of reading full papers."
                     )
-                else:
-                    return f"{metadata}\n\n---\n\nFile download failed."
+
+                error_details = "\n".join(f"  - {err}" for err in download.errors) or "  - No download source succeeded"
+                return (
+                    f"{metadata}\n\n---\n\nFile download failed.\n\n"
+                    f"Attempted sources:\n{error_details}\n\n"
+                    "For WebDAV-backed attachments, configure "
+                    "ZOTERO_WEBDAV_URL / ZOTERO_WEBDAV_USERNAME / ZOTERO_WEBDAV_PASSWORD."
+                )
         except Exception as download_error:
             ctx.error(f"Error downloading/converting file: {str(download_error)}")
             if local_extract_error_msg:

--- a/src/zotero_mcp/webdav.py
+++ b/src/zotero_mcp/webdav.py
@@ -1,0 +1,141 @@
+"""Helpers for accessing Zotero WebDAV attachment storage."""
+
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path, PurePosixPath
+from urllib.parse import quote
+
+import requests
+
+_PLACEHOLDER_PREFIX = "REPLACE_WITH_YOUR_"
+
+
+class WebDAVNotConfiguredError(RuntimeError):
+    """Raised when WebDAV environment variables are missing."""
+
+
+def _get_env_value(name: str) -> str | None:
+    """Return a non-placeholder environment value, if present."""
+    value = os.getenv(name, "").strip()
+    if not value or value.startswith(_PLACEHOLDER_PREFIX):
+        return None
+    return value
+
+
+def get_webdav_config() -> tuple[str, str, str] | None:
+    """Return configured WebDAV credentials, or None when incomplete."""
+    base_url = _get_env_value("ZOTERO_WEBDAV_URL")
+    username = _get_env_value("ZOTERO_WEBDAV_USERNAME")
+    password = _get_env_value("ZOTERO_WEBDAV_PASSWORD")
+
+    if not all((base_url, username, password)):
+        return None
+
+    return (base_url.rstrip("/") + "/", username, password)
+
+
+def is_webdav_configured() -> bool:
+    """Return True when direct WebDAV access is configured."""
+    return get_webdav_config() is not None
+
+
+def _select_primary_member(
+    members: list[zipfile.ZipInfo], expected_filename: str | None
+) -> zipfile.ZipInfo:
+    """Pick the most likely primary file from a Zotero WebDAV archive."""
+    expected_basename = Path(expected_filename).name.lower() if expected_filename else ""
+    expected_suffix = Path(expected_filename).suffix.lower() if expected_filename else ""
+
+    def _score(info: zipfile.ZipInfo) -> tuple[bool, bool, int, int]:
+        member_path = PurePosixPath(info.filename)
+        basename = member_path.name.lower()
+        suffix = member_path.suffix.lower()
+        return (
+            basename != expected_basename,
+            bool(expected_suffix) and suffix != expected_suffix,
+            len(member_path.parts),
+            len(info.filename),
+        )
+
+    return min(members, key=_score)
+
+
+def _extract_archive(
+    archive_source: bytes | str | Path,
+    destination_dir: str | Path,
+    expected_filename: str | None,
+) -> Path:
+    """Extract a WebDAV attachment zip and return the primary file path."""
+    destination = Path(destination_dir)
+    destination.mkdir(parents=True, exist_ok=True)
+
+    archive_file: io.BytesIO | str | Path
+    if isinstance(archive_source, bytes):
+        archive_file = io.BytesIO(archive_source)
+    else:
+        archive_file = archive_source
+
+    with zipfile.ZipFile(archive_file) as zf:
+        members = [info for info in zf.infolist() if not info.is_dir()]
+        if not members:
+            raise ValueError("WebDAV archive contained no files")
+
+        extracted_paths: dict[str, Path] = {}
+        for info in members:
+            relative = Path(PurePosixPath(info.filename))
+            if relative.is_absolute() or ".." in relative.parts:
+                raise ValueError(f"Unsafe path in WebDAV archive: {info.filename}")
+
+            output_path = destination / relative
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(info) as source, open(output_path, "wb") as target:
+                shutil.copyfileobj(source, target)
+            extracted_paths[info.filename] = output_path
+
+        selected = _select_primary_member(members, expected_filename)
+        return extracted_paths[selected.filename]
+
+
+def download_attachment_from_webdav(
+    attachment_key: str,
+    destination_dir: str | Path,
+    expected_filename: str | None = None,
+    timeout: float = 30.0,
+) -> Path:
+    """Download a WebDAV-backed Zotero attachment and return the primary file path."""
+    config = get_webdav_config()
+    if not config:
+        raise WebDAVNotConfiguredError(
+            "Missing ZOTERO_WEBDAV_URL / ZOTERO_WEBDAV_USERNAME / ZOTERO_WEBDAV_PASSWORD"
+        )
+
+    base_url, username, password = config
+    url = f"{base_url}{quote(attachment_key)}.zip"
+
+    session = requests.Session()
+    session.auth = (username, password)
+    session.trust_env = True
+
+    temp_zip_path = None
+    try:
+        response = session.get(url, timeout=(10.0, timeout), stream=True)
+        if response.status_code == 404:
+            raise FileNotFoundError(f"Attachment {attachment_key} was not found in WebDAV storage")
+        response.raise_for_status()
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as temp_zip:
+            temp_zip_path = temp_zip.name
+            for chunk in response.iter_content(chunk_size=1024 * 64):
+                if chunk:
+                    temp_zip.write(chunk)
+        return _extract_archive(temp_zip_path, destination_dir, expected_filename)
+    finally:
+        if temp_zip_path and os.path.exists(temp_zip_path):
+            os.unlink(temp_zip_path)
+        close = getattr(session, "close", None)
+        if callable(close):
+            close()

--- a/src/zotero_mcp/webdav.py
+++ b/src/zotero_mcp/webdav.py
@@ -87,7 +87,8 @@ def _extract_archive(
 
         extracted_paths: dict[str, Path] = {}
         for info in members:
-            relative = Path(PurePosixPath(info.filename))
+            normalized_name = info.filename.replace("\\", "/")
+            relative = Path(PurePosixPath(normalized_name))
             if relative.is_absolute() or ".." in relative.parts:
                 raise ValueError(f"Unsafe path in WebDAV archive: {info.filename}")
 
@@ -115,7 +116,7 @@ def download_attachment_from_webdav(
         )
 
     base_url, username, password = config
-    url = f"{base_url}{quote(attachment_key)}.zip"
+    url = f"{base_url}{quote(attachment_key, safe='')}.zip"
 
     session = requests.Session()
     session.auth = (username, password)

--- a/tests/test_metadata_formats.py
+++ b/tests/test_metadata_formats.py
@@ -1,0 +1,93 @@
+"""Tests for metadata output formats."""
+
+import json
+
+from zotero_mcp import server
+
+
+class DummyContext:
+    def info(self, *_args, **_kwargs):
+        return None
+
+    def error(self, *_args, **_kwargs):
+        return None
+
+    def warning(self, *_args, **_kwargs):
+        return None
+
+
+class FakeZoteroForMetadata:
+    def __init__(self, item):
+        self._item = item
+
+    def item(self, key):
+        if key != self._item["key"]:
+            raise KeyError(key)
+        return self._item
+
+
+def test_get_item_metadata_json_returns_complete_raw_item(monkeypatch):
+    item = {
+        "key": "ITEM0001",
+        "version": 7,
+        "links": {"self": {"href": "https://api.zotero.org/users/1/items/ITEM0001"}},
+        "meta": {"numChildren": 2},
+        "data": {
+            "key": "ITEM0001",
+            "itemType": "journalArticle",
+            "title": "Genome paper",
+            "date": "2025-01-01",
+            "creators": [{"creatorType": "author", "firstName": "Lin", "lastName": "Wang"}],
+            "abstractNote": "Abstract text",
+            "DOI": "10.1234/example",
+            "url": "https://example.com/paper",
+            "extra": "Citation Key: Wang2025",
+            "relations": {"dc:relation": ["http://zotero.org/users/1/items/ABCD1234"]},
+            "collections": ["COLL0001"],
+            "tags": [{"tag": "seed"}],
+            "language": "en",
+        },
+    }
+    fake = FakeZoteroForMetadata(item)
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+
+    result = server.get_item_metadata("ITEM0001", format="json", ctx=DummyContext())
+    parsed = json.loads(result)
+
+    assert parsed["key"] == "ITEM0001"
+    assert parsed["version"] == 7
+    assert parsed["meta"]["numChildren"] == 2
+    assert parsed["data"]["language"] == "en"
+    assert parsed["data"]["relations"]["dc:relation"] == [
+        "http://zotero.org/users/1/items/ABCD1234"
+    ]
+
+
+def test_get_item_metadata_markdown_remains_readable_summary(monkeypatch):
+    item = {
+        "key": "ITEM0002",
+        "data": {
+            "key": "ITEM0002",
+            "itemType": "journalArticle",
+            "title": "Readable metadata",
+            "date": "2024",
+            "publicationTitle": "Nature Plants",
+            "volume": "10",
+            "issue": "2",
+            "pages": "12-20",
+            "creators": [{"creatorType": "author", "firstName": "Li", "lastName": "Chen"}],
+            "DOI": "10.9999/readable",
+            "tags": [{"tag": "plants"}],
+            "abstractNote": "Summary abstract",
+        },
+        "meta": {"numChildren": 1},
+    }
+    fake = FakeZoteroForMetadata(item)
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+
+    result = server.get_item_metadata("ITEM0002", format="markdown", ctx=DummyContext())
+
+    assert "# Readable metadata" in result
+    assert "**Journal:** Nature Plants, Volume 10, Issue 2, Pages 12-20" in result
+    assert "**DOI:** 10.9999/readable" in result
+    assert "## Abstract" in result

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -61,8 +61,19 @@ def test_download_attachment_from_webdav_extracts_expected_file(tmp_path, monkey
     assert file_path == tmp_path / "paper.pdf"
     assert file_path.read_bytes() == b"%PDF-1.4 webdav test"
     assert session.auth == ("alice", "secret")
-    assert session.trust_env is True
     assert session.requested == [("https://dav.example.com/zotero/ABCD1234.zip", (10.0, 30.0), True)]
+
+
+def test_download_attachment_from_webdav_escapes_attachment_key(tmp_path, monkeypatch):
+    session = _FakeSession(_FakeResponse(_build_zip_bytes("paper.pdf", b"%PDF-1.4 webdav test")))
+    monkeypatch.setenv("ZOTERO_WEBDAV_URL", "https://dav.example.com/zotero")
+    monkeypatch.setenv("ZOTERO_WEBDAV_USERNAME", "alice")
+    monkeypatch.setenv("ZOTERO_WEBDAV_PASSWORD", "secret")
+    monkeypatch.setattr("requests.Session", lambda: session)
+
+    webdav.download_attachment_from_webdav("AB/CD", tmp_path, expected_filename="paper.pdf")
+
+    assert session.requested == [("https://dav.example.com/zotero/AB%2FCD.zip", (10.0, 30.0), True)]
 
 
 def test_download_attachment_file_falls_back_to_webdav(tmp_path, monkeypatch):
@@ -87,5 +98,15 @@ def test_download_attachment_file_falls_back_to_webdav(tmp_path, monkeypatch):
     assert result.source == "WebDAV"
     assert result.errors == [
         "Local Zotero: not available",
-        "Web API: not available",
     ]
+
+
+def test_extract_archive_rejects_backslash_path_traversal(tmp_path):
+    zip_bytes = _build_zip_bytes("..\\evil.txt", b"oops")
+
+    try:
+        webdav._extract_archive(zip_bytes, tmp_path, expected_filename="evil.txt")
+    except ValueError as exc:
+        assert "Unsafe path" in str(exc)
+    else:
+        raise AssertionError("Expected _extract_archive() to reject backslash traversal paths")

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -1,0 +1,91 @@
+"""Tests for direct WebDAV attachment access."""
+
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from zotero_mcp import client, webdav
+
+
+class _FailingZotero:
+    def dump(self, *_args, **_kwargs):
+        raise RuntimeError("not available")
+
+
+class _FakeResponse:
+    def __init__(self, content: bytes, status_code: int = 200):
+        self.content = content
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"http {self.status_code}")
+
+    def iter_content(self, chunk_size=8192):
+        for start in range(0, len(self.content), chunk_size):
+            yield self.content[start:start + chunk_size]
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+        self.auth = None
+        self.trust_env = True
+        self.requested = []
+
+    def get(self, url, timeout=None, stream=False):
+        self.requested.append((url, timeout, stream))
+        return self._response
+
+    def close(self):
+        return None
+
+
+def _build_zip_bytes(name: str, content: bytes) -> bytes:
+    import io
+
+    buf = io.BytesIO()
+    with ZipFile(buf, "w", ZIP_DEFLATED) as zf:
+        zf.writestr(name, content)
+    return buf.getvalue()
+
+
+def test_download_attachment_from_webdav_extracts_expected_file(tmp_path, monkeypatch):
+    session = _FakeSession(_FakeResponse(_build_zip_bytes("paper.pdf", b"%PDF-1.4 webdav test")))
+    monkeypatch.setenv("ZOTERO_WEBDAV_URL", "https://dav.example.com/zotero")
+    monkeypatch.setenv("ZOTERO_WEBDAV_USERNAME", "alice")
+    monkeypatch.setenv("ZOTERO_WEBDAV_PASSWORD", "secret")
+    monkeypatch.setattr("requests.Session", lambda: session)
+
+    file_path = webdav.download_attachment_from_webdav("ABCD1234", tmp_path, expected_filename="paper.pdf")
+
+    assert file_path == tmp_path / "paper.pdf"
+    assert file_path.read_bytes() == b"%PDF-1.4 webdav test"
+    assert session.auth == ("alice", "secret")
+    assert session.trust_env is True
+    assert session.requested == [("https://dav.example.com/zotero/ABCD1234.zip", (10.0, 30.0), True)]
+
+
+def test_download_attachment_file_falls_back_to_webdav(tmp_path, monkeypatch):
+    webdav_path = tmp_path / "nested" / "paper.pdf"
+    webdav_path.parent.mkdir()
+    webdav_path.write_bytes(b"%PDF-1.4")
+
+    monkeypatch.setattr(
+        "zotero_mcp.client.download_attachment_from_webdav",
+        lambda attachment_key, destination_dir, expected_filename=None: webdav_path,
+    )
+
+    result = client.download_attachment_file(
+        "ABCD1234",
+        tmp_path,
+        "paper.pdf",
+        local_client=_FailingZotero(),
+        web_client=_FailingZotero(),
+    )
+
+    assert result.path == webdav_path
+    assert result.source == "WebDAV"
+    assert result.errors == [
+        "Local Zotero: not available",
+        "Web API: not available",
+    ]

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -1,6 +1,5 @@
 """Tests for direct WebDAV attachment access."""
 
-from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from zotero_mcp import client, webdav


### PR DESCRIPTION
## Summary
  - add direct WebDAV attachment fallback for remote setups
  - reuse the unified attachment download cascade in fulltext + annotation flows
  - add `format="json"` to `zotero_get_item_metadata` for complete raw Zotero metadata
  - obfuscate WebDAV credentials in CLI config display
  - document the new WebDAV env vars and metadata format

  ## Why
  Remote Zotero setups can have complete metadata via the Zotero API while storing attachment files in WebDAV. This change keeps metadata authoritative in Zotero and adds a file-access fallback for WebDAV-backed attachments, while also exposing full raw item metadata when clients need field-complete results.

  ## Notes
  - metadata and attachment access remain separate paths
  - markdown metadata output is preserved
  - WebDAV is only used for attachment bytes, not metadata