### PR TITLE
improve collection tool descriptions; add zotero_delete_collection

### DIFF
--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -97,6 +97,7 @@ from zotero_mcp.tools.annotations import (  # noqa: F401
 from zotero_mcp.tools.write import (  # noqa: F401
     batch_update_tags,
     create_collection,
+    delete_collection,
     search_collections,
     manage_collections,
     add_by_doi,

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -201,7 +201,15 @@ def get_item_fulltext(
 
 @mcp.tool(
     name="zotero_get_collections",
-    description="List all collections in your Zotero library."
+    description=(
+        "List all collections in your Zotero library as a hierarchical tree "
+        "(parents and nested subcollections, each with its 8-character key). "
+        "Use this when the user wants to see the full library structure. "
+        "If you already know a name and just need the key, prefer "
+        "zotero_search_collections — it returns only matches. "
+        "Default limit is 100; pass limit up to 5000 for larger libraries. "
+        "Example: zotero_get_collections() → a markdown tree of all collections."
+    )
 )
 def get_collections(
     limit: int | str | None = None,

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -268,8 +268,59 @@ def create_collection(
 
 
 @mcp.tool(
+    name="zotero_delete_collection",
+    description=(
+        "Delete a collection (folder) from your Zotero library by its "
+        "8-character key. Items inside the collection are NOT deleted — they "
+        "remain in the library (and in any other collections they belong to). "
+        "Subcollections ARE deleted along with the parent. "
+        "This is a hard delete — Zotero's API does not trash collections, so "
+        "the operation cannot be undone via the API. Use "
+        "zotero_search_collections to find the key first. "
+        'Example: zotero_delete_collection(collection_key="KMMQDFQ4").'
+    )
+)
+def delete_collection(
+    collection_key: str,
+    *,
+    ctx: Context
+) -> str:
+    try:
+        _read_zot, write_zot = _helpers._get_write_client(ctx)
+    except ValueError as e:
+        return str(e)
+
+    try:
+        ctx.info(f"Deleting collection {collection_key}")
+
+        try:
+            coll = write_zot.collection(collection_key)
+        except Exception as e:
+            return f"Collection not found: `{collection_key}` ({e})"
+
+        name = coll.get("data", {}).get("name", collection_key)
+        resp = write_zot.delete_collection(coll)
+        if _helpers._handle_write_response(resp, ctx):
+            return f"Deleted collection \"{name}\" (`{collection_key}`)"
+        return f"Failed to delete collection `{collection_key}`: {resp}"
+
+    except Exception as e:
+        ctx.error(f"Error deleting collection: {e}")
+        return f"Error deleting collection: {e}"
+
+
+@mcp.tool(
     name="zotero_search_collections",
-    description="Search for collections by name to find their keys."
+    description=(
+        "Search collections by name and return their 8-character keys. "
+        "Matching is case-insensitive substring, with multi-word queries "
+        "ANDed across words (NOT OR-ed): query 'reading list' matches only "
+        "collections whose name contains both 'reading' AND 'list'. "
+        "To match either word, issue two separate searches. "
+        "Returns the collection's key plus its parent (if any). "
+        'Example: zotero_search_collections(query="orals") → keys for every '
+        'collection with "orals" in its name.'
+    )
 )
 def search_collections(
     query: str,

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -28,6 +28,7 @@ class FakeZoteroCollections(FakeZotero):
         self.added_to_collections = []   # (collection_key, items)
         self.removed_from_collections = []  # (collection_key, item)
         self.created_collections = []
+        self.deleted_collections = []
 
     def create_collections(self, colls, **kwargs):
         self.created_collections.extend(colls)
@@ -42,6 +43,16 @@ class FakeZoteroCollections(FakeZotero):
 
     def deletefrom_collection(self, collection_key, item, **kwargs):
         self.removed_from_collections.append((collection_key, item))
+        return _FakeResponse(204)
+
+    def collection(self, key, **kwargs):
+        for c in self._collections:
+            if c.get("key") == key:
+                return c
+        raise Exception(f"Code: 404 — Not found: collection {key}")
+
+    def delete_collection(self, collection, **kwargs):
+        self.deleted_collections.append(collection)
         return _FakeResponse(204)
 
 
@@ -491,3 +502,40 @@ class TestManageCollections:
 
         # Both items should be added to the collection
         assert "success" in result.lower() or "added" in result.lower()
+
+
+# ===========================================================================
+# Feature 4: zotero_delete_collection
+# ===========================================================================
+
+
+class TestDeleteCollection:
+    """Tests for the delete_collection tool function."""
+
+    def test_deletes_existing_collection(self, monkeypatch, fake_zot, ctx):
+        _patch_web_only(monkeypatch, fake_zot)
+
+        result = server.delete_collection(collection_key="ABC00001", ctx=ctx)
+
+        assert len(fake_zot.deleted_collections) == 1
+        assert fake_zot.deleted_collections[0]["key"] == "ABC00001"
+        assert "Deleted" in result
+        assert "Machine Learning" in result
+        assert "ABC00001" in result
+
+    def test_unknown_key_returns_error(self, monkeypatch, fake_zot, ctx):
+        _patch_web_only(monkeypatch, fake_zot)
+
+        result = server.delete_collection(collection_key="NOPEKEY1", ctx=ctx)
+
+        assert fake_zot.deleted_collections == []
+        assert "not found" in result.lower()
+        assert "NOPEKEY1" in result
+
+    def test_local_only_mode_rejected(self, monkeypatch, fake_zot, ctx):
+        _patch_local_only(monkeypatch, fake_zot)
+
+        result = server.delete_collection(collection_key="ABC00001", ctx=ctx)
+
+        assert "local-only mode" in result
+        assert fake_zot.deleted_collections == []


### PR DESCRIPTION
## Summary

Applies the tool-description rubric from Hasan et al., *"Model Context Protocol (MCP) Tool Descriptions Are Smelly! Towards Improving AI Agent Efficiency with Augmented MCP Tool Descriptions"* ([arXiv:2602.14878](https://arxiv.org/abs/2602.14878)) to this server's collection-level tools.

Their headline finding: **97.1% of MCP tool descriptions analyzed contain at least one smell**, and resolving smells across all six rubric components (purpose, guidelines, limitations, parameter explanation, examples, length/completeness) lifts median task success rates by 5.85 pp.

Scoring our five collection tools against the rubric, two scored low:

| Tool | Score (old) |
|---|---|
| `zotero_get_collections` | 10/25 |
| `zotero_search_collections` | 8/25 |

Both stated a purpose but gave no guidelines, examples, or hint at non-obvious semantics.

## Changes

- **`zotero_search_collections`**: the old one-liner *"Search for collections by name to find their keys"* didn't reveal that multi-word queries are ANDed (not OR-ed) across words, nor that matching is case-insensitive substring. New description states both explicitly, with a worked example.
- **`zotero_get_collections`**: old description didn't distinguish it from `search_collections`, omitted the default 100 / max 5000 limit, and had no example. New description addresses all three.
- **New tool `zotero_delete_collection`**: no delete-collection tool existed, making it impossible to programmatically clean up scratch collections created by an agent. Zotero's API does a hard delete on collections (no trash equivalent), so the description warns explicitly and notes that items in the collection remain in the library (including in any other collections they belong to). Subcollections are deleted with the parent.

## Test plan
- [x] New `TestDeleteCollection` covers: happy path, unknown-key error (no write call), local-only-mode rejection.
- [x] All 30 tests in `test_collections.py` pass.
- [ ] Maintainer review of the rubric-based description rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)