### PR TITLE
feat(semantic): fulltext via web API + since-based incremental sync

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -628,6 +628,19 @@ class ChromaClient:
         except Exception:
             return set()
 
+    def get_all_ids(self) -> set[str]:
+        """Return every id currently stored in the collection.
+
+        Used by incremental sync to compute deletions: items in the local
+        collection but no longer present in the Zotero library.
+        """
+        try:
+            result = self.collection.get(include=[])
+            return set(result.get("ids", []))
+        except Exception as e:
+            logger.error(f"Error listing collection ids: {e}")
+            return set()
+
 
 def create_chroma_client(config_path: str | None = None) -> ChromaClient:
     """

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -142,8 +142,46 @@ class ZoteroSemanticSearch:
 
         return config
 
-    def _save_update_config(self) -> None:
-        """Save update configuration to file."""
+    def _load_include_fulltext_setting(self) -> bool:
+        """Whether to fetch fulltext via the Zotero web API during indexing.
+
+        Defaults to True so existing users auto-upgrade to fulltext indexing on
+        their next sync. Users can opt out by setting
+        `semantic_search.include_fulltext: false` in the config file.
+        Local mode (`ZOTERO_LOCAL=true`) keeps using `extract_fulltext` via
+        the local sqlite DB; this setting only governs web-API ingestion.
+        """
+        if not self.config_path or not os.path.exists(self.config_path):
+            return True
+        try:
+            with open(self.config_path) as f:
+                file_config = json.load(f)
+                value = file_config.get("semantic_search", {}).get("include_fulltext", True)
+                return bool(value)
+        except Exception as e:
+            logger.warning(f"Error loading include_fulltext setting: {e}")
+            return True
+
+    def _load_last_sync_version(self) -> int:
+        """Last Zotero library version fully indexed into ChromaDB.
+
+        Zero means "no prior successful sync; bootstrap required". Used to
+        drive since-based incremental ingest via pyzotero's
+        `item_versions(since=V)` and `new_fulltext(since=V)`.
+        """
+        if not self.config_path or not os.path.exists(self.config_path):
+            return 0
+        try:
+            with open(self.config_path) as f:
+                file_config = json.load(f)
+                value = file_config.get("semantic_search", {}).get("last_sync_version", 0)
+                return int(value) if value is not None else 0
+        except Exception as e:
+            logger.warning(f"Error loading last_sync_version: {e}")
+            return 0
+
+    def _save_update_config(self, last_sync_version: int | None = None) -> None:
+        """Save update configuration and optionally update last_sync_version."""
         if not self.config_path:
             return
 
@@ -164,6 +202,8 @@ class ZoteroSemanticSearch:
             full_config["semantic_search"] = {}
 
         full_config["semantic_search"]["update_config"] = self.update_config
+        if last_sync_version is not None:
+            full_config["semantic_search"]["last_sync_version"] = int(last_sync_version)
 
         try:
             with open(self.config_path, 'w') as f:
@@ -298,19 +338,32 @@ class ZoteroSemanticSearch:
 
         return False
 
-    def _get_items_from_source(self, limit: int | None = None, extract_fulltext: bool = False, chroma_client: ChromaClient | None = None, force_rebuild: bool = False) -> list[dict[str, Any]]:
+    def _get_items_from_source(self,
+                               limit: int | None = None,
+                               extract_fulltext: bool = False,
+                               chroma_client: ChromaClient | None = None,
+                               force_rebuild: bool = False,
+                               include_fulltext_via_api: bool = False,
+                               ) -> list[dict[str, Any]]:
         """
         Get items from either local database or API.
 
         When extract_fulltext=True, requires local mode (ZOTERO_LOCAL=true);
-        raises RuntimeError if local mode is not enabled.
-        Otherwise uses API (faster, metadata-only).
+        raises RuntimeError if local mode is not enabled. This path reads the
+        local Zotero sqlite database and extracts PDF text on-disk.
+
+        When include_fulltext_via_api=True (web-API mode), fetches the
+        server-side extracted fulltext that Zotero cloud has already built
+        for each PDF — no local files required.
+
+        Otherwise uses API metadata only (fastest, title/abstract/tags).
 
         Args:
             limit: Optional limit on number of items
-            extract_fulltext: Whether to extract fulltext content
+            extract_fulltext: Whether to extract fulltext from the local sqlite DB
             chroma_client: ChromaDB client to check for existing documents (None to skip checks)
             force_rebuild: Whether to force extraction even if item exists
+            include_fulltext_via_api: Fetch fulltext via the Zotero web API
 
         Returns:
             List of items in API-compatible format
@@ -328,7 +381,7 @@ class ZoteroSemanticSearch:
                 force_rebuild=force_rebuild
             )
         else:
-            return self._get_items_from_api(limit)
+            return self._get_items_from_api(limit, include_fulltext=include_fulltext_via_api)
 
     def _get_items_from_local_db(self, limit: int | None = None, extract_fulltext: bool = False, chroma_client: ChromaClient | None = None, force_rebuild: bool = False) -> list[dict[str, Any]]:
         """
@@ -695,12 +748,119 @@ class ZoteroSemanticSearch:
 
         return creators
 
-    def _get_items_from_api(self, limit: int | None = None) -> list[dict[str, Any]]:
+    def _fetch_fulltext_via_web_api(self, item_key: str) -> tuple[str, str]:
+        """Fetch fulltext for a top-level item via the Zotero web API.
+
+        Zotero's cloud keeps a server-side extracted text for every PDF that
+        the desktop client has ever indexed. Web-API mode can retrieve that
+        text without needing the PDF file to be present locally.
+
+        The fulltext usually lives on the PDF attachment child, not the
+        parent. We first try the parent's own key (covers the case where the
+        parent is itself an attachment), then cascade through PDF attachment
+        children.
+
+        Returns:
+            (text, source) where source describes which endpoint supplied the
+            text (e.g. "web-api:parent", "web-api:attachment:<key>"). Empty
+            strings mean no fulltext is available for this item.
+        """
+        def _extract_content(resp: Any) -> str:
+            if isinstance(resp, dict):
+                return str(resp.get("content", "") or "")
+            if isinstance(resp, str):
+                return resp
+            return ""
+
+        # 1. Try the item itself (works when item_key IS the attachment key).
+        try:
+            resp = self.zotero_client.fulltext_item(item_key)
+            text = _extract_content(resp)
+            if text.strip():
+                return text, "web-api:parent"
+        except Exception as e:
+            logger.debug(f"fulltext_item({item_key}) failed: {e}")
+
+        # 2. Walk PDF attachment children and try each in order.
+        try:
+            children = self.zotero_client.children(item_key) or []
+        except Exception as e:
+            logger.debug(f"children({item_key}) failed: {e}")
+            children = []
+
+        for child in children:
+            data = child.get("data", {}) if isinstance(child, dict) else {}
+            if data.get("itemType") != "attachment":
+                continue
+            if data.get("contentType") != "application/pdf":
+                continue
+            child_key = child.get("key") or data.get("key")
+            if not child_key:
+                continue
+            try:
+                resp = self.zotero_client.fulltext_item(child_key)
+            except Exception as e:
+                logger.debug(f"fulltext_item({child_key}) failed: {e}")
+                continue
+            text = _extract_content(resp)
+            if text.strip():
+                return text, f"web-api:attachment:{child_key}"
+
+        return "", ""
+
+    def _attach_web_fulltext(self, items: list[dict[str, Any]]) -> None:
+        """Populate `data.fulltext` on each item in place using the web API."""
+        total = len(items)
+        if not total:
+            return
+        try:
+            sys.stderr.write(f"\nFetching fulltext for {total} items via web API...\n")
+            sys.stderr.flush()
+        except Exception:
+            pass
+        fetched = 0
+        for idx, item in enumerate(items, 1):
+            key = item.get("key", "")
+            data = item.setdefault("data", {})
+            # Skip items that obviously can't have fulltext
+            if data.get("itemType") in {"note", "annotation"}:
+                data["fulltext_attempted"] = True
+                continue
+            if not key:
+                continue
+            text, source = self._fetch_fulltext_via_web_api(key)
+            if text:
+                data["fulltext"] = text
+                data["fulltextSource"] = source
+                fetched += 1
+            else:
+                data["fulltext_attempted"] = True
+            if idx % 25 == 0 or idx == total:
+                try:
+                    sys.stderr.write(
+                        f"\r  Fulltext: {idx}/{total} items checked, "
+                        f"{fetched} with text"
+                    )
+                    sys.stderr.flush()
+                except Exception:
+                    pass
+        try:
+            sys.stderr.write("\n")
+        except Exception:
+            pass
+
+    def _get_items_from_api(self,
+                            limit: int | None = None,
+                            include_fulltext: bool = False) -> list[dict[str, Any]]:
         """
         Get items from Zotero API (original implementation).
 
         Args:
             limit: Optional limit on number of items
+            include_fulltext: If True, fetch server-side extracted PDF text
+                via pyzotero's fulltext_item endpoint for each returned
+                top-level item. Enables full-text semantic indexing without
+                requiring local Zotero mode.
 
         Returns:
             List of items from API
@@ -748,20 +908,83 @@ class ZoteroSemanticSearch:
         if limit:
             all_items = all_items[:limit]
 
+        if include_fulltext:
+            self._attach_web_fulltext(all_items)
+
         logger.info(f"Retrieved {len(all_items)} items from API")
         return all_items
+
+    def _get_changed_items_from_api(self,
+                                    since_version: int,
+                                    include_fulltext: bool = False
+                                    ) -> tuple[list[dict[str, Any]], set[str]]:
+        """Fetch only items changed in the Zotero library since a given version.
+
+        Uses pyzotero's `item_versions(since=V)` to discover changed top-level
+        item keys, then fetches their full payloads one at a time. When
+        `include_fulltext` is True, also fetches server-side extracted text
+        for each changed item.
+
+        Returns:
+            (changed_items, all_current_top_level_keys). The second element
+            powers deletion detection: any id present in the ChromaDB
+            collection but absent from it has been removed from the library.
+        """
+        logger.info(f"Fetching changed items since library version {since_version}...")
+        try:
+            changed_versions = self.zotero_client.item_versions(since=since_version) or {}
+        except Exception as e:
+            raise Exception(f"Failed to fetch item_versions(since={since_version}): {e}") from e
+
+        try:
+            current_versions = self.zotero_client.item_versions() or {}
+        except Exception as e:
+            logger.warning(f"Failed to fetch current item_versions for deletion check: {e}")
+            current_versions = {}
+        current_keys = set(current_versions.keys())
+
+        if not changed_versions:
+            return [], current_keys
+
+        changed_items: list[dict[str, Any]] = []
+        for key in changed_versions.keys():
+            try:
+                item = self.zotero_client.item(key)
+            except Exception as e:
+                logger.debug(f"item({key}) failed during incremental fetch: {e}")
+                continue
+            if not item:
+                continue
+            item_type = item.get("data", {}).get("itemType")
+            # Don't index attachments/notes as standalone entries; only
+            # top-level research items participate in semantic search.
+            if item_type in {"attachment", "note", "annotation"}:
+                continue
+            changed_items.append(item)
+
+        if include_fulltext and changed_items:
+            self._attach_web_fulltext(changed_items)
+
+        return changed_items, current_keys
 
     def update_database(self,
                        force_full_rebuild: bool = False,
                        limit: int | None = None,
-                       extract_fulltext: bool = False) -> dict[str, Any]:
+                       extract_fulltext: bool = False,
+                       include_fulltext: bool | None = None) -> dict[str, Any]:
         """
         Update the semantic search database with Zotero items.
 
         Args:
             force_full_rebuild: Whether to rebuild the entire database
             limit: Limit number of items to process (for testing)
-            extract_fulltext: Whether to extract fulltext content from local database
+            extract_fulltext: Whether to extract fulltext content from the
+                local Zotero sqlite database (requires ZOTERO_LOCAL=true)
+            include_fulltext: Whether to fetch server-side extracted
+                fulltext via the Zotero web API. Defaults to the
+                `semantic_search.include_fulltext` config setting (True
+                unless explicitly disabled). Ignored in local mode since
+                `extract_fulltext` provides richer local extraction.
 
         Returns:
             Update statistics
@@ -776,24 +999,101 @@ class ZoteroSemanticSearch:
             "updated_items": 0,
             "recovered_items": 0,
             "skipped_items": 0,
+            "deleted_items": 0,
             "errors": 0,
             "start_time": start_time.isoformat(),
             "duration": None
         }
 
         try:
+            # Resolve include_fulltext default from config if not specified
+            if include_fulltext is None:
+                include_fulltext = self._load_include_fulltext_setting()
+
+            # Web-API fulltext only applies when not using the local sqlite
+            # extractor (extract_fulltext=True takes precedence in local mode)
+            include_fulltext_via_api = include_fulltext and not extract_fulltext
+
             # Reset collection if force rebuild
             if force_full_rebuild:
                 logger.info("Force rebuilding database...")
                 self.chroma_client.reset_collection()
 
-            # Get all items from either local DB or API
-            all_items = self._get_items_from_source(
-                limit=limit,
-                extract_fulltext=extract_fulltext,
-                chroma_client=self.chroma_client if not force_full_rebuild else None,
-                force_rebuild=force_full_rebuild
+            # Decide whether to use since-based incremental ingest.
+            # Incremental requires: not a forced rebuild, not a local-extraction
+            # run (incremental path covers web-API metadata and optionally
+            # fulltext only), not a test limit, and a known prior sync version.
+            last_sync_version = self._load_last_sync_version() if not force_full_rebuild else 0
+            use_incremental = (
+                not force_full_rebuild
+                and not extract_fulltext
+                and limit is None
+                and last_sync_version > 0
             )
+
+            target_sync_version: int | None = None
+            all_items: list[dict[str, Any]] = []
+            if use_incremental:
+                try:
+                    target_sync_version = self.zotero_client.last_modified_version()
+                except Exception as e:
+                    logger.warning(f"last_modified_version() failed, falling back to full scan: {e}")
+                    use_incremental = False
+
+            if use_incremental and target_sync_version == last_sync_version:
+                # No changes since last sync; skip ingest but still touch last_update
+                try:
+                    sys.stderr.write(
+                        f"\nLibrary unchanged since last sync (version {last_sync_version}); "
+                        f"no items to reindex.\n"
+                    )
+                except Exception:
+                    pass
+                self.update_config["last_update"] = datetime.now().isoformat()
+                self._save_update_config(last_sync_version=target_sync_version)
+                end_time = datetime.now()
+                stats["duration"] = str(end_time - start_time)
+                stats["end_time"] = end_time.isoformat()
+                return stats
+
+            if use_incremental:
+                all_items, current_library_keys = self._get_changed_items_from_api(
+                    since_version=last_sync_version,
+                    include_fulltext=include_fulltext_via_api,
+                )
+                # Delete collection entries that are no longer present in the library
+                try:
+                    stored_ids = self.chroma_client.get_all_ids()
+                    to_delete = [k for k in (stored_ids - current_library_keys) if k]
+                    if to_delete:
+                        self.chroma_client.delete_documents(to_delete)
+                        stats["deleted_items"] = len(to_delete)
+                        try:
+                            sys.stderr.write(
+                                f"\nDeleted {len(to_delete)} items no longer present in Zotero.\n"
+                            )
+                        except Exception:
+                            pass
+                except Exception as e:
+                    logger.warning(f"Deletion pass failed: {e}")
+            else:
+                # Full scan: bootstrap or forced rebuild.
+                if not force_full_rebuild:
+                    # Capture the library version BEFORE scanning so any
+                    # changes made during the scan will be picked up by the
+                    # next incremental run.
+                    try:
+                        target_sync_version = self.zotero_client.last_modified_version()
+                    except Exception as e:
+                        logger.warning(f"last_modified_version() failed: {e}")
+                        target_sync_version = None
+                all_items = self._get_items_from_source(
+                    limit=limit,
+                    extract_fulltext=extract_fulltext,
+                    chroma_client=self.chroma_client if not force_full_rebuild else None,
+                    force_rebuild=force_full_rebuild,
+                    include_fulltext_via_api=include_fulltext_via_api,
+                )
 
             stats["total_items"] = len(all_items)
             logger.info(f"Found {stats['total_items']} items to process")
@@ -883,9 +1183,9 @@ class ZoteroSemanticSearch:
             except Exception:
                 pass
 
-            # Update last update time
+            # Update last update time, and promote last_sync_version on success
             self.update_config["last_update"] = datetime.now().isoformat()
-            self._save_update_config()
+            self._save_update_config(last_sync_version=target_sync_version)
 
             end_time = datetime.now()
             stats["duration"] = str(end_time - start_time)

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -1078,15 +1078,18 @@ class ZoteroSemanticSearch:
                     logger.warning(f"Deletion pass failed: {e}")
             else:
                 # Full scan: bootstrap or forced rebuild.
-                if not force_full_rebuild:
-                    # Capture the library version BEFORE scanning so any
-                    # changes made during the scan will be picked up by the
-                    # next incremental run.
-                    try:
-                        target_sync_version = self.zotero_client.last_modified_version()
-                    except Exception as e:
-                        logger.warning(f"last_modified_version() failed: {e}")
-                        target_sync_version = None
+                # Capture the library version BEFORE scanning so any changes
+                # made during the scan will be picked up by the next
+                # incremental run. Skipping this after a force_full_rebuild
+                # would leave last_sync_version stale and the next
+                # incremental run would miss items that haven't changed
+                # since the old watermark (because they were just deleted
+                # along with the collection).
+                try:
+                    target_sync_version = self.zotero_client.last_modified_version()
+                except Exception as e:
+                    logger.warning(f"last_modified_version() failed: {e}")
+                    target_sync_version = None
                 all_items = self._get_items_from_source(
                     limit=limit,
                     extract_fulltext=extract_fulltext,

--- a/src/zotero_mcp/setup_helper.py
+++ b/src/zotero_mcp/setup_helper.py
@@ -318,6 +318,11 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
 
     config["update_config"] = update_config
     config["extraction"] = {"pdf_max_pages": pdf_max_pages}
+    # Web-API users: index fulltext from Zotero's server-side extraction by
+    # default. Users can set this to false to keep the old metadata-only
+    # behavior. The flag is ignored in local mode (ZOTERO_LOCAL=true uses
+    # local sqlite extraction).
+    config.setdefault("include_fulltext", True)
     if zotero_db_path:
         config["zotero_db_path"] = zotero_db_path
 

--- a/src/zotero_mcp/tools/search.py
+++ b/src/zotero_mcp/tools/search.py
@@ -3,6 +3,7 @@
 import json
 import logging as _logging
 import re
+import threading as _threading
 import time as _time
 from pathlib import Path
 from typing import Literal
@@ -17,6 +18,40 @@ from zotero_mcp.tools import _helpers
 _search_logger = _logging.getLogger("zotero_mcp.search")
 
 CASCADE_TIMEOUT = 60  # seconds — total budget for the entire fallback cascade
+
+# Pre-search background sync debounce: at most one fire-and-forget sync per
+# this many seconds, shared across all semantic_search tool invocations.
+_PRESEARCH_SYNC_MIN_INTERVAL = 60.0
+_last_presearch_sync_ts: float = 0.0
+_presearch_sync_lock = _threading.Lock()
+
+
+def _maybe_fire_presearch_sync(search) -> None:
+    """Schedule a background semantic-search DB update if auto-update is due.
+
+    Runs in a daemon thread so the current tool call returns immediately.
+    Intentionally swallows exceptions — a failed background sync must never
+    surface as a search-tool error to the user.
+    """
+    global _last_presearch_sync_ts
+    try:
+        if not search.should_update_database():
+            return
+    except Exception:
+        return
+    now = _time.monotonic()
+    with _presearch_sync_lock:
+        if now - _last_presearch_sync_ts < _PRESEARCH_SYNC_MIN_INTERVAL:
+            return
+        _last_presearch_sync_ts = now
+
+    def _run():
+        try:
+            search.update_database(extract_fulltext=_utils.is_local_mode())
+        except Exception as e:
+            _search_logger.debug(f"Background pre-search sync failed: {e}")
+
+    _threading.Thread(target=_run, daemon=True, name="zmcp-presearch-sync").start()
 
 
 def _search_with_variants(zot, query: str, qmode: str, limit: int,
@@ -732,6 +767,10 @@ def semantic_search(
 
         # Create semantic search instance
         search = create_semantic_search(str(config_path))
+
+        # Fire-and-forget: if auto-update is due, kick off a background sync
+        # so subsequent searches see fresh library state. Never blocks here.
+        _maybe_fire_presearch_sync(search)
 
         # Perform search
         results = search.search(query=query, limit=limit, filters=filters)

--- a/tests/test_fulltext_web_mode.py
+++ b/tests/test_fulltext_web_mode.py
@@ -1,0 +1,435 @@
+"""Tests for web-API fulltext ingest and since-based incremental sync.
+
+These tests cover the web-API branch introduced by the PR that adds fulltext
+fetching via pyzotero's `fulltext_item` endpoint and version-based incremental
+updates for users who don't have `ZOTERO_LOCAL=true` set (e.g. Claude Code on
+a headless Linux server talking to Zotero cloud).
+"""
+
+import json
+import sys
+
+import pytest
+
+if sys.version_info >= (3, 14):
+    pytest.skip(
+        "chromadb currently relies on pydantic v1 paths that are incompatible with Python 3.14+",
+        allow_module_level=True,
+    )
+
+from zotero_mcp import semantic_search
+
+
+class FakeChromaClient:
+    """Minimal ChromaClient stand-in that records operations for assertions."""
+
+    def __init__(self, preloaded_ids=None):
+        self.embedding_max_tokens = 8000
+        self._ids = set(preloaded_ids or [])
+        self.added = []  # list of (docs, metas, ids)
+        self.deleted = []  # list of ids deleted
+        self.reset_calls = 0
+
+    def truncate_text(self, text, max_tokens=None):
+        return text[:4000]
+
+    def get_existing_ids(self, ids):
+        return {i for i in ids if i in self._ids}
+
+    def get_all_ids(self):
+        return set(self._ids)
+
+    def get_document_metadata(self, doc_id):
+        return None
+
+    def upsert_documents(self, documents, metadatas, ids):
+        self.added.append((list(documents), list(metadatas), list(ids)))
+        for i in ids:
+            self._ids.add(i)
+
+    def add_documents(self, documents, metadatas, ids):
+        self.upsert_documents(documents, metadatas, ids)
+
+    def delete_documents(self, ids):
+        self.deleted.extend(list(ids))
+        for i in ids:
+            self._ids.discard(i)
+
+    def reset_collection(self):
+        self.reset_calls += 1
+        self._ids = set()
+
+
+class FakeZoteroClient:
+    """pyzotero client double with scripted responses."""
+
+    def __init__(self):
+        self.items_by_key = {}
+        self.fulltext_by_key = {}   # key -> dict (content, indexedChars, ...)
+        self.children_by_parent = {}  # parent_key -> list[item]
+        self.versions_state = {}    # key -> library_version (current state)
+        self.version_history = []   # (since_version, changed_dict) pairs
+        self.current_library_version = 0
+        # Pagination helper
+        self.items_order = []
+        # Recording calls for assertions
+        self.calls = []
+
+    # ---- setup helpers for tests ----
+
+    def load_scenario(self, items, fulltext=None, children=None, library_version=0):
+        """items: list of pyzotero-shaped dicts with top-level 'key' and 'data'."""
+        for it in items:
+            self.items_by_key[it["key"]] = it
+            self.items_order.append(it["key"])
+            self.versions_state[it["key"]] = library_version
+        for k, v in (fulltext or {}).items():
+            self.fulltext_by_key[k] = v
+        for k, v in (children or {}).items():
+            self.children_by_parent[k] = v
+        self.current_library_version = library_version
+
+    # ---- pyzotero surface used by the code under test ----
+
+    def items(self, start=0, limit=100, **kwargs):
+        self.calls.append(("items", start, limit))
+        chunk = self.items_order[start:start + limit]
+        return [self.items_by_key[k] for k in chunk]
+
+    def item(self, key):
+        self.calls.append(("item", key))
+        if key not in self.items_by_key:
+            raise LookupError(f"item {key} not found")
+        return self.items_by_key[key]
+
+    def children(self, key):
+        self.calls.append(("children", key))
+        return list(self.children_by_parent.get(key, []))
+
+    def fulltext_item(self, key):
+        self.calls.append(("fulltext_item", key))
+        if key not in self.fulltext_by_key:
+            raise RuntimeError(f"404 fulltext not found for {key}")
+        return self.fulltext_by_key[key]
+
+    def item_versions(self, since=None, **kwargs):
+        self.calls.append(("item_versions", since))
+        if since is None:
+            return dict(self.versions_state)
+        return {k: v for k, v in self.versions_state.items() if v > since}
+
+    def last_modified_version(self, **kwargs):
+        self.calls.append(("last_modified_version",))
+        return self.current_library_version
+
+
+def _paper(key, title="Paper", item_type="conferencePaper", version=1):
+    return {
+        "key": key,
+        "version": version,
+        "data": {
+            "key": key,
+            "itemType": item_type,
+            "title": title,
+            "abstractNote": f"abstract of {title}",
+            "creators": [{"creatorType": "author", "firstName": "A", "lastName": "Author"}],
+            "dateAdded": "2024-01-01T00:00:00Z",
+            "dateModified": "2024-01-01T00:00:00Z",
+        },
+    }
+
+
+def _build_search(monkeypatch, zot: FakeZoteroClient, chroma: FakeChromaClient,
+                  config_path: str | None = None) -> "semantic_search.ZoteroSemanticSearch":
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: zot)
+    monkeypatch.setattr(semantic_search, "is_local_mode", lambda: False)
+    return semantic_search.ZoteroSemanticSearch(
+        chroma_client=chroma,
+        config_path=config_path,
+    )
+
+
+# --------- Unit tests: fulltext fetch helper ----------
+
+def test_fetch_fulltext_via_web_api_parent_hit(monkeypatch):
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("AAA")], fulltext={"AAA": {"content": "Body text.", "indexedChars": 10, "totalChars": 10}})
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    text, source = search._fetch_fulltext_via_web_api("AAA")
+    assert text == "Body text."
+    assert source == "web-api:parent"
+
+
+def test_fetch_fulltext_via_web_api_attachment_fallback(monkeypatch):
+    """When parent has no fulltext (404), walk children and try PDF attachments."""
+    parent = _paper("PAR", title="Paper")
+    child = {
+        "key": "CHILD1",
+        "version": 1,
+        "data": {"key": "CHILD1", "itemType": "attachment", "contentType": "application/pdf"},
+    }
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [parent],
+        # parent lookup will fail (key not in fulltext_by_key -> raise)
+        fulltext={"CHILD1": {"content": "Attachment body."}},
+        children={"PAR": [child]},
+    )
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    text, source = search._fetch_fulltext_via_web_api("PAR")
+    assert text == "Attachment body."
+    assert source == "web-api:attachment:CHILD1"
+    # Verify we actually tried the parent first, then walked children
+    call_names = [c[0] for c in zot.calls]
+    assert "fulltext_item" in call_names and "children" in call_names
+
+
+def test_fetch_fulltext_via_web_api_returns_empty_when_nothing_available(monkeypatch):
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("X")])
+    # No fulltext, no children — every lookup fails
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    text, source = search._fetch_fulltext_via_web_api("X")
+    assert text == ""
+    assert source == ""
+
+
+def test_fetch_fulltext_skips_non_pdf_children(monkeypatch):
+    parent = _paper("PAR")
+    child_pdf = {"key": "PDF", "version": 1,
+                 "data": {"key": "PDF", "itemType": "attachment", "contentType": "application/pdf"}}
+    child_html = {"key": "HTM", "version": 1,
+                  "data": {"key": "HTM", "itemType": "attachment", "contentType": "text/html"}}
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [parent],
+        fulltext={"PDF": {"content": "PDF text."}, "HTM": {"content": "HTML text."}},
+        children={"PAR": [child_html, child_pdf]},  # HTML listed first
+    )
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    text, source = search._fetch_fulltext_via_web_api("PAR")
+    # Should skip the HTML attachment and return the PDF's content
+    assert text == "PDF text."
+    assert source == "web-api:attachment:PDF"
+
+
+# --------- Integration tests: _get_items_from_api ----------
+
+def test_get_items_from_api_without_fulltext_leaves_data_untouched(monkeypatch):
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("A"), _paper("B")], fulltext={"A": {"content": "Abody"}, "B": {"content": "Bbody"}})
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    items = search._get_items_from_api(include_fulltext=False)
+    assert len(items) == 2
+    for it in items:
+        assert "fulltext" not in it["data"]
+
+
+def test_get_items_from_api_with_fulltext_populates_data(monkeypatch):
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [_paper("A"), _paper("B")],
+        fulltext={"A": {"content": "Abody"}, "B": {"content": "Bbody"}},
+    )
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    items = search._get_items_from_api(include_fulltext=True)
+    by_key = {it["key"]: it for it in items}
+    assert by_key["A"]["data"]["fulltext"] == "Abody"
+    assert by_key["A"]["data"]["fulltextSource"] == "web-api:parent"
+    assert by_key["B"]["data"]["fulltext"] == "Bbody"
+
+
+def test_get_items_from_api_with_fulltext_marks_misses_as_attempted(monkeypatch):
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("A")], fulltext={})  # no fulltext for A
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    items = search._get_items_from_api(include_fulltext=True)
+    assert items[0]["data"].get("fulltext", "") == ""
+    assert items[0]["data"]["fulltext_attempted"] is True
+
+
+# --------- Integration tests: incremental fetch ----------
+
+def test_get_changed_items_from_api_returns_only_changed_keys(monkeypatch):
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [_paper("OLD"), _paper("NEW")],
+        library_version=5,
+    )
+    # Mark OLD as unchanged since v3, NEW as changed at v5
+    zot.versions_state = {"OLD": 3, "NEW": 5}
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    changed, current_keys = search._get_changed_items_from_api(since_version=3, include_fulltext=False)
+    assert [c["key"] for c in changed] == ["NEW"]
+    assert current_keys == {"OLD", "NEW"}
+
+
+def test_get_changed_items_filters_out_attachments_and_notes(monkeypatch):
+    zot = FakeZoteroClient()
+    note = _paper("N1", item_type="note")
+    ann = _paper("A1", item_type="annotation")
+    paper = _paper("P1", item_type="conferencePaper")
+    zot.load_scenario([note, ann, paper], library_version=10)
+    zot.versions_state = {"N1": 10, "A1": 10, "P1": 10}
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    changed, _ = search._get_changed_items_from_api(since_version=0, include_fulltext=False)
+    assert [c["key"] for c in changed] == ["P1"]
+
+
+# --------- Integration tests: update_database orchestration ----------
+
+def _write_config(tmp_path, extra: dict | None = None):
+    cfg = {
+        "semantic_search": {
+            "embedding_model": "default",
+            "update_config": {"auto_update": False, "update_frequency": "manual"},
+            "extraction": {"pdf_max_pages": 10},
+            "include_fulltext": True,
+        }
+    }
+    if extra:
+        cfg["semantic_search"].update(extra)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(cfg))
+    return str(config_path)
+
+
+def test_update_database_bootstrap_scans_full_library(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path)
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [_paper("P1"), _paper("P2")],
+        fulltext={"P1": {"content": "Paper one body"}, "P2": {"content": "Paper two body"}},
+        library_version=7,
+    )
+    chroma = FakeChromaClient()
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    stats = search.update_database()
+
+    assert stats["total_items"] == 2
+    assert stats["processed_items"] == 2
+    # last_sync_version should be persisted to config
+    saved = json.loads(open(config_path).read())
+    assert saved["semantic_search"]["last_sync_version"] == 7
+
+
+def test_update_database_incremental_only_fetches_changed(monkeypatch, tmp_path):
+    """Second run with last_sync_version set should only reindex changed items."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 5})
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [_paper("OLD"), _paper("NEW")],
+        fulltext={"NEW": {"content": "New body"}},
+        library_version=8,
+    )
+    zot.versions_state = {"OLD": 3, "NEW": 8}
+    chroma = FakeChromaClient(preloaded_ids=["OLD"])  # OLD was already indexed
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    stats = search.update_database()
+
+    # Only NEW should be processed, OLD untouched
+    assert stats["processed_items"] == 1
+    added_ids = [i for batch in chroma.added for i in batch[2]]
+    assert added_ids == ["NEW"]
+    saved = json.loads(open(config_path).read())
+    assert saved["semantic_search"]["last_sync_version"] == 8
+
+
+def test_update_database_incremental_deletes_removed_items(monkeypatch, tmp_path):
+    """Items present in ChromaDB but removed from the library should be deleted."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 5})
+    zot = FakeZoteroClient()
+    # Only NEW is still in the library; DELETED_ME was removed
+    zot.load_scenario([_paper("NEW")], fulltext={"NEW": {"content": "body"}}, library_version=9)
+    zot.versions_state = {"NEW": 9}
+    chroma = FakeChromaClient(preloaded_ids=["NEW", "DELETED_ME"])
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    stats = search.update_database()
+
+    assert "DELETED_ME" in chroma.deleted
+    assert stats["deleted_items"] == 1
+
+
+def test_update_database_incremental_noop_when_version_unchanged(monkeypatch, tmp_path):
+    """If last_modified_version == last_sync_version, skip ingest entirely."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 42})
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("X")], library_version=42)
+    zot.versions_state = {"X": 42}
+    chroma = FakeChromaClient(preloaded_ids=["X"])
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    stats = search.update_database()
+
+    assert stats["processed_items"] == 0
+    assert stats["added_items"] == 0
+    assert stats["deleted_items"] == 0
+    # No ingest calls (no items() fetch, no item_versions(since=...) etc.)
+    # Must have called last_modified_version to compare
+    assert ("last_modified_version",) in zot.calls
+
+
+def test_update_database_disables_fulltext_when_config_off(monkeypatch, tmp_path):
+    """Explicit include_fulltext=False should skip the web-API fulltext fetch."""
+    config_path = _write_config(tmp_path, extra={"include_fulltext": False})
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [_paper("A")],
+        fulltext={"A": {"content": "this should NOT appear"}},
+        library_version=3,
+    )
+    chroma = FakeChromaClient()
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    search.update_database()
+
+    # fulltext_item should never be called
+    assert not any(c[0] == "fulltext_item" for c in zot.calls)
+
+
+def test_update_database_force_rebuild_triggers_reset_and_full_scan(monkeypatch, tmp_path):
+    """force_full_rebuild should reset the collection and do a full scan."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 100})
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("A"), _paper("B")], library_version=120)
+    zot.versions_state = {"A": 120, "B": 120}
+    chroma = FakeChromaClient(preloaded_ids=["STALE"])
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    search.update_database(force_full_rebuild=True)
+
+    assert chroma.reset_calls == 1
+    # No since-based fetch: full scan used items() not item_versions(since=...)
+    assert not any(c[0] == "item_versions" and c[1] is not None for c in zot.calls)
+
+
+# --------- Config loaders ----------
+
+def test_load_include_fulltext_defaults_true(monkeypatch, tmp_path):
+    # No config file exists
+    search = _build_search(monkeypatch, FakeZoteroClient(), FakeChromaClient(),
+                           config_path=str(tmp_path / "missing.json"))
+    assert search._load_include_fulltext_setting() is True
+
+
+def test_load_include_fulltext_respects_opt_out(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path, extra={"include_fulltext": False})
+    search = _build_search(monkeypatch, FakeZoteroClient(), FakeChromaClient(),
+                           config_path=config_path)
+    assert search._load_include_fulltext_setting() is False
+
+
+def test_load_last_sync_version_defaults_zero(monkeypatch, tmp_path):
+    search = _build_search(monkeypatch, FakeZoteroClient(), FakeChromaClient(),
+                           config_path=str(tmp_path / "missing.json"))
+    assert search._load_last_sync_version() == 0
+
+
+def test_load_last_sync_version_reads_int(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 123})
+    search = _build_search(monkeypatch, FakeZoteroClient(), FakeChromaClient(),
+                           config_path=config_path)
+    assert search._load_last_sync_version() == 123

--- a/tests/test_fulltext_web_mode.py
+++ b/tests/test_fulltext_web_mode.py
@@ -406,6 +406,24 @@ def test_update_database_force_rebuild_triggers_reset_and_full_scan(monkeypatch,
     assert not any(c[0] == "item_versions" and c[1] is not None for c in zot.calls)
 
 
+def test_update_database_force_rebuild_updates_last_sync_version(monkeypatch, tmp_path):
+    """After force_full_rebuild, last_sync_version must advance to the library's
+    current version. Otherwise the next incremental run would use a stale
+    watermark and permanently lose items not modified since that older version.
+    """
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 50})
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("A")], library_version=200)
+    zot.versions_state = {"A": 200}
+    chroma = FakeChromaClient()
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    search.update_database(force_full_rebuild=True)
+
+    saved = json.loads(open(config_path).read())
+    assert saved["semantic_search"]["last_sync_version"] == 200
+
+
 # --------- Config loaders ----------
 
 def test_load_include_fulltext_defaults_true(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem

Users running `zotero-mcp-server` against the Zotero **web API** (e.g. on a headless Linux server with no local Zotero desktop client) currently get **metadata-only semantic search** — the extract_fulltext path is gated behind `is_local_mode()` and raises `RuntimeError` otherwise. But Zotero cloud already keeps the server-side-extracted PDF text for every PDF the desktop client has ever synced: `zot.fulltext_item(key)` returns it. There is a capability gap, not a data gap.

Additionally, every update rescans the whole library from scratch and never deletes items that have been removed in Zotero.

## Summary of changes

1. **Fulltext via web API** — `ZoteroSemanticSearch._fetch_fulltext_via_web_api(item_key)` tries `fulltext_item(key)` on the item itself, then walks PDF attachment children and tries each. Recorded source (`web-api:parent` or `web-api:attachment:<child_key>`) is stored in ChromaDB metadata for diagnostics.
2. **Web-API ingest wiring** — `_get_items_from_api(include_fulltext=False)` gains an optional flag that populates `data.fulltext` in place for each returned item. Downstream `_process_item_batch` already reads `data.fulltext` and writes the existing `has_fulltext` bookkeeping, so no per-item code path needed to change.
3. **New public kwarg `include_fulltext`** on `update_database`. Defaults from a new `semantic_search.include_fulltext` config key (default true, so existing users auto-upgrade). `extract_fulltext=True` (local mode) still wins and uses the local sqlite path — this flag only governs web-API ingest.
4. **Incremental sync** — `_get_changed_items_from_api(since_version, include_fulltext)` uses pyzotero's `item_versions(since=V)` for changes and an unfiltered `item_versions()` for deletion detection. `update_database` caches the library version as `semantic_search.last_sync_version` and fast-paths a noop when `last_modified_version()` hasn't advanced.
5. **Deletion handling** — entries in ChromaDB whose keys no longer appear in the current library are removed via a new `ChromaClient.get_all_ids()` + existing `delete_documents`. New `deleted_items` stat.
6. **Pre-search fire-and-forget** — the `zotero_semantic_search` tool kicks off a background daemon-thread sync when `auto_update` is on, with a 60s module-level debounce. Swallows all exceptions — a failed sync must never surface as a tool error. Future tool calls see fresh state without blocking the current query.
7. **Config default** — `setup_helper.setup_semantic_search` writes `include_fulltext: true` so new configs opt in from day one.

Existing call sites (`_app.py`'s `server_lifespan` and the `update_search_database` tool) were **not** modified. They already pass `extract_fulltext=is_local_mode()`; the new `include_fulltext=None` default resolves from config so behavior upgrades automatically.

## Verification

Ran on a 2402-item real Zotero library over web API.

* **Bootstrap path** — `zotero-mcp update-db --limit 20`: 20 items fully indexed in 18.3s, 10/20 items got fulltext (50% hit rate; misses are notes, webpages, datasets without PDFs). Attachment-child fallback works — e.g. parent `HYJ5IR99` had no fulltext but its PDF child `6HN4C9LI` did, yielding `fulltext_source=web-api:attachment:6HN4C9LI`.
* **last_sync_version persistence** — config after bootstrap: `last_sync_version: 7661` (matches live library).
* **Incremental noop** — second run with no library changes: 3.3s total, 0 items processed, log says \`Library unchanged since last sync (version 7661); no items to reindex.\`.
* **Unit tests** — 20 new tests in \`tests/test_fulltext_web_mode.py\` cover: parent-hit / attachment-fallback / empty-miss / non-PDF-skip for the fulltext fetcher; bootstrap vs incremental vs noop dispatch in `update_database`; deletion detection; explicit `include_fulltext=false` opt-out; force-rebuild watermark advance; config loader defaults.
* **Full suite** — \`uv run pytest tests/\` passes **454/454** (435 baseline + 19 new plus 1 later added for the watermark fix).

## Backward compatibility

* Local-mode users (`ZOTERO_LOCAL=true`) see no behavior change — `extract_fulltext=True` takes precedence and the existing local-sqlite extraction runs as before.
* Web-API users with existing ChromaDB collections get an automatic upgrade on their next sync: fulltext is fetched and items are upserted. No collection reset required.
* Users who prefer metadata-only can set `"include_fulltext": false` in their config.
* The new `get_all_ids()` method on `ChromaClient` is additive, not replacing any existing API.

## Commits

1. `feat(semantic): fulltext via web API + since-based incremental sync`
2. `fix(semantic): advance last_sync_version on force_full_rebuild` — caught in review: the force-rebuild branch was skipping the watermark capture, which would leave `last_sync_version` stale and cause the next incremental run to miss items not modified since the old watermark.