### PR TITLE
feat: add zotero_delete_collection tool

### DIFF
--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -97,6 +97,7 @@ from zotero_mcp.tools.annotations import (  # noqa: F401
 from zotero_mcp.tools.write import (  # noqa: F401
     batch_update_tags,
     create_collection,
+    delete_collection,
     search_collections,
     manage_collections,
     add_by_doi,

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -268,6 +268,48 @@ def create_collection(
 
 
 @mcp.tool(
+    name="zotero_delete_collection",
+    description=(
+        "Delete a collection (folder) from your Zotero library by its "
+        "8-character key. Items inside the collection are NOT deleted — they "
+        "remain in the library (and in any other collections they belong to). "
+        "Subcollections ARE deleted along with the parent. "
+        "This is a hard delete — Zotero's API does not trash collections, so "
+        "the operation cannot be undone via the API. Use "
+        "zotero_search_collections to find the key first. "
+        'Example: zotero_delete_collection(collection_key="KMMQDFQ4").'
+    )
+)
+def delete_collection(
+    collection_key: str,
+    *,
+    ctx: Context
+) -> str:
+    try:
+        _read_zot, write_zot = _helpers._get_write_client(ctx)
+    except ValueError as e:
+        return str(e)
+
+    try:
+        ctx.info(f"Deleting collection {collection_key}")
+
+        try:
+            coll = write_zot.collection(collection_key)
+        except Exception as e:
+            return f"Collection not found: `{collection_key}` ({e})"
+
+        name = coll.get("data", {}).get("name", collection_key)
+        resp = write_zot.delete_collection(coll)
+        if _helpers._handle_write_response(resp, ctx):
+            return f"Deleted collection \"{name}\" (`{collection_key}`)"
+        return f"Failed to delete collection `{collection_key}`: {resp}"
+
+    except Exception as e:
+        ctx.error(f"Error deleting collection: {e}")
+        return f"Error deleting collection: {e}"
+
+
+@mcp.tool(
     name="zotero_search_collections",
     description="Search for collections by name to find their keys."
 )

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -28,6 +28,7 @@ class FakeZoteroCollections(FakeZotero):
         self.added_to_collections = []   # (collection_key, items)
         self.removed_from_collections = []  # (collection_key, item)
         self.created_collections = []
+        self.deleted_collections = []
 
     def create_collections(self, colls, **kwargs):
         self.created_collections.extend(colls)
@@ -42,6 +43,16 @@ class FakeZoteroCollections(FakeZotero):
 
     def deletefrom_collection(self, collection_key, item, **kwargs):
         self.removed_from_collections.append((collection_key, item))
+        return _FakeResponse(204)
+
+    def collection(self, key, **kwargs):
+        for c in self._collections:
+            if c.get("key") == key:
+                return c
+        raise Exception(f"Code: 404 — Not found: collection {key}")
+
+    def delete_collection(self, collection, **kwargs):
+        self.deleted_collections.append(collection)
         return _FakeResponse(204)
 
 
@@ -491,3 +502,40 @@ class TestManageCollections:
 
         # Both items should be added to the collection
         assert "success" in result.lower() or "added" in result.lower()
+
+
+# ===========================================================================
+# Feature 4: zotero_delete_collection
+# ===========================================================================
+
+
+class TestDeleteCollection:
+    """Tests for the delete_collection tool function."""
+
+    def test_deletes_existing_collection(self, monkeypatch, fake_zot, ctx):
+        _patch_web_only(monkeypatch, fake_zot)
+
+        result = server.delete_collection(collection_key="ABC00001", ctx=ctx)
+
+        assert len(fake_zot.deleted_collections) == 1
+        assert fake_zot.deleted_collections[0]["key"] == "ABC00001"
+        assert "Deleted" in result
+        assert "Machine Learning" in result
+        assert "ABC00001" in result
+
+    def test_unknown_key_returns_error(self, monkeypatch, fake_zot, ctx):
+        _patch_web_only(monkeypatch, fake_zot)
+
+        result = server.delete_collection(collection_key="NOPEKEY1", ctx=ctx)
+
+        assert fake_zot.deleted_collections == []
+        assert "not found" in result.lower()
+        assert "NOPEKEY1" in result
+
+    def test_local_only_mode_rejected(self, monkeypatch, fake_zot, ctx):
+        _patch_local_only(monkeypatch, fake_zot)
+
+        result = server.delete_collection(collection_key="ABC00001", ctx=ctx)
+
+        assert "local-only mode" in result
+        assert fake_zot.deleted_collections == []


### PR DESCRIPTION
## Summary

Before this change there was no way to delete a collection via MCP. This made it impossible to programmatically clean up scratch or test collections created by an agent during a session — a gap surfaced while evaluating the collection-level tools against the tool-description rubric from Hasan et al. ([arXiv:2602.14878](https://arxiv.org/abs/2602.14878)).

## Notes on the API

Zotero's web API does a **hard delete** on collections (unlike items/notes, there is no trash equivalent), so the tool description explicitly warns and clarifies two easy-to-miss behaviors:

- items inside the collection are **NOT** deleted (they remain in the library and in any other collections they belong to)
- subcollections **ARE** deleted along with the parent

## Test plan
- [x] `TestDeleteCollection` covers: happy path, unknown-key error (no write call), local-only-mode rejection.
- [x] All 30 tests in `test_collections.py` pass.

_Split from a previous combined PR; the description improvements for `zotero_get_collections` and `zotero_search_collections` are in [#254](https://github.com/54yyyu/zotero-mcp/pull/254)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)