### PR TITLE
fix: zotero_get_collection_items returns unrelated library items for unknown keys

### DIFF
--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -332,12 +332,20 @@ def get_collection_items(
         ctx.info(f"Fetching items for collection {collection_key}")
         zot = _client.get_zotero_client()
 
-        # First get the collection details
+        # First get the collection details. Fail fast on lookup error: the
+        # Zotero web API returns library-wide items for invalid or not-yet-
+        # propagated collection keys rather than 404ing, so we must not fall
+        # through to collection_items() when we can't confirm the collection
+        # exists.
         try:
             collection = zot.collection(collection_key)
             collection_name = collection["data"].get("name", "Unnamed Collection")
-        except Exception:
-            collection_name = f"Collection {collection_key}"
+        except Exception as e:
+            ctx.error(f"Collection lookup failed for {collection_key}: {e}")
+            return (
+                f"Collection not found or not yet accessible: `{collection_key}`. "
+                f"If you just created this collection, wait a moment and try again."
+            )
 
         limit = _helpers._normalize_limit(limit, default=50)
 

--- a/tests/test_token_optimization.py
+++ b/tests/test_token_optimization.py
@@ -445,3 +445,53 @@ class TestBuildAttachmentExtra:
         result2 = _build_attachment_extra({"has_pdf": False, "attachment_count": 2, "has_notes": False})
         assert "1 attachment" in result1["Attachments"]
         assert "2 attachments" in result2["Attachments"]
+
+
+# ---------------------------------------------------------------------------
+# Race condition: unknown / not-yet-propagated collection key
+# ---------------------------------------------------------------------------
+
+class RacyFakeZotero(FakeZotero):
+    """Simulates the Zotero web API's behavior for an unknown or
+    not-yet-propagated collection key: ``collection()`` 404s, but
+    ``collection_items()`` returns unrelated library-wide items instead
+    of erroring. This is the shape that produced the bug in production."""
+
+    def __init__(self, library_items):
+        super().__init__()
+        self._library_items = library_items
+
+    def collection(self, key, **kwargs):
+        raise Exception(f"Code: 404 — Not found: collection {key}")
+
+    def collection_items(self, key, *args, **kwargs):
+        return self._library_items
+
+
+class TestCollectionItemsRace:
+    def test_unknown_collection_returns_error_not_library_items(
+        self, monkeypatch, dummy_ctx
+    ):
+        """When ``zot.collection(key)`` fails, the tool must return a
+        clear error instead of falling through to ``collection_items()``,
+        which may return library-wide items for an unknown key."""
+        library = [
+            _make_parent("X1", "Unrelated Paper One", collections=["OTHER"]),
+            _make_parent("X2", "Unrelated Paper Two", collections=["OTHER"]),
+        ]
+        zot = RacyFakeZotero(library_items=library)
+        monkeypatch.setattr(
+            "zotero_mcp.tools.retrieval._client.get_zotero_client", lambda: zot
+        )
+        from zotero_mcp.tools.retrieval import get_collection_items
+
+        result = get_collection_items(
+            collection_key="FRESHKEY", detail="keys_only", ctx=dummy_ctx
+        )
+
+        assert "not found" in result.lower() or "not yet accessible" in result.lower()
+        assert "FRESHKEY" in result
+        assert "Unrelated Paper One" not in result
+        assert "Unrelated Paper Two" not in result
+        assert "X1" not in result
+        assert "X2" not in result


### PR DESCRIPTION
## Summary

- `zotero_get_collection_items` silently swallowed errors from `zot.collection(key)` and fell through to `zot.collection_items(key)`. For an unknown or not-yet-propagated collection key, pyzotero returns library-wide items rather than 404ing, so the tool reported hundreds or thousands of unrelated items under a fallback name like `Collection ABC123`.
- Fix: fail fast. If `zot.collection(key)` raises, return a clear error instead of calling `collection_items()`.

## Reproduction

Observed on the Zotero web API by creating a subcollection and immediately querying it:

```
# Items in Collection: Collection 6KVG3ZBK (1665 items)
- RTKZQI8E | Model Context Protocol (MCP) Tool Descriptions Are Smelly!... [PDF]
- J3R3ZGH8 | Trials of Belonging... (not in this collection)
- B83QA2T9 | Expelling the Poor... (not in this collection)
...
```

A second call a few seconds later correctly returned "No items found" — confirming an API propagation race. `zotero_search_items` with the same fresh key correctly returned empty, so the bug is specific to this tool.

## Test

The new test `TestCollectionItemsRace` stubs a `zot` where `collection()` raises but `collection_items()` returns unrelated items — faithfully reproducing the production bug shape. **The test fails against the unpatched code** and passes with the fix. Verified both directions locally.

## Test plan
- [x] New test fails on unfixed code (reproduces the bug)
- [x] New test passes with the fix
- [x] All 26 tests in `test_token_optimization.py` pass
- [ ] Maintainer sanity-check on Zotero's actual `collection_items()` behavior for unknown keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)