### PR TITLE
feat(semantic): chunked ingest + groupby rerank + gap-fill resume (builds on #260)

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -42,11 +42,16 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
                  model_name: str = "text-embedding-3-small",
                  api_key: str | None = None,
                  base_url: str | None = None,
-                 request_batch_size: int | None = None):
+                 request_batch_size: int | None = None,
+                 rate_limit_rps: float | None = None):
+        import threading as _threading
         self.model_name = model_name
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         self.base_url = base_url or os.getenv("OPENAI_BASE_URL")
         self.request_batch_size = int(request_batch_size) if request_batch_size else self.DEFAULT_REQUEST_BATCH_SIZE
+        self.rate_limit_rps: float | None = float(rate_limit_rps) if rate_limit_rps else None
+        self._rate_lock = _threading.Lock()
+        self._last_request_ts: float = 0.0
         if not self.api_key:
             raise ValueError("OpenAI API key is required")
 
@@ -68,6 +73,7 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
             "model_name": self.model_name,
             "base_url": self.base_url,
             "request_batch_size": self.request_batch_size,
+            "rate_limit_rps": self.rate_limit_rps,
         }
 
     @staticmethod
@@ -77,10 +83,32 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
             api_key=config.get("api_key"),
             base_url=config.get("base_url"),
             request_batch_size=config.get("request_batch_size"),
+            rate_limit_rps=config.get("rate_limit_rps"),
         )
 
+    def _wait_for_rate_limit(self) -> None:
+        """Sleep as needed so successive HTTP requests stay under `rate_limit_rps`.
+
+        Applied at the individual HTTP request level (including each
+        sub-batch) so rate-limited providers see a steady request cadence
+        regardless of how many inputs the caller passed. The lock keeps
+        parallel threads (e.g. the pre-search fire-and-forget sync)
+        honest.
+        """
+        rps = self.rate_limit_rps
+        if not rps or rps <= 0:
+            return
+        import time as _t
+        with self._rate_lock:
+            now = _t.monotonic()
+            min_interval = 1.0 / rps
+            wait = min_interval - (now - self._last_request_ts)
+            if wait > 0:
+                _t.sleep(wait)
+            self._last_request_ts = _t.monotonic()
+
     def __call__(self, input: Documents) -> Embeddings:
-        """Generate embeddings, sub-batching when needed.
+        """Generate embeddings, sub-batching + rate-limiting each request.
 
         Upstream callers (e.g. `_process_item_batch`) may pass more items
         than the provider accepts in a single POST. We split into
@@ -91,6 +119,7 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
             return []
         batch_size = self.request_batch_size or self.DEFAULT_REQUEST_BATCH_SIZE
         if len(input) <= batch_size:
+            self._wait_for_rate_limit()
             response = self.client.embeddings.create(
                 model=self.model_name,
                 input=input,
@@ -99,6 +128,7 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
         vecs: list = []
         for i in range(0, len(input), batch_size):
             sub = input[i:i + batch_size]
+            self._wait_for_rate_limit()
             response = self.client.embeddings.create(
                 model=self.model_name,
                 input=sub,
@@ -429,7 +459,22 @@ class ChromaClient:
             model_name = self.embedding_config.get("model_name", "text-embedding-3-small")
             api_key = self.embedding_config.get("api_key")
             base_url = self.embedding_config.get("base_url")
-            return OpenAIEmbeddingFunction(model_name=model_name, api_key=api_key, base_url=base_url)
+            request_batch_size = self.embedding_config.get("request_batch_size")
+            # Pull the rate limit from the outer semantic_search config if
+            # present (preferred), with a fallback to embedding_config for
+            # users who scope it per-provider.
+            rate_limit_rps = (
+                self.embedding_config.get("rate_limit_rps")
+                if self.embedding_config.get("rate_limit_rps") is not None
+                else self.embedding_config.get("_semantic_rate_limit_rps")
+            )
+            return OpenAIEmbeddingFunction(
+                model_name=model_name,
+                api_key=api_key,
+                base_url=base_url,
+                request_batch_size=request_batch_size,
+                rate_limit_rps=rate_limit_rps,
+            )
 
         elif self.embedding_model == "gemini":
             model_name = self.embedding_config.get("model_name", "gemini-embedding-001")
@@ -788,6 +833,15 @@ def create_chroma_client(config_path: str | None = None) -> ChromaClient:
                 ec["base_url"] = env_base
         if ec.get("api_key"):
             config["embedding_config"] = ec
+
+    # Propagate the top-level semantic_search.embedding_rate_limit_rps down
+    # into the embedding_config so OpenAIEmbeddingFunction sees it at
+    # construction time. The explicit-inside-embedding_config value, if
+    # set, wins.
+    if "embedding_rate_limit_rps" in config and config["embedding_rate_limit_rps"] is not None:
+        ec = dict(config.get("embedding_config") or {})
+        ec.setdefault("rate_limit_rps", config["embedding_rate_limit_rps"])
+        config["embedding_config"] = ec
 
     return ChromaClient(
         collection_name=config["collection_name"],

--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -628,6 +628,19 @@ class ChromaClient:
         except Exception:
             return set()
 
+    def get_all_ids(self) -> set[str]:
+        """Return every id currently stored in the collection.
+
+        Used by incremental sync to compute deletions: items in the local
+        collection but no longer present in the Zotero library.
+        """
+        try:
+            result = self.collection.get(include=[])
+            return set(result.get("ids", []))
+        except Exception as e:
+            logger.error(f"Error listing collection ids: {e}")
+            return set()
+
 
 def create_chroma_client(config_path: str | None = None) -> ChromaClient:
     """

--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -641,6 +641,47 @@ class ChromaClient:
             logger.error(f"Error listing collection ids: {e}")
             return set()
 
+    def delete_documents_by_parent(self, parent_item_key: str) -> int:
+        """Delete every chunk associated with a parent Zotero item.
+
+        Chunk ids follow the `<parent_item_key>__<chunk_index>` convention
+        and also carry `metadata.parent_item_key`. We prefer the metadata
+        filter because it is authoritative even for legacy ids written
+        before the chunking migration.
+
+        Returns the number of ids removed.
+        """
+        try:
+            result = self.collection.get(
+                where={"parent_item_key": parent_item_key},
+                include=[],
+            )
+            ids = list(result.get("ids", []))
+        except Exception as e:
+            logger.debug(
+                f"parent_item_key filter failed for {parent_item_key}: {e}; "
+                f"falling back to id-prefix match"
+            )
+            ids = []
+        # Fallback for legacy collections where parent_item_key wasn't stored
+        if not ids:
+            try:
+                all_ids = self.collection.get(include=[]).get("ids", [])
+                prefix = f"{parent_item_key}__"
+                ids = [i for i in all_ids
+                       if i == parent_item_key or i.startswith(prefix)]
+            except Exception as e:
+                logger.error(f"Could not enumerate collection to delete parent {parent_item_key}: {e}")
+                return 0
+        if not ids:
+            return 0
+        try:
+            self.collection.delete(ids=ids)
+            return len(ids)
+        except Exception as e:
+            logger.error(f"Failed to delete {len(ids)} chunks for parent {parent_item_key}: {e}")
+            return 0
+
 
 def create_chroma_client(config_path: str | None = None) -> ChromaClient:
     """

--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -722,6 +722,32 @@ class ChromaClient:
             logger.error(f"Error listing collection ids: {e}")
             return set()
 
+    def delete_documents_by_item_type(self, item_type: str) -> int:
+        """Delete every chunk whose `metadata.item_type` equals the argument.
+
+        Used to purge stale data after tightening the ingest filter — e.g.
+        a past bug let `annotation` items through and they now sit in the
+        collection as noise. ChromaDB accepts a `where={}` filter on
+        `delete` but we first enumerate so we can return the count.
+        """
+        try:
+            result = self.collection.get(
+                where={"item_type": item_type},
+                include=[],
+            )
+            ids = list(result.get("ids", []))
+        except Exception as e:
+            logger.debug(f"item_type filter for {item_type} failed: {e}")
+            return 0
+        if not ids:
+            return 0
+        try:
+            self.collection.delete(ids=ids)
+            return len(ids)
+        except Exception as e:
+            logger.error(f"Failed to delete {len(ids)} chunks of type {item_type}: {e}")
+            return 0
+
     def delete_documents_by_parent(self, parent_item_key: str) -> int:
         """Delete every chunk associated with a parent Zotero item.
 

--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -31,10 +31,22 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
 
     max_input_tokens = 8000  # text-embedding-3-* limit is 8191
 
-    def __init__(self, model_name: str = "text-embedding-3-small", api_key: str | None = None, base_url: str | None = None):
+    # Per-request input-list cap. OpenAI allows up to 2048 items but many
+    # OpenAI-compatible providers are stricter — SiliconFlow is 64 for
+    # `/v1/embeddings`, Mistral is 512, etc. Defaulting to 64 here keeps
+    # the code portable across providers; real OpenAI users can set
+    # `embedding_config.request_batch_size: 2048` to maximize throughput.
+    DEFAULT_REQUEST_BATCH_SIZE = 64
+
+    def __init__(self,
+                 model_name: str = "text-embedding-3-small",
+                 api_key: str | None = None,
+                 base_url: str | None = None,
+                 request_batch_size: int | None = None):
         self.model_name = model_name
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         self.base_url = base_url or os.getenv("OPENAI_BASE_URL")
+        self.request_batch_size = int(request_batch_size) if request_batch_size else self.DEFAULT_REQUEST_BATCH_SIZE
         if not self.api_key:
             raise ValueError("OpenAI API key is required")
 
@@ -52,7 +64,11 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
         return "openai"
 
     def get_config(self) -> dict[str, Any]:
-        return {"model_name": self.model_name, "base_url": self.base_url}
+        return {
+            "model_name": self.model_name,
+            "base_url": self.base_url,
+            "request_batch_size": self.request_batch_size,
+        }
 
     @staticmethod
     def build_from_config(config: dict[str, Any]) -> "OpenAIEmbeddingFunction":
@@ -60,15 +76,35 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
             model_name=config.get("model_name", "text-embedding-3-small"),
             api_key=config.get("api_key"),
             base_url=config.get("base_url"),
+            request_batch_size=config.get("request_batch_size"),
         )
 
     def __call__(self, input: Documents) -> Embeddings:
-        """Generate embeddings using OpenAI API."""
-        response = self.client.embeddings.create(
-            model=self.model_name,
-            input=input
-        )
-        return [data.embedding for data in response.data]
+        """Generate embeddings, sub-batching when needed.
+
+        Upstream callers (e.g. `_process_item_batch`) may pass more items
+        than the provider accepts in a single POST. We split into
+        `request_batch_size` slices and concatenate the resulting vectors.
+        Return order matches input order.
+        """
+        if not input:
+            return []
+        batch_size = self.request_batch_size or self.DEFAULT_REQUEST_BATCH_SIZE
+        if len(input) <= batch_size:
+            response = self.client.embeddings.create(
+                model=self.model_name,
+                input=input,
+            )
+            return [data.embedding for data in response.data]
+        vecs: list = []
+        for i in range(0, len(input), batch_size):
+            sub = input[i:i + batch_size]
+            response = self.client.embeddings.create(
+                model=self.model_name,
+                input=sub,
+            )
+            vecs.extend(data.embedding for data in response.data)
+        return vecs
 
     def embed_query(self, text: str) -> list[float]:
         """Embed a query string. No special handling needed for OpenAI."""

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -1329,6 +1329,13 @@ class ZoteroSemanticSearch:
                 retry_ok = 0
                 retry_fail = 0
                 for doc, meta, doc_id in _failed_docs:
+                    # Retry must respect the same rate limit as the main
+                    # ingest path. Without this throttle, a large retry
+                    # burst can hammer SiliconFlow / other rate-limited
+                    # providers with N unthrottled HTTP requests and
+                    # re-trigger 429s — each of which the retry loop logs
+                    # as a permanent failure and moves on, leaving gaps.
+                    self._throttle_embedding_request()
                     try:
                         self.chroma_client.upsert_documents([doc], [meta], [doc_id])
                         retry_ok += 1

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -1136,9 +1136,17 @@ class ZoteroSemanticSearch:
             # (`<key>`); PR2 stores one per chunk (`<key>__<i>`). Mixing both
             # pollutes dedup / rerank. Detect and upgrade to a fresh rebuild
             # so the user never has to run --force-rebuild manually.
+            #
+            # Also cover the related case where the collection was silently
+            # reset at ChromaClient init (embedding-model dim change) but
+            # config still carries a non-zero last_sync_version. Without this
+            # guard, the incremental fast-path would see library version
+            # unchanged and skip ingest, leaving the collection permanently
+            # empty until the user manually ran --force-rebuild.
             if not force_full_rebuild:
                 try:
                     existing_ids = self.chroma_client.get_all_ids()
+                    cached_sync = self._load_last_sync_version()
                     if existing_ids:
                         sample = list(existing_ids)[:20]
                         if not any("__" in i for i in sample):
@@ -1155,6 +1163,20 @@ class ZoteroSemanticSearch:
                             except Exception:
                                 pass
                             force_full_rebuild = True
+                    elif cached_sync > 0:
+                        logger.info(
+                            "Collection is empty but config claims prior sync "
+                            f"(version {cached_sync}); likely reset after an "
+                            "embedding-model change. Rebuilding from scratch."
+                        )
+                        try:
+                            sys.stderr.write(
+                                "\nCollection was reset (likely after an embedding-model "
+                                "change); rebuilding from scratch...\n"
+                            )
+                        except Exception:
+                            pass
+                        force_full_rebuild = True
                 except Exception as e:
                     logger.debug(f"Legacy id-format check failed: {e}")
 

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -9,6 +9,8 @@ over research libraries.
 import json
 import os
 import sys
+import threading
+import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -98,6 +100,12 @@ class ZoteroSemanticSearch:
         self._reranker: CrossEncoderReranker | None = None
         self._reranker_config = self._load_reranker_config()
 
+        # Embedding-request throttle state (thread-safe: the indexing loop
+        # runs batches sequentially but the pre-search fire-and-forget sync
+        # in tools/search.py kicks off another indexer thread).
+        self._embed_throttle_lock = threading.Lock()
+        self._last_embed_ts: float = 0.0
+
     def _load_reranker_config(self) -> dict[str, Any]:
         """Load reranker configuration from file or use defaults."""
         config: dict[str, Any] = {
@@ -179,6 +187,116 @@ class ZoteroSemanticSearch:
         except Exception as e:
             logger.warning(f"Error loading last_sync_version: {e}")
             return 0
+
+    def _load_chunking_settings(self) -> dict[str, int]:
+        """Chunk window / overlap sizes in tiktoken cl100k_base tokens.
+
+        Default 1500-token window with 225-token (15%) overlap fits
+        comfortably inside OpenAI text-embedding-3-small (8192 ctx),
+        SiliconFlow bge-m3 (8192 ctx), and leaves headroom for prepended
+        structured metadata.
+        """
+        defaults = {"window": 1500, "overlap": 225}
+        if not self.config_path or not os.path.exists(self.config_path):
+            return defaults
+        try:
+            with open(self.config_path) as f:
+                file_config = json.load(f)
+                overrides = file_config.get("semantic_search", {}).get("chunking", {})
+                if isinstance(overrides, dict):
+                    defaults.update({k: int(v) for k, v in overrides.items()
+                                     if k in defaults})
+        except Exception as e:
+            logger.warning(f"Error loading chunking settings: {e}")
+        return defaults
+
+    def _load_embedding_rate_limit(self) -> float | None:
+        """Max embedding HTTP requests per second, or None for no throttle.
+
+        Useful when driving a rate-limited OpenAI-compatible endpoint such as
+        SiliconFlow or a free-tier OpenAI key. Default is None (no throttle).
+        """
+        if not self.config_path or not os.path.exists(self.config_path):
+            return None
+        try:
+            with open(self.config_path) as f:
+                file_config = json.load(f)
+                val = file_config.get("semantic_search", {}).get("embedding_rate_limit_rps")
+                if val is None:
+                    return None
+                rps = float(val)
+                return rps if rps > 0 else None
+        except Exception:
+            return None
+
+    def _throttle_embedding_request(self) -> None:
+        """Sleep as needed to respect `embedding_rate_limit_rps`.
+
+        Call this immediately before every ChromaDB upsert/add that will
+        trigger a remote embedding request. Each upsert batches many docs
+        into a single POST, so throttling at the upsert boundary matches
+        the per-request rate limit enforced by the provider.
+        """
+        rps = self._load_embedding_rate_limit()
+        if not rps:
+            return
+        with self._embed_throttle_lock:
+            now = time.monotonic()
+            min_interval = 1.0 / rps
+            wait = min_interval - (now - self._last_embed_ts)
+            if wait > 0:
+                time.sleep(wait)
+            self._last_embed_ts = time.monotonic()
+
+    def _chunk_document(self, text: str,
+                        window: int = 1500,
+                        overlap: int = 225) -> list[str]:
+        """Split text into overlapping token windows.
+
+        Uses tiktoken (cl100k_base) for token counting so window sizes are
+        aligned with the tokenizer used by OpenAI and OpenAI-compatible
+        embedding providers (SiliconFlow, Mistral, etc.). Falls back to a
+        conservative 4-char-per-token approximation when tiktoken is
+        unavailable.
+
+        Short inputs (≤ window tokens) return a single-chunk list — callers
+        must still wrap in a list to keep the ingest loop uniform.
+        """
+        if not text or not text.strip():
+            return []
+        if window <= 0:
+            return [text.strip()]
+        # Clamp overlap to < window to prevent infinite loops on malformed config
+        overlap = max(0, min(overlap, window - 1))
+        step = max(1, window - overlap)
+
+        if _tokenizer is None:
+            char_window = window * 4
+            char_step = step * 4
+            chunks = []
+            for i in range(0, len(text), char_step):
+                piece = text[i:i + char_window].strip()
+                if piece:
+                    chunks.append(piece)
+                if i + char_window >= len(text):
+                    break
+            return chunks or [text.strip()]
+
+        tokens = _tokenizer.encode(text, disallowed_special=())
+        if len(tokens) <= window:
+            return [text.strip()]
+
+        chunks: list[str] = []
+        for i in range(0, len(tokens), step):
+            window_tokens = tokens[i:i + window]
+            if not window_tokens:
+                break
+            piece = _tokenizer.decode(window_tokens).strip()
+            if piece:
+                chunks.append(piece)
+            if i + window >= len(tokens):
+                break
+        return chunks
 
     def _save_update_config(self, last_sync_version: int | None = None) -> None:
         """Save update configuration and optionally update last_sync_version."""
@@ -1014,6 +1132,32 @@ class ZoteroSemanticSearch:
             # extractor (extract_fulltext=True takes precedence in local mode)
             include_fulltext_via_api = include_fulltext and not extract_fulltext
 
+            # Migrate from pre-chunking id format: PR1 stored one id per item
+            # (`<key>`); PR2 stores one per chunk (`<key>__<i>`). Mixing both
+            # pollutes dedup / rerank. Detect and upgrade to a fresh rebuild
+            # so the user never has to run --force-rebuild manually.
+            if not force_full_rebuild:
+                try:
+                    existing_ids = self.chroma_client.get_all_ids()
+                    if existing_ids:
+                        sample = list(existing_ids)[:20]
+                        if not any("__" in i for i in sample):
+                            logger.info(
+                                "Legacy pre-chunking id format detected; "
+                                "rebuilding collection."
+                            )
+                            try:
+                                sys.stderr.write(
+                                    "\nCollection was built by an older (pre-chunking) "
+                                    "version; rebuilding to enable paragraph-level "
+                                    "semantic search...\n"
+                                )
+                            except Exception:
+                                pass
+                            force_full_rebuild = True
+                except Exception as e:
+                    logger.debug(f"Legacy id-format check failed: {e}")
+
             # Reset collection if force rebuild
             if force_full_rebuild:
                 logger.info("Force rebuilding database...")
@@ -1061,16 +1205,25 @@ class ZoteroSemanticSearch:
                     since_version=last_sync_version,
                     include_fulltext=include_fulltext_via_api,
                 )
-                # Delete collection entries that are no longer present in the library
+                # Delete collection entries that are no longer present in the
+                # library. With chunking, stored ids are `<parent>__<i>` so we
+                # must group by parent before computing the diff.
                 try:
                     stored_ids = self.chroma_client.get_all_ids()
-                    to_delete = [k for k in (stored_ids - current_library_keys) if k]
-                    if to_delete:
-                        self.chroma_client.delete_documents(to_delete)
-                        stats["deleted_items"] = len(to_delete)
+                    stored_parents = {
+                        i.split("__", 1)[0] if "__" in i else i
+                        for i in stored_ids
+                    }
+                    deleted_parents = [k for k in (stored_parents - current_library_keys) if k]
+                    if deleted_parents:
+                        total_deleted_chunks = 0
+                        for pkey in deleted_parents:
+                            total_deleted_chunks += self.chroma_client.delete_documents_by_parent(pkey)
+                        stats["deleted_items"] = len(deleted_parents)
                         try:
                             sys.stderr.write(
-                                f"\nDeleted {len(to_delete)} items no longer present in Zotero.\n"
+                                f"\nDeleted {len(deleted_parents)} items "
+                                f"({total_deleted_chunks} chunks) no longer present in Zotero.\n"
                             )
                         except Exception:
                             pass
@@ -1210,19 +1363,29 @@ class ZoteroSemanticSearch:
         force_rebuild: bool = False,
         _failed_docs: list | None = None,
     ) -> dict[str, int]:
-        """Process a batch of items.
+        """Process a batch of items into chunked embeddings.
+
+        Each Zotero item is split into one-or-more overlapping token chunks
+        via `_chunk_document`. Chunk ids follow `<item_key>__<chunk_index>`
+        and each chunk's metadata carries `parent_item_key` so the search
+        handler can groupby back to one result per paper.
+
+        Before upserting fresh chunks for an item we delete any pre-existing
+        chunks for that parent so the chunk count can shrink between runs
+        (fulltext re-extraction sometimes yields less text).
 
         _failed_docs: optional list (passed by reference from update_database)
-        that collects (doc_text, metadata, doc_id) tuples for batches that fail
-        mid-run. Without this, the retry path at update_database:839-865 is
-        dead code — a NameError raised here would crash the whole reindex,
-        making every transient ChromaDB error fatal instead of recoverable.
+        that collects (doc_text, metadata, doc_id) tuples for batches that
+        fail mid-run. Without this, a transient ChromaDB error crashes the
+        whole reindex instead of surviving via the retry path.
         """
         stats = {"processed": 0, "added": 0, "updated": 0, "skipped": 0, "errors": 0}
 
-        documents = []
-        metadatas = []
-        ids = []
+        documents: list[str] = []
+        metadatas: list[dict[str, Any]] = []
+        ids: list[str] = []
+        parents_touched: list[str] = []
+        chunk_settings = self._load_chunking_settings()
 
         for item in items:
             try:
@@ -1239,18 +1402,35 @@ class ZoteroSemanticSearch:
                     doc_text = (structured_text + "\n\n" + fulltext) if structured_text.strip() else fulltext
                 else:
                     doc_text = structured_text
-                metadata = self._create_metadata(item)
+                base_metadata = self._create_metadata(item)
 
                 if not doc_text.strip():
                     stats["skipped"] += 1
                     continue
 
-                # Truncate to fit the configured embedding model's token limit
-                doc_text = self.chroma_client.truncate_text(doc_text)
+                # Split into token-bounded chunks. Unlike the old truncate-only
+                # path, chunking preserves the entire fulltext across multiple
+                # embeddings so paragraph-level semantic matches can land
+                # anywhere in the paper, not just the first 8k tokens.
+                chunks = self._chunk_document(
+                    doc_text,
+                    window=chunk_settings["window"],
+                    overlap=chunk_settings["overlap"],
+                )
+                if not chunks:
+                    stats["skipped"] += 1
+                    continue
 
-                documents.append(doc_text)
-                metadatas.append(metadata)
-                ids.append(item_key)
+                parents_touched.append(item_key)
+                total_chunks = len(chunks)
+                for idx, chunk_text in enumerate(chunks):
+                    chunk_meta = dict(base_metadata)
+                    chunk_meta["parent_item_key"] = item_key
+                    chunk_meta["chunk_index"] = idx
+                    chunk_meta["total_chunks"] = total_chunks
+                    documents.append(chunk_text)
+                    metadatas.append(chunk_meta)
+                    ids.append(f"{item_key}__{idx}")
 
                 stats["processed"] += 1
 
@@ -1258,34 +1438,50 @@ class ZoteroSemanticSearch:
                 logger.error(f"Error processing item {item.get('key', 'unknown')}: {e}")
                 stats["errors"] += 1
 
-        # Add documents to ChromaDB if any
-        if documents:
-            existing_ids = set()
-            if not force_rebuild:
-                existing_ids = self.chroma_client.get_existing_ids(ids)
+        if not documents:
+            return stats
 
+        # For non-rebuild runs: clear any stale chunks for these parents so
+        # chunk count can shrink. On force_rebuild the collection was already
+        # reset upstream, so no pre-existing chunks exist.
+        if not force_rebuild:
+            for pkey in parents_touched:
+                try:
+                    self.chroma_client.delete_documents_by_parent(pkey)
+                except Exception as e:
+                    logger.debug(f"Pre-upsert cleanup for {pkey} failed: {e}")
+
+        # Track which parents were already in the collection, for added/updated stats
+        pre_existing_parents: set[str] = set()
+        if not force_rebuild:
+            # get_existing_ids expects chunk ids; sample the first chunk of
+            # each parent to decide "new" vs "update" without a separate
+            # collection scan. This is a statistics-only signal.
+            sample_ids = [f"{p}__0" for p in parents_touched]
             try:
-                self.chroma_client.upsert_documents(documents, metadatas, ids)
-                for doc_id in ids:
-                    if doc_id in existing_ids:
-                        stats["updated"] += 1
-                    else:
-                        stats["added"] += 1
-            except Exception as e:
-                # Batch failed — collect failures for end-of-run retry.
-                # ChromaDB's ONNX tokenizer can fail intermittently in bursts;
-                # retrying immediately usually fails too. Collecting failures
-                # and retrying after all batches are done is more effective.
-                logger.warning(f"Batch upsert failed ({e}), saving for retry")
-                if _failed_docs is not None:
-                    for j in range(len(documents)):
-                        _failed_docs.append((documents[j], metadatas[j], ids[j]))
-                    # Count them as errors so stats are accurate
-                    stats["errors"] += len(documents)
+                pre_existing_parents = {
+                    i.split("__", 1)[0]
+                    for i in self.chroma_client.get_existing_ids(sample_ids)
+                }
+            except Exception:
+                pre_existing_parents = set()
+
+        try:
+            self._throttle_embedding_request()
+            self.chroma_client.upsert_documents(documents, metadatas, ids)
+            for pkey in parents_touched:
+                if pkey in pre_existing_parents:
+                    stats["updated"] += 1
                 else:
-                    # No retry list — this is the legacy crash path; re-raise
-                    # so caller sees the real error instead of hiding it.
-                    raise
+                    stats["added"] += 1
+        except Exception as e:
+            logger.warning(f"Batch upsert failed ({e}), saving for retry")
+            if _failed_docs is not None:
+                for j in range(len(documents)):
+                    _failed_docs.append((documents[j], metadatas[j], ids[j]))
+                stats["errors"] += len(parents_touched)
+            else:
+                raise
 
         return stats
 
@@ -1296,38 +1492,53 @@ class ZoteroSemanticSearch:
         """
         Perform semantic search over the Zotero library.
 
+        Because items are stored as multiple chunks (one per ~1500 tokens),
+        a naive top-N query can return the same paper multiple times. We
+        oversample from ChromaDB, groupby `parent_item_key`, keep the best
+        chunk per parent, then truncate to the user's requested limit.
+
         Args:
             query: Search query text
-            limit: Maximum number of results to return
+            limit: Maximum number of results to return (counted in unique papers)
             filters: Optional metadata filters
 
         Returns:
             Search results with Zotero item details
         """
         try:
-            # Over-fetch candidates when re-ranking is enabled
             reranker = self._get_reranker()
-            fetch_limit = limit
-            if reranker:
-                multiplier = self._reranker_config.get("candidate_multiplier", 3)
-                fetch_limit = limit * multiplier
+            rerank_mult = self._reranker_config.get("candidate_multiplier", 3) if reranker else 1
+            target_candidates = max(limit, 1) * rerank_mult
+            # Oversample generously: same paper may contribute many chunks,
+            # so the first N hits can all come from 1-2 papers. A 5x
+            # oversample on top of rerank's multiplier balances recall vs.
+            # network cost.
+            chroma_limit = max(target_candidates * 5, 50)
 
-            # Perform semantic search
             results = self.chroma_client.search(
                 query_texts=[query],
-                n_results=fetch_limit,
+                n_results=chroma_limit,
                 where=filters
             )
 
-            # Re-rank results with cross-encoder if enabled
+            # Collapse by parent: one best chunk per paper
+            results = self._dedupe_by_parent(results, keep=target_candidates)
+
+            # Re-rank survives after dedup since it works on (query, doc)
+            # pairs which are independent of chunk identity.
             if reranker and results.get("documents") and results["documents"][0]:
                 documents = results["documents"][0]
                 ranked_indices = reranker.rerank(query, documents, top_k=limit)
                 for key in ["ids", "distances", "documents", "metadatas"]:
                     if results.get(key) and results[key][0]:
                         results[key][0] = [results[key][0][i] for i in ranked_indices]
+            else:
+                # Without a reranker, dedupe already sorted by distance; just
+                # clip to the user-visible limit.
+                for key in ["ids", "distances", "documents", "metadatas"]:
+                    if results.get(key) and results[key][0]:
+                        results[key][0] = results[key][0][:limit]
 
-            # Enrich results with full Zotero item data
             enriched_results = self._enrich_search_results(results, query)
 
             return {
@@ -1349,8 +1560,57 @@ class ZoteroSemanticSearch:
                 "error": str(e)
             }
 
+    def _dedupe_by_parent(self, chroma_results: dict[str, Any], keep: int) -> dict[str, Any]:
+        """Collapse chunk hits so each parent_item_key appears at most once.
+
+        Keeps the chunk with the smallest distance (highest similarity)
+        per parent. Sorts the survivors ascending by distance and truncates
+        to `keep`. Falls back to the id's pre-`__` prefix when a metadata
+        record lacks `parent_item_key` (e.g. entries indexed before the
+        chunking migration).
+        """
+        if not chroma_results.get("ids") or not chroma_results["ids"][0]:
+            return chroma_results
+
+        ids = chroma_results["ids"][0]
+        distances = chroma_results.get("distances", [[]])[0] or []
+        documents = chroma_results.get("documents", [[]])[0] or []
+        metadatas = chroma_results.get("metadatas", [[]])[0] or []
+
+        best_per_parent: dict[str, int] = {}  # parent -> original index
+        for i, doc_id in enumerate(ids):
+            meta = metadatas[i] if i < len(metadatas) else {}
+            pkey = (meta or {}).get("parent_item_key")
+            if not pkey:
+                pkey = doc_id.split("__", 1)[0] if "__" in doc_id else doc_id
+            dist = distances[i] if i < len(distances) else float("inf")
+            cur = best_per_parent.get(pkey)
+            if cur is None:
+                best_per_parent[pkey] = i
+                continue
+            cur_dist = distances[cur] if cur < len(distances) else float("inf")
+            if dist < cur_dist:
+                best_per_parent[pkey] = i
+
+        kept_indices = sorted(
+            best_per_parent.values(),
+            key=lambda i: distances[i] if i < len(distances) else float("inf"),
+        )[:keep]
+
+        return {
+            "ids": [[ids[i] for i in kept_indices]],
+            "distances": [[distances[i] for i in kept_indices]] if distances else [[]],
+            "documents": [[documents[i] for i in kept_indices]] if documents else [[]],
+            "metadatas": [[metadatas[i] for i in kept_indices]] if metadatas else [[]],
+        }
+
     def _enrich_search_results(self, chroma_results: dict[str, Any], query: str) -> list[dict[str, Any]]:
-        """Enrich ChromaDB results with full Zotero item data."""
+        """Enrich ChromaDB results with full Zotero item data.
+
+        `ids` in chroma_results are chunk-scoped (`<parent>__<index>`).
+        We resolve each to its parent Zotero item for the web-API lookup
+        and surface that parent key as the result's `item_key`.
+        """
         enriched = []
 
         if not chroma_results.get("ids") or not chroma_results["ids"][0]:
@@ -1361,16 +1621,22 @@ class ZoteroSemanticSearch:
         documents = chroma_results.get("documents", [[]])[0]
         metadatas = chroma_results.get("metadatas", [[]])[0]
 
-        for i, item_key in enumerate(ids):
+        for i, chunk_id in enumerate(ids):
+            meta = metadatas[i] if i < len(metadatas) else {}
+            parent_key = (meta or {}).get("parent_item_key")
+            if not parent_key:
+                parent_key = chunk_id.split("__", 1)[0] if "__" in chunk_id else chunk_id
             try:
                 # Get full item data from Zotero
-                zotero_item = self.zotero_client.item(item_key)
+                zotero_item = self.zotero_client.item(parent_key)
 
                 enriched_result = {
-                    "item_key": item_key,
+                    "item_key": parent_key,
+                    "chunk_id": chunk_id,
+                    "chunk_index": (meta or {}).get("chunk_index"),
                     "similarity_score": 1 - distances[i] if i < len(distances) else 0,
                     "matched_text": documents[i] if i < len(documents) else "",
-                    "metadata": metadatas[i] if i < len(metadatas) else {},
+                    "metadata": meta,
                     "zotero_item": zotero_item,
                     "query": query
                 }
@@ -1378,13 +1644,15 @@ class ZoteroSemanticSearch:
                 enriched.append(enriched_result)
 
             except Exception as e:
-                logger.error(f"Error enriching result for item {item_key}: {e}")
+                logger.error(f"Error enriching result for item {parent_key}: {e}")
                 # Include basic result even if enrichment fails
                 enriched.append({
-                    "item_key": item_key,
+                    "item_key": parent_key,
+                    "chunk_id": chunk_id,
+                    "chunk_index": (meta or {}).get("chunk_index"),
                     "similarity_score": 1 - distances[i] if i < len(distances) else 0,
                     "matched_text": documents[i] if i < len(documents) else "",
-                    "metadata": metadatas[i] if i < len(metadatas) else {},
+                    "metadata": meta,
                     "query": query,
                     "error": f"Could not fetch full item data: {e}"
                 })

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -142,8 +142,46 @@ class ZoteroSemanticSearch:
 
         return config
 
-    def _save_update_config(self) -> None:
-        """Save update configuration to file."""
+    def _load_include_fulltext_setting(self) -> bool:
+        """Whether to fetch fulltext via the Zotero web API during indexing.
+
+        Defaults to True so existing users auto-upgrade to fulltext indexing on
+        their next sync. Users can opt out by setting
+        `semantic_search.include_fulltext: false` in the config file.
+        Local mode (`ZOTERO_LOCAL=true`) keeps using `extract_fulltext` via
+        the local sqlite DB; this setting only governs web-API ingestion.
+        """
+        if not self.config_path or not os.path.exists(self.config_path):
+            return True
+        try:
+            with open(self.config_path) as f:
+                file_config = json.load(f)
+                value = file_config.get("semantic_search", {}).get("include_fulltext", True)
+                return bool(value)
+        except Exception as e:
+            logger.warning(f"Error loading include_fulltext setting: {e}")
+            return True
+
+    def _load_last_sync_version(self) -> int:
+        """Last Zotero library version fully indexed into ChromaDB.
+
+        Zero means "no prior successful sync; bootstrap required". Used to
+        drive since-based incremental ingest via pyzotero's
+        `item_versions(since=V)` and `new_fulltext(since=V)`.
+        """
+        if not self.config_path or not os.path.exists(self.config_path):
+            return 0
+        try:
+            with open(self.config_path) as f:
+                file_config = json.load(f)
+                value = file_config.get("semantic_search", {}).get("last_sync_version", 0)
+                return int(value) if value is not None else 0
+        except Exception as e:
+            logger.warning(f"Error loading last_sync_version: {e}")
+            return 0
+
+    def _save_update_config(self, last_sync_version: int | None = None) -> None:
+        """Save update configuration and optionally update last_sync_version."""
         if not self.config_path:
             return
 
@@ -164,6 +202,8 @@ class ZoteroSemanticSearch:
             full_config["semantic_search"] = {}
 
         full_config["semantic_search"]["update_config"] = self.update_config
+        if last_sync_version is not None:
+            full_config["semantic_search"]["last_sync_version"] = int(last_sync_version)
 
         try:
             with open(self.config_path, 'w') as f:
@@ -298,19 +338,32 @@ class ZoteroSemanticSearch:
 
         return False
 
-    def _get_items_from_source(self, limit: int | None = None, extract_fulltext: bool = False, chroma_client: ChromaClient | None = None, force_rebuild: bool = False) -> list[dict[str, Any]]:
+    def _get_items_from_source(self,
+                               limit: int | None = None,
+                               extract_fulltext: bool = False,
+                               chroma_client: ChromaClient | None = None,
+                               force_rebuild: bool = False,
+                               include_fulltext_via_api: bool = False,
+                               ) -> list[dict[str, Any]]:
         """
         Get items from either local database or API.
 
         When extract_fulltext=True, requires local mode (ZOTERO_LOCAL=true);
-        raises RuntimeError if local mode is not enabled.
-        Otherwise uses API (faster, metadata-only).
+        raises RuntimeError if local mode is not enabled. This path reads the
+        local Zotero sqlite database and extracts PDF text on-disk.
+
+        When include_fulltext_via_api=True (web-API mode), fetches the
+        server-side extracted fulltext that Zotero cloud has already built
+        for each PDF — no local files required.
+
+        Otherwise uses API metadata only (fastest, title/abstract/tags).
 
         Args:
             limit: Optional limit on number of items
-            extract_fulltext: Whether to extract fulltext content
+            extract_fulltext: Whether to extract fulltext from the local sqlite DB
             chroma_client: ChromaDB client to check for existing documents (None to skip checks)
             force_rebuild: Whether to force extraction even if item exists
+            include_fulltext_via_api: Fetch fulltext via the Zotero web API
 
         Returns:
             List of items in API-compatible format
@@ -328,7 +381,7 @@ class ZoteroSemanticSearch:
                 force_rebuild=force_rebuild
             )
         else:
-            return self._get_items_from_api(limit)
+            return self._get_items_from_api(limit, include_fulltext=include_fulltext_via_api)
 
     def _get_items_from_local_db(self, limit: int | None = None, extract_fulltext: bool = False, chroma_client: ChromaClient | None = None, force_rebuild: bool = False) -> list[dict[str, Any]]:
         """
@@ -695,12 +748,119 @@ class ZoteroSemanticSearch:
 
         return creators
 
-    def _get_items_from_api(self, limit: int | None = None) -> list[dict[str, Any]]:
+    def _fetch_fulltext_via_web_api(self, item_key: str) -> tuple[str, str]:
+        """Fetch fulltext for a top-level item via the Zotero web API.
+
+        Zotero's cloud keeps a server-side extracted text for every PDF that
+        the desktop client has ever indexed. Web-API mode can retrieve that
+        text without needing the PDF file to be present locally.
+
+        The fulltext usually lives on the PDF attachment child, not the
+        parent. We first try the parent's own key (covers the case where the
+        parent is itself an attachment), then cascade through PDF attachment
+        children.
+
+        Returns:
+            (text, source) where source describes which endpoint supplied the
+            text (e.g. "web-api:parent", "web-api:attachment:<key>"). Empty
+            strings mean no fulltext is available for this item.
+        """
+        def _extract_content(resp: Any) -> str:
+            if isinstance(resp, dict):
+                return str(resp.get("content", "") or "")
+            if isinstance(resp, str):
+                return resp
+            return ""
+
+        # 1. Try the item itself (works when item_key IS the attachment key).
+        try:
+            resp = self.zotero_client.fulltext_item(item_key)
+            text = _extract_content(resp)
+            if text.strip():
+                return text, "web-api:parent"
+        except Exception as e:
+            logger.debug(f"fulltext_item({item_key}) failed: {e}")
+
+        # 2. Walk PDF attachment children and try each in order.
+        try:
+            children = self.zotero_client.children(item_key) or []
+        except Exception as e:
+            logger.debug(f"children({item_key}) failed: {e}")
+            children = []
+
+        for child in children:
+            data = child.get("data", {}) if isinstance(child, dict) else {}
+            if data.get("itemType") != "attachment":
+                continue
+            if data.get("contentType") != "application/pdf":
+                continue
+            child_key = child.get("key") or data.get("key")
+            if not child_key:
+                continue
+            try:
+                resp = self.zotero_client.fulltext_item(child_key)
+            except Exception as e:
+                logger.debug(f"fulltext_item({child_key}) failed: {e}")
+                continue
+            text = _extract_content(resp)
+            if text.strip():
+                return text, f"web-api:attachment:{child_key}"
+
+        return "", ""
+
+    def _attach_web_fulltext(self, items: list[dict[str, Any]]) -> None:
+        """Populate `data.fulltext` on each item in place using the web API."""
+        total = len(items)
+        if not total:
+            return
+        try:
+            sys.stderr.write(f"\nFetching fulltext for {total} items via web API...\n")
+            sys.stderr.flush()
+        except Exception:
+            pass
+        fetched = 0
+        for idx, item in enumerate(items, 1):
+            key = item.get("key", "")
+            data = item.setdefault("data", {})
+            # Skip items that obviously can't have fulltext
+            if data.get("itemType") in {"note", "annotation"}:
+                data["fulltext_attempted"] = True
+                continue
+            if not key:
+                continue
+            text, source = self._fetch_fulltext_via_web_api(key)
+            if text:
+                data["fulltext"] = text
+                data["fulltextSource"] = source
+                fetched += 1
+            else:
+                data["fulltext_attempted"] = True
+            if idx % 25 == 0 or idx == total:
+                try:
+                    sys.stderr.write(
+                        f"\r  Fulltext: {idx}/{total} items checked, "
+                        f"{fetched} with text"
+                    )
+                    sys.stderr.flush()
+                except Exception:
+                    pass
+        try:
+            sys.stderr.write("\n")
+        except Exception:
+            pass
+
+    def _get_items_from_api(self,
+                            limit: int | None = None,
+                            include_fulltext: bool = False) -> list[dict[str, Any]]:
         """
         Get items from Zotero API (original implementation).
 
         Args:
             limit: Optional limit on number of items
+            include_fulltext: If True, fetch server-side extracted PDF text
+                via pyzotero's fulltext_item endpoint for each returned
+                top-level item. Enables full-text semantic indexing without
+                requiring local Zotero mode.
 
         Returns:
             List of items from API
@@ -748,20 +908,83 @@ class ZoteroSemanticSearch:
         if limit:
             all_items = all_items[:limit]
 
+        if include_fulltext:
+            self._attach_web_fulltext(all_items)
+
         logger.info(f"Retrieved {len(all_items)} items from API")
         return all_items
+
+    def _get_changed_items_from_api(self,
+                                    since_version: int,
+                                    include_fulltext: bool = False
+                                    ) -> tuple[list[dict[str, Any]], set[str]]:
+        """Fetch only items changed in the Zotero library since a given version.
+
+        Uses pyzotero's `item_versions(since=V)` to discover changed top-level
+        item keys, then fetches their full payloads one at a time. When
+        `include_fulltext` is True, also fetches server-side extracted text
+        for each changed item.
+
+        Returns:
+            (changed_items, all_current_top_level_keys). The second element
+            powers deletion detection: any id present in the ChromaDB
+            collection but absent from it has been removed from the library.
+        """
+        logger.info(f"Fetching changed items since library version {since_version}...")
+        try:
+            changed_versions = self.zotero_client.item_versions(since=since_version) or {}
+        except Exception as e:
+            raise Exception(f"Failed to fetch item_versions(since={since_version}): {e}") from e
+
+        try:
+            current_versions = self.zotero_client.item_versions() or {}
+        except Exception as e:
+            logger.warning(f"Failed to fetch current item_versions for deletion check: {e}")
+            current_versions = {}
+        current_keys = set(current_versions.keys())
+
+        if not changed_versions:
+            return [], current_keys
+
+        changed_items: list[dict[str, Any]] = []
+        for key in changed_versions.keys():
+            try:
+                item = self.zotero_client.item(key)
+            except Exception as e:
+                logger.debug(f"item({key}) failed during incremental fetch: {e}")
+                continue
+            if not item:
+                continue
+            item_type = item.get("data", {}).get("itemType")
+            # Don't index attachments/notes as standalone entries; only
+            # top-level research items participate in semantic search.
+            if item_type in {"attachment", "note", "annotation"}:
+                continue
+            changed_items.append(item)
+
+        if include_fulltext and changed_items:
+            self._attach_web_fulltext(changed_items)
+
+        return changed_items, current_keys
 
     def update_database(self,
                        force_full_rebuild: bool = False,
                        limit: int | None = None,
-                       extract_fulltext: bool = False) -> dict[str, Any]:
+                       extract_fulltext: bool = False,
+                       include_fulltext: bool | None = None) -> dict[str, Any]:
         """
         Update the semantic search database with Zotero items.
 
         Args:
             force_full_rebuild: Whether to rebuild the entire database
             limit: Limit number of items to process (for testing)
-            extract_fulltext: Whether to extract fulltext content from local database
+            extract_fulltext: Whether to extract fulltext content from the
+                local Zotero sqlite database (requires ZOTERO_LOCAL=true)
+            include_fulltext: Whether to fetch server-side extracted
+                fulltext via the Zotero web API. Defaults to the
+                `semantic_search.include_fulltext` config setting (True
+                unless explicitly disabled). Ignored in local mode since
+                `extract_fulltext` provides richer local extraction.
 
         Returns:
             Update statistics
@@ -776,24 +999,101 @@ class ZoteroSemanticSearch:
             "updated_items": 0,
             "recovered_items": 0,
             "skipped_items": 0,
+            "deleted_items": 0,
             "errors": 0,
             "start_time": start_time.isoformat(),
             "duration": None
         }
 
         try:
+            # Resolve include_fulltext default from config if not specified
+            if include_fulltext is None:
+                include_fulltext = self._load_include_fulltext_setting()
+
+            # Web-API fulltext only applies when not using the local sqlite
+            # extractor (extract_fulltext=True takes precedence in local mode)
+            include_fulltext_via_api = include_fulltext and not extract_fulltext
+
             # Reset collection if force rebuild
             if force_full_rebuild:
                 logger.info("Force rebuilding database...")
                 self.chroma_client.reset_collection()
 
-            # Get all items from either local DB or API
-            all_items = self._get_items_from_source(
-                limit=limit,
-                extract_fulltext=extract_fulltext,
-                chroma_client=self.chroma_client if not force_full_rebuild else None,
-                force_rebuild=force_full_rebuild
+            # Decide whether to use since-based incremental ingest.
+            # Incremental requires: not a forced rebuild, not a local-extraction
+            # run (incremental path covers web-API metadata and optionally
+            # fulltext only), not a test limit, and a known prior sync version.
+            last_sync_version = self._load_last_sync_version() if not force_full_rebuild else 0
+            use_incremental = (
+                not force_full_rebuild
+                and not extract_fulltext
+                and limit is None
+                and last_sync_version > 0
             )
+
+            target_sync_version: int | None = None
+            all_items: list[dict[str, Any]] = []
+            if use_incremental:
+                try:
+                    target_sync_version = self.zotero_client.last_modified_version()
+                except Exception as e:
+                    logger.warning(f"last_modified_version() failed, falling back to full scan: {e}")
+                    use_incremental = False
+
+            if use_incremental and target_sync_version == last_sync_version:
+                # No changes since last sync; skip ingest but still touch last_update
+                try:
+                    sys.stderr.write(
+                        f"\nLibrary unchanged since last sync (version {last_sync_version}); "
+                        f"no items to reindex.\n"
+                    )
+                except Exception:
+                    pass
+                self.update_config["last_update"] = datetime.now().isoformat()
+                self._save_update_config(last_sync_version=target_sync_version)
+                end_time = datetime.now()
+                stats["duration"] = str(end_time - start_time)
+                stats["end_time"] = end_time.isoformat()
+                return stats
+
+            if use_incremental:
+                all_items, current_library_keys = self._get_changed_items_from_api(
+                    since_version=last_sync_version,
+                    include_fulltext=include_fulltext_via_api,
+                )
+                # Delete collection entries that are no longer present in the library
+                try:
+                    stored_ids = self.chroma_client.get_all_ids()
+                    to_delete = [k for k in (stored_ids - current_library_keys) if k]
+                    if to_delete:
+                        self.chroma_client.delete_documents(to_delete)
+                        stats["deleted_items"] = len(to_delete)
+                        try:
+                            sys.stderr.write(
+                                f"\nDeleted {len(to_delete)} items no longer present in Zotero.\n"
+                            )
+                        except Exception:
+                            pass
+                except Exception as e:
+                    logger.warning(f"Deletion pass failed: {e}")
+            else:
+                # Full scan: bootstrap or forced rebuild.
+                if not force_full_rebuild:
+                    # Capture the library version BEFORE scanning so any
+                    # changes made during the scan will be picked up by the
+                    # next incremental run.
+                    try:
+                        target_sync_version = self.zotero_client.last_modified_version()
+                    except Exception as e:
+                        logger.warning(f"last_modified_version() failed: {e}")
+                        target_sync_version = None
+                all_items = self._get_items_from_source(
+                    limit=limit,
+                    extract_fulltext=extract_fulltext,
+                    chroma_client=self.chroma_client if not force_full_rebuild else None,
+                    force_rebuild=force_full_rebuild,
+                    include_fulltext_via_api=include_fulltext_via_api,
+                )
 
             stats["total_items"] = len(all_items)
             logger.info(f"Found {stats['total_items']} items to process")
@@ -883,9 +1183,9 @@ class ZoteroSemanticSearch:
             except Exception:
                 pass
 
-            # Update last update time
+            # Update last update time, and promote last_sync_version on success
             self.update_config["last_update"] = datetime.now().isoformat()
-            self._save_update_config()
+            self._save_update_config(last_sync_version=target_sync_version)
 
             end_time = datetime.now()
             stats["duration"] = str(end_time - start_time)

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -1085,6 +1085,49 @@ class ZoteroSemanticSearch:
 
         return changed_items, current_keys
 
+    def _fetch_items_by_keys(self, keys: list[str]) -> list[dict[str, Any]]:
+        """Bulk-fetch top-level items by itemKey, batched through the
+        Zotero web API's `itemKey=K1,K2,...` query parameter.
+
+        Zotero caps the itemKey response at 50 items per request, which is
+        still 50× faster than per-key fetches for large backfills. Falls
+        back to per-key fetch if a batched request raises so a single bad
+        key can't stall the whole backfill. Attachments / notes / inline
+        annotations are filtered out to match the rest of the ingest
+        pipeline's assumptions.
+        """
+        if not keys:
+            return []
+        BATCH = 50
+        results: list[dict[str, Any]] = []
+        for i in range(0, len(keys), BATCH):
+            batch = keys[i:i + BATCH]
+            try:
+                self.zotero_client.add_parameters(
+                    itemKey=",".join(batch),
+                    limit=len(batch),
+                )
+                items = self.zotero_client.items() or []
+            except Exception as e:
+                logger.debug(
+                    f"Batched itemKey fetch failed ({e}); falling back to "
+                    f"per-key for this batch of {len(batch)}"
+                )
+                items = []
+                for key in batch:
+                    try:
+                        one = self.zotero_client.item(key)
+                        if one:
+                            items.append(one)
+                    except Exception as e2:
+                        logger.debug(f"item({key}) failed in fallback: {e2}")
+            for it in items:
+                itype = it.get("data", {}).get("itemType")
+                if itype in {"attachment", "note", "annotation"}:
+                    continue
+                results.append(it)
+        return results
+
     def update_database(self,
                        force_full_rebuild: bool = False,
                        limit: int | None = None,
@@ -1118,6 +1161,7 @@ class ZoteroSemanticSearch:
             "recovered_items": 0,
             "skipped_items": 0,
             "deleted_items": 0,
+            "gap_filled_items": 0,
             "errors": 0,
             "start_time": start_time.isoformat(),
             "duration": None
@@ -1137,16 +1181,16 @@ class ZoteroSemanticSearch:
             # pollutes dedup / rerank. Detect and upgrade to a fresh rebuild
             # so the user never has to run --force-rebuild manually.
             #
-            # Also cover the related case where the collection was silently
-            # reset at ChromaClient init (embedding-model dim change) but
-            # config still carries a non-zero last_sync_version. Without this
-            # guard, the incremental fast-path would see library version
-            # unchanged and skip ingest, leaving the collection permanently
-            # empty until the user manually ran --force-rebuild.
+            # The "empty collection but cached_sync > 0" case (e.g. after an
+            # embedding-model dim change triggered a silent collection
+            # reset) doesn't need a force-rebuild here because the
+            # diff-driven incremental path's gap-fill naturally handles it:
+            # stored_parents is empty -> missing_keys = all library keys ->
+            # every item gets ingested, with no need to throw away
+            # progress.
             if not force_full_rebuild:
                 try:
                     existing_ids = self.chroma_client.get_all_ids()
-                    cached_sync = self._load_last_sync_version()
                     if existing_ids:
                         sample = list(existing_ids)[:20]
                         if not any("__" in i for i in sample):
@@ -1163,20 +1207,6 @@ class ZoteroSemanticSearch:
                             except Exception:
                                 pass
                             force_full_rebuild = True
-                    elif cached_sync > 0:
-                        logger.info(
-                            "Collection is empty but config claims prior sync "
-                            f"(version {cached_sync}); likely reset after an "
-                            "embedding-model change. Rebuilding from scratch."
-                        )
-                        try:
-                            sys.stderr.write(
-                                "\nCollection was reset (likely after an embedding-model "
-                                "change); rebuilding from scratch...\n"
-                            )
-                        except Exception:
-                            pass
-                        force_full_rebuild = True
                 except Exception as e:
                     logger.debug(f"Legacy id-format check failed: {e}")
 
@@ -1206,36 +1236,53 @@ class ZoteroSemanticSearch:
                     logger.warning(f"last_modified_version() failed, falling back to full scan: {e}")
                     use_incremental = False
 
-            if use_incremental and target_sync_version == last_sync_version:
-                # No changes since last sync; skip ingest but still touch last_update
-                try:
-                    sys.stderr.write(
-                        f"\nLibrary unchanged since last sync (version {last_sync_version}); "
-                        f"no items to reindex.\n"
-                    )
-                except Exception:
-                    pass
-                self.update_config["last_update"] = datetime.now().isoformat()
-                self._save_update_config(last_sync_version=target_sync_version)
-                end_time = datetime.now()
-                stats["duration"] = str(end_time - start_time)
-                stats["end_time"] = end_time.isoformat()
-                return stats
-
             if use_incremental:
-                all_items, current_library_keys = self._get_changed_items_from_api(
+                # Diff-driven incremental path:
+                #   changed = items whose version > last_sync_version
+                #   missing = items currently in the library but not in our
+                #             ChromaDB (resume case: killed mid-rebuild,
+                #             embedding-model change reset, etc.)
+                #   deleted = items present in ChromaDB but no longer in the
+                #             library
+                # The ingest set is `changed ∪ missing`; if both that and
+                # `deleted` are empty the run is a true noop.
+                changed_items, current_library_keys = self._get_changed_items_from_api(
                     since_version=last_sync_version,
                     include_fulltext=include_fulltext_via_api,
                 )
+
+                # Gap-fill: items in the library but missing from ChromaDB.
+                # This is what makes resume work — a killed rebuild leaves
+                # ChromaDB partially populated without advancing
+                # last_sync_version, and the next run needs to pick up the
+                # holes instead of declaring "library unchanged; noop".
+                stored_ids = self.chroma_client.get_all_ids()
+                stored_parents = {
+                    i.split("__", 1)[0] if "__" in i else i
+                    for i in stored_ids
+                }
+                already_queued = {it.get("key") for it in changed_items if it.get("key")}
+                missing_keys = current_library_keys - stored_parents - already_queued
+                gap_items: list[dict[str, Any]] = []
+                if missing_keys:
+                    try:
+                        sys.stderr.write(
+                            f"\nGap fill: {len(missing_keys)} items in library "
+                            f"missing from ChromaDB; fetching...\n"
+                        )
+                    except Exception:
+                        pass
+                    gap_items = self._fetch_items_by_keys(sorted(missing_keys))
+                    if include_fulltext_via_api and gap_items:
+                        self._attach_web_fulltext(gap_items)
+                stats["gap_filled_items"] = len(gap_items)
+
+                all_items = changed_items + gap_items
+
                 # Delete collection entries that are no longer present in the
                 # library. With chunking, stored ids are `<parent>__<i>` so we
                 # must group by parent before computing the diff.
                 try:
-                    stored_ids = self.chroma_client.get_all_ids()
-                    stored_parents = {
-                        i.split("__", 1)[0] if "__" in i else i
-                        for i in stored_ids
-                    }
                     deleted_parents = [k for k in (stored_parents - current_library_keys) if k]
                     if deleted_parents:
                         total_deleted_chunks = 0
@@ -1251,6 +1298,23 @@ class ZoteroSemanticSearch:
                             pass
                 except Exception as e:
                     logger.warning(f"Deletion pass failed: {e}")
+
+                # True noop: nothing to add, nothing to delete. Still advance
+                # the watermark so subsequent runs short-circuit immediately.
+                if not all_items and not stats["deleted_items"]:
+                    try:
+                        sys.stderr.write(
+                            f"\nLibrary fully synced (version {target_sync_version}); "
+                            f"nothing to reindex.\n"
+                        )
+                    except Exception:
+                        pass
+                    self.update_config["last_update"] = datetime.now().isoformat()
+                    self._save_update_config(last_sync_version=target_sync_version)
+                    end_time = datetime.now()
+                    stats["duration"] = str(end_time - start_time)
+                    stats["end_time"] = end_time.isoformat()
+                    return stats
             else:
                 # Full scan: bootstrap or forced rebuild.
                 # Capture the library version BEFORE scanning so any changes

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -1078,15 +1078,18 @@ class ZoteroSemanticSearch:
                     logger.warning(f"Deletion pass failed: {e}")
             else:
                 # Full scan: bootstrap or forced rebuild.
-                if not force_full_rebuild:
-                    # Capture the library version BEFORE scanning so any
-                    # changes made during the scan will be picked up by the
-                    # next incremental run.
-                    try:
-                        target_sync_version = self.zotero_client.last_modified_version()
-                    except Exception as e:
-                        logger.warning(f"last_modified_version() failed: {e}")
-                        target_sync_version = None
+                # Capture the library version BEFORE scanning so any changes
+                # made during the scan will be picked up by the next
+                # incremental run. Skipping this after a force_full_rebuild
+                # would leave last_sync_version stale and the next
+                # incremental run would miss items that haven't changed
+                # since the old watermark (because they were just deleted
+                # along with the collection).
+                try:
+                    target_sync_version = self.zotero_client.last_modified_version()
+                except Exception as e:
+                    logger.warning(f"last_modified_version() failed: {e}")
+                    target_sync_version = None
                 all_items = self._get_items_from_source(
                     limit=limit,
                     extract_fulltext=extract_fulltext,

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -1011,10 +1011,15 @@ class ZoteroSemanticSearch:
             if not items:
                 break
 
-            # Filter out attachments and notes by default
+            # Filter out attachments, notes, and annotations. Annotations
+            # (PDF highlights / user comments) are top-level in the pyzotero
+            # /items listing but are semantically noise — they have no body
+            # text of their own and clog up semantic search results. The
+            # since-based fetch and itemKey batch-fetch already filter
+            # annotation too; keeping all three paths consistent.
             filtered_items = [
                 item for item in items
-                if item.get("data", {}).get("itemType") not in ["attachment", "note"]
+                if item.get("data", {}).get("itemType") not in ["attachment", "note", "annotation"]
             ]
 
             all_items.extend(filtered_items)
@@ -1162,6 +1167,7 @@ class ZoteroSemanticSearch:
             "skipped_items": 0,
             "deleted_items": 0,
             "gap_filled_items": 0,
+            "cleaned_annotation_chunks": 0,
             "errors": 0,
             "start_time": start_time.isoformat(),
             "duration": None
@@ -1214,6 +1220,25 @@ class ZoteroSemanticSearch:
             if force_full_rebuild:
                 logger.info("Force rebuilding database...")
                 self.chroma_client.reset_collection()
+            else:
+                # Self-healing: purge annotation chunks. A past version of
+                # `_get_items_from_api` excluded only attachment+note and
+                # let the `annotation` itemType through, producing
+                # thousands of useless zero-text entries. Now that the
+                # filter is tightened, sweep any stragglers on every run.
+                try:
+                    cleaned = self.chroma_client.delete_documents_by_item_type("annotation")
+                    if cleaned:
+                        stats["cleaned_annotation_chunks"] = cleaned
+                        try:
+                            sys.stderr.write(
+                                f"\nCleaned up {cleaned} stale annotation chunks "
+                                f"(past ingest-filter bug).\n"
+                            )
+                        except Exception:
+                            pass
+                except Exception as e:
+                    logger.debug(f"Annotation cleanup failed: {e}")
 
             # Decide whether to use since-based incremental ingest.
             # Incremental requires: not a forced rebuild, not a local-extraction

--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -102,6 +102,7 @@ from zotero_mcp.tools.write import (  # noqa: F401
     add_by_doi,
     add_by_url,
     update_item,
+    create_item,
     find_duplicates,
     merge_duplicates,
     get_pdf_outline,

--- a/src/zotero_mcp/setup_helper.py
+++ b/src/zotero_mcp/setup_helper.py
@@ -318,6 +318,11 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
 
     config["update_config"] = update_config
     config["extraction"] = {"pdf_max_pages": pdf_max_pages}
+    # Web-API users: index fulltext from Zotero's server-side extraction by
+    # default. Users can set this to false to keep the old metadata-only
+    # behavior. The flag is ignored in local mode (ZOTERO_LOCAL=true uses
+    # local sqlite extraction).
+    config.setdefault("include_fulltext", True)
     if zotero_db_path:
         config["zotero_db_path"] = zotero_db_path
 

--- a/src/zotero_mcp/setup_helper.py
+++ b/src/zotero_mcp/setup_helper.py
@@ -323,6 +323,13 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
     # behavior. The flag is ignored in local mode (ZOTERO_LOCAL=true uses
     # local sqlite extraction).
     config.setdefault("include_fulltext", True)
+    # Chunk every indexed document into overlapping token windows. 1500/225
+    # fits comfortably in OpenAI text-embedding-3-small, SiliconFlow bge-m3,
+    # and keeps paragraph-level localization intact.
+    config.setdefault("chunking", {"window": 1500, "overlap": 225})
+    # Set to a positive float (e.g. 2.0) when driving a rate-limited
+    # OpenAI-compatible endpoint such as SiliconFlow free tier.
+    config.setdefault("embedding_rate_limit_rps", None)
     if zotero_db_path:
         config["zotero_db_path"] = zotero_db_path
 

--- a/src/zotero_mcp/tools/search.py
+++ b/src/zotero_mcp/tools/search.py
@@ -3,6 +3,7 @@
 import json
 import logging as _logging
 import re
+import threading as _threading
 import time as _time
 from pathlib import Path
 from typing import Literal
@@ -17,6 +18,40 @@ from zotero_mcp.tools import _helpers
 _search_logger = _logging.getLogger("zotero_mcp.search")
 
 CASCADE_TIMEOUT = 60  # seconds — total budget for the entire fallback cascade
+
+# Pre-search background sync debounce: at most one fire-and-forget sync per
+# this many seconds, shared across all semantic_search tool invocations.
+_PRESEARCH_SYNC_MIN_INTERVAL = 60.0
+_last_presearch_sync_ts: float = 0.0
+_presearch_sync_lock = _threading.Lock()
+
+
+def _maybe_fire_presearch_sync(search) -> None:
+    """Schedule a background semantic-search DB update if auto-update is due.
+
+    Runs in a daemon thread so the current tool call returns immediately.
+    Intentionally swallows exceptions — a failed background sync must never
+    surface as a search-tool error to the user.
+    """
+    global _last_presearch_sync_ts
+    try:
+        if not search.should_update_database():
+            return
+    except Exception:
+        return
+    now = _time.monotonic()
+    with _presearch_sync_lock:
+        if now - _last_presearch_sync_ts < _PRESEARCH_SYNC_MIN_INTERVAL:
+            return
+        _last_presearch_sync_ts = now
+
+    def _run():
+        try:
+            search.update_database(extract_fulltext=_utils.is_local_mode())
+        except Exception as e:
+            _search_logger.debug(f"Background pre-search sync failed: {e}")
+
+    _threading.Thread(target=_run, daemon=True, name="zmcp-presearch-sync").start()
 
 
 def _search_with_variants(zot, query: str, qmode: str, limit: int,
@@ -732,6 +767,10 @@ def semantic_search(
 
         # Create semantic search instance
         search = create_semantic_search(str(config_path))
+
+        # Fire-and-forget: if auto-update is due, kick off a background sync
+        # so subsequent searches see fresh library state. Never blocks here.
+        _maybe_fire_presearch_sync(search)
 
         # Perform search
         results = search.search(query=query, limit=limit, filters=filters)

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -729,13 +729,36 @@ _UPDATE_ITEM_API_TO_PARAM = {
     "edition": "edition",
     "ISBN": "isbn",
     "bookTitle": "book_title",
+    "proceedingsTitle": "book_title",
+    "conferenceName": "conference_name",
+    "place": "place",
+    "series": "series",
 }
+
+
+# The Zotero field that holds the container / venue title depends on the item
+# type: bookSection uses "bookTitle" while conferencePaper uses
+# "proceedingsTitle". The generic `book_title` parameter is remapped to the
+# correct field so values land instead of being rejected as invalid for the type.
+_CONTAINER_TITLE_FIELD = {
+    "bookSection": "bookTitle",
+    "conferencePaper": "proceedingsTitle",
+}
+
+
+def _container_title_field(item_type: str | None) -> str:
+    """Return the Zotero field name that stores the container/venue title."""
+    return _CONTAINER_TITLE_FIELD.get(item_type or "", "bookTitle")
 
 
 @mcp.tool(
     name="zotero_update_item",
     description=(
         "Update metadata for an existing item in your Zotero library. "
+        "Pass item_type to convert the item to a different type (e.g. webpage -> "
+        "conferencePaper); fields valid for the new type (book_title, volume, pages, "
+        "etc.) are then applied instead of being skipped. For conferencePaper and "
+        "bookSection, book_title sets the venue/container title. "
         "To add tags without removing existing ones, use add_tags (not tags). "
         "To remove specific tags, use remove_tags. "
         "Using tags replaces ALL existing tags — use add_tags/remove_tags for incremental changes."
@@ -743,6 +766,7 @@ _UPDATE_ITEM_API_TO_PARAM = {
 )
 def update_item(
     item_key: str,
+    item_type: str | None = None,
     title: str | None = None,
     creators: list[dict] | str | None = None,
     date: str | None = None,
@@ -789,6 +813,27 @@ def update_item(
         data = item.get("data", {})
         changes = []
 
+        # Optional item-type change: rebuild the data payload from the new
+        # type's template so only fields valid for that type are sent (Zotero
+        # rejects fields invalid for an item type), carrying over compatible
+        # existing values + creators/tags/collections/extra.
+        current_type = data.get("itemType")
+        if item_type is not None and item_type != current_type:
+            template = write_zot.item_template(item_type)
+            new_data = dict(template)
+            for field in list(new_data.keys()):
+                if field != "itemType" and field in data:
+                    new_data[field] = data[field]
+            for meta in ("key", "version"):
+                if meta in data:
+                    new_data[meta] = data[meta]
+            new_data["itemType"] = item_type
+            item["data"] = new_data
+            data = new_data
+            changes.append(f"- **itemType**: '{current_type}' -> '{item_type}'")
+
+        effective_type = data.get("itemType")
+
         # Apply field updates
         field_updates = {}
         if title is not None:
@@ -824,7 +869,7 @@ def update_item(
         if isbn is not None:
             field_updates["ISBN"] = isbn
         if book_title is not None:
-            field_updates["bookTitle"] = book_title
+            field_updates[_container_title_field(effective_type)] = book_title
 
         skipped = []
         for field, value in field_updates.items():
@@ -901,6 +946,163 @@ def update_item(
     except Exception as e:
         ctx.error(f"Error updating item: {e}")
         return f"Error updating item: {e}"
+
+
+@mcp.tool(
+    name="zotero_create_item",
+    description=(
+        "Create a new, properly-typed item from scratch (no DOI/arXiv/file needed). "
+        "Use this for any Zotero item type — conferencePaper, journalArticle, book, "
+        "report, thesis, etc. — including papers whose DOI is not on CrossRef "
+        "(e.g. DataCite DOIs like 10.4230/LIPIcs.*). "
+        "item_type and title are required. For conferencePaper and bookSection, "
+        "book_title sets the venue/container title; for journalArticle use "
+        "publication_title."
+    )
+)
+def create_item(
+    item_type: str,
+    title: str,
+    creators: list[dict] | str | None = None,
+    date: str | None = None,
+    doi: str | None = None,
+    url: str | None = None,
+    abstract: str | None = None,
+    extra: str | None = None,
+    publication_title: str | None = None,
+    book_title: str | None = None,
+    conference_name: str | None = None,
+    place: str | None = None,
+    series: str | None = None,
+    volume: str | None = None,
+    issue: str | None = None,
+    pages: str | None = None,
+    publisher: str | None = None,
+    issn: str | None = None,
+    isbn: str | None = None,
+    language: str | None = None,
+    short_title: str | None = None,
+    edition: str | None = None,
+    tags: list[str] | str | None = None,
+    collections: list[str] | str | None = None,
+    collection_names: list[str] | str | None = None,
+    *,
+    ctx: Context
+) -> str:
+    try:
+        read_zot, write_zot = _helpers._get_write_client(ctx)
+    except ValueError as e:
+        return str(e)
+
+    try:
+        if not (title and title.strip()):
+            return "Error: 'title' is required to create an item."
+
+        ctx.info(f"Creating {item_type} item: {title}")
+
+        try:
+            template = write_zot.item_template(item_type)
+        except Exception as e:
+            return f"Error: could not load template for item type '{item_type}': {e}"
+        item_data = dict(template)
+        item_data["itemType"] = item_type
+
+        # Build field updates, remapping book_title to the container field for
+        # the target type (proceedingsTitle for conferencePaper, etc.).
+        field_updates = {"title": title}
+        if date is not None:
+            field_updates["date"] = date
+        if doi is not None:
+            field_updates["DOI"] = doi
+        if url is not None:
+            field_updates["url"] = url
+        if abstract is not None:
+            field_updates["abstractNote"] = abstract
+        if extra is not None:
+            field_updates["extra"] = extra
+        if publication_title is not None:
+            field_updates["publicationTitle"] = publication_title
+        if book_title is not None:
+            field_updates[_container_title_field(item_type)] = book_title
+        if conference_name is not None:
+            field_updates["conferenceName"] = conference_name
+        if place is not None:
+            field_updates["place"] = place
+        if series is not None:
+            field_updates["series"] = series
+        if volume is not None:
+            field_updates["volume"] = volume
+        if issue is not None:
+            field_updates["issue"] = issue
+        if pages is not None:
+            field_updates["pages"] = pages
+        if publisher is not None:
+            field_updates["publisher"] = publisher
+        if issn is not None:
+            field_updates["ISSN"] = issn
+        if isbn is not None:
+            field_updates["ISBN"] = isbn
+        if language is not None:
+            field_updates["language"] = language
+        if short_title is not None:
+            field_updates["shortTitle"] = short_title
+        if edition is not None:
+            field_updates["edition"] = edition
+
+        applied = []
+        skipped = []
+        for field, value in field_updates.items():
+            param_name = _UPDATE_ITEM_API_TO_PARAM.get(field, field)
+            if field in item_data:
+                item_data[field] = value
+                applied.append(param_name)
+            else:
+                skipped.append(param_name)
+
+        # Creators
+        if creators is not None:
+            if isinstance(creators, str):
+                creators = json.loads(creators)
+            item_data["creators"] = creators
+
+        # Tags
+        tag_list = _helpers._normalize_str_list_input(tags, "tags")
+        if tag_list:
+            item_data["tags"] = [{"tag": t} for t in tag_list]
+
+        # Collections (keys + resolved names)
+        coll_keys = set(_helpers._normalize_str_list_input(collections, "collections"))
+        if collection_names is not None:
+            names = _helpers._normalize_str_list_input(collection_names, "collection_names")
+            coll_keys.update(_helpers._resolve_collection_names(read_zot, names, ctx=ctx))
+        if coll_keys:
+            item_data["collections"] = list(coll_keys)
+
+        result = write_zot.create_items([item_data])
+        if isinstance(result, dict) and result.get("success"):
+            item_key = next(iter(result["success"].values()))
+            skip_warning = ""
+            if skipped:
+                skip_warning = (
+                    f"\n\nSkipped (not valid for item type "
+                    f"'{item_type}'): {', '.join(skipped)}"
+                )
+            return (
+                f"Successfully created **{title}**\n\n"
+                f"Item key: `{item_key}`\n"
+                f"Type: {item_type}\n"
+                f"Fields set: {', '.join(applied)}"
+                + skip_warning
+                + "\n\n_Note: To include this item in semantic search, run "
+                "zotero_update_search_database._"
+            )
+        return f"Failed to create item: {result}"
+
+    except ValueError as e:
+        return f"Input error: {e}"
+    except Exception as e:
+        ctx.error(f"Error creating item: {e}")
+        return f"Error creating item: {e}"
 
 
 @mcp.tool(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,19 @@ class FakeZotero:
                 "language": "",
                 "shortTitle": "",
             })
+        if item_type == "conferencePaper":
+            base.update({
+                "proceedingsTitle": "",
+                "conferenceName": "",
+                "place": "",
+                "publisher": "",
+                "volume": "",
+                "pages": "",
+                "series": "",
+                "ISBN": "",
+                "language": "",
+                "shortTitle": "",
+            })
         return base
 
     def addto_collection(self, collection_key, items, **kwargs):

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -476,11 +476,15 @@ def test_openai_embedding_sub_batches_large_input():
     from zotero_mcp.chroma_client import OpenAIEmbeddingFunction
     from unittest.mock import MagicMock
 
+    import threading as _t
     ef = OpenAIEmbeddingFunction.__new__(OpenAIEmbeddingFunction)
     ef.model_name = "BAAI/bge-m3"
     ef.api_key = "test"
     ef.base_url = "https://api.siliconflow.cn/v1"
     ef.request_batch_size = 3
+    ef.rate_limit_rps = None
+    ef._rate_lock = _t.Lock()
+    ef._last_request_ts = 0.0
     ef.client = MagicMock()
 
     def fake_create(model, input):
@@ -504,11 +508,15 @@ def test_openai_embedding_single_request_when_under_batch_size():
     from zotero_mcp.chroma_client import OpenAIEmbeddingFunction
     from unittest.mock import MagicMock
 
+    import threading as _t
     ef = OpenAIEmbeddingFunction.__new__(OpenAIEmbeddingFunction)
     ef.model_name = "text-embedding-3-small"
     ef.api_key = "test"
     ef.base_url = None
     ef.request_batch_size = 64
+    ef.rate_limit_rps = None
+    ef._rate_lock = _t.Lock()
+    ef._last_request_ts = 0.0
     ef.client = MagicMock()
     resp = MagicMock()
     resp.data = [MagicMock(embedding=[0.1, 0.2]) for _ in range(5)]

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -421,3 +421,58 @@ def test_load_chunking_settings_overrides(monkeypatch, tmp_path):
 def test_load_embedding_rate_limit_defaults_none(monkeypatch, tmp_path):
     search = _build_search(monkeypatch, config_path=str(tmp_path / "missing.json"))
     assert search._load_embedding_rate_limit() is None
+
+
+# --------- OpenAIEmbeddingFunction sub-batching ---------
+
+def test_openai_embedding_sub_batches_large_input():
+    """When input exceeds request_batch_size, __call__ splits the request.
+
+    SiliconFlow caps /v1/embeddings at 64 inputs per POST. Without
+    sub-batching, any item that chunks into >64 pieces would 413. This
+    test fakes the openai client and confirms request splitting.
+    """
+    from zotero_mcp.chroma_client import OpenAIEmbeddingFunction
+    from unittest.mock import MagicMock
+
+    ef = OpenAIEmbeddingFunction.__new__(OpenAIEmbeddingFunction)
+    ef.model_name = "BAAI/bge-m3"
+    ef.api_key = "test"
+    ef.base_url = "https://api.siliconflow.cn/v1"
+    ef.request_batch_size = 3
+    ef.client = MagicMock()
+
+    def fake_create(model, input):
+        resp = MagicMock()
+        resp.data = [MagicMock(embedding=[float(i)]) for i in range(len(input))]
+        return resp
+    ef.client.embeddings.create.side_effect = fake_create
+
+    # 7 inputs with batch_size=3 -> 3 requests: 3 + 3 + 1
+    result = ef(["a", "b", "c", "d", "e", "f", "g"])
+    assert len(result) == 7
+    assert ef.client.embeddings.create.call_count == 3
+    # Verify the split sizes
+    call_args = [c.kwargs.get("input", c.args[1] if len(c.args) > 1 else None)
+                 for c in ef.client.embeddings.create.call_args_list]
+    assert [len(ca) for ca in call_args] == [3, 3, 1]
+
+
+def test_openai_embedding_single_request_when_under_batch_size():
+    """Small inputs still hit the endpoint exactly once."""
+    from zotero_mcp.chroma_client import OpenAIEmbeddingFunction
+    from unittest.mock import MagicMock
+
+    ef = OpenAIEmbeddingFunction.__new__(OpenAIEmbeddingFunction)
+    ef.model_name = "text-embedding-3-small"
+    ef.api_key = "test"
+    ef.base_url = None
+    ef.request_batch_size = 64
+    ef.client = MagicMock()
+    resp = MagicMock()
+    resp.data = [MagicMock(embedding=[0.1, 0.2]) for _ in range(5)]
+    ef.client.embeddings.create.return_value = resp
+
+    result = ef(["a", "b", "c", "d", "e"])
+    assert len(result) == 5
+    assert ef.client.embeddings.create.call_count == 1

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,0 +1,423 @@
+"""Tests for the chunking, groupby rerank, throttle, and id-format
+migration introduced in the chunked semantic search PR.
+"""
+
+import json
+import sys
+import time
+
+import pytest
+
+if sys.version_info >= (3, 14):
+    pytest.skip(
+        "chromadb currently relies on pydantic v1 paths that are incompatible with Python 3.14+",
+        allow_module_level=True,
+    )
+
+from zotero_mcp import semantic_search
+
+
+class FakeChromaClient:
+    """Richer ChromaClient double covering chunked-era surface."""
+
+    def __init__(self, preloaded_ids=None):
+        self.embedding_max_tokens = 8000
+        self._ids = set(preloaded_ids or [])
+        self.added = []
+        self.deleted = []
+        self.deleted_by_parent = []
+        self.reset_calls = 0
+        self._last_query_kwargs = None
+        self._search_response = {
+            "ids": [[]],
+            "distances": [[]],
+            "documents": [[]],
+            "metadatas": [[]],
+        }
+
+    def truncate_text(self, text, max_tokens=None):
+        return text
+
+    def get_existing_ids(self, ids):
+        return {i for i in ids if i in self._ids}
+
+    def get_all_ids(self):
+        return set(self._ids)
+
+    def get_document_metadata(self, doc_id):
+        return None
+
+    def upsert_documents(self, documents, metadatas, ids):
+        self.added.append((list(documents), list(metadatas), list(ids)))
+        for i in ids:
+            self._ids.add(i)
+
+    def delete_documents(self, ids):
+        self.deleted.extend(list(ids))
+        for i in ids:
+            self._ids.discard(i)
+
+    def delete_documents_by_parent(self, parent_item_key):
+        prefix = f"{parent_item_key}__"
+        victims = [i for i in self._ids if i == parent_item_key or i.startswith(prefix)]
+        if victims:
+            self.deleted.extend(victims)
+            for v in victims:
+                self._ids.discard(v)
+        self.deleted_by_parent.append(parent_item_key)
+        return len(victims)
+
+    def reset_collection(self):
+        self.reset_calls += 1
+        self._ids = set()
+
+    def set_search_response(self, ids, distances, documents, metadatas):
+        self._search_response = {
+            "ids": [ids],
+            "distances": [distances],
+            "documents": [documents],
+            "metadatas": [metadatas],
+        }
+
+    def search(self, query_texts=None, n_results=10, where=None, where_document=None):
+        self._last_query_kwargs = {
+            "query_texts": query_texts,
+            "n_results": n_results,
+            "where": where,
+        }
+        return self._search_response
+
+
+def _build_search(monkeypatch, chroma=None, config_path=None,
+                  zotero_client=None):
+    monkeypatch.setattr(semantic_search, "get_zotero_client",
+                        lambda: zotero_client or object())
+    monkeypatch.setattr(semantic_search, "is_local_mode", lambda: False)
+    return semantic_search.ZoteroSemanticSearch(
+        chroma_client=chroma or FakeChromaClient(),
+        config_path=config_path,
+    )
+
+
+def _write_config(tmp_path, extra=None):
+    cfg = {
+        "semantic_search": {
+            "embedding_model": "default",
+            "update_config": {"auto_update": False, "update_frequency": "manual"},
+            "extraction": {"pdf_max_pages": 10},
+            "include_fulltext": True,
+        }
+    }
+    if extra:
+        cfg["semantic_search"].update(extra)
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps(cfg))
+    return str(p)
+
+
+# --------- Chunking ---------
+
+def test_chunk_short_text_returns_single_chunk(monkeypatch):
+    search = _build_search(monkeypatch)
+    chunks = search._chunk_document("A short abstract.", window=1500, overlap=225)
+    assert chunks == ["A short abstract."]
+
+
+def test_chunk_empty_returns_empty(monkeypatch):
+    search = _build_search(monkeypatch)
+    assert search._chunk_document("", window=1500) == []
+    assert search._chunk_document("    ", window=1500) == []
+
+
+def test_chunk_long_text_produces_multiple_chunks(monkeypatch):
+    search = _build_search(monkeypatch)
+    # Build a document well above the window size. cl100k_base typically
+    # counts ~1.3 tokens per 1-char word; use a very small window so any
+    # tokenizer yields at least two chunks.
+    text = ("word " * 400).strip()
+    chunks = search._chunk_document(text, window=50, overlap=10)
+    assert len(chunks) >= 2
+    # Chunks are non-empty and meaningfully sized
+    for c in chunks:
+        assert c.strip()
+
+
+def test_chunk_overlap_clamped_to_window(monkeypatch):
+    """Malformed config with overlap >= window must not loop forever."""
+    search = _build_search(monkeypatch)
+    text = ("word " * 300).strip()
+    # overlap == window would cause step=0 in a naive implementation
+    chunks = search._chunk_document(text, window=20, overlap=20)
+    assert chunks  # finite, non-empty
+    assert len(chunks) < 1000  # didn't explode
+
+
+def test_chunk_size_respects_window(monkeypatch):
+    """Every emitted chunk must fit inside the configured window token limit."""
+    search = _build_search(monkeypatch)
+    text = ("paragraph text. " * 500).strip()
+    window = 100
+    chunks = search._chunk_document(text, window=window, overlap=10)
+    # Use the same tokenizer the chunker relies on
+    from zotero_mcp.semantic_search import _tokenizer
+    if _tokenizer is None:
+        pytest.skip("tiktoken not available")
+    for c in chunks:
+        assert len(_tokenizer.encode(c, disallowed_special=())) <= window
+
+
+# --------- Chunked ingest via _process_item_batch ---------
+
+def _item(key, title="Paper", fulltext=""):
+    return {
+        "key": key,
+        "version": 1,
+        "data": {
+            "key": key,
+            "itemType": "journalArticle",
+            "title": title,
+            "abstractNote": "abstract",
+            "creators": [],
+            "fulltext": fulltext,
+            "dateAdded": "2024-01-01T00:00:00Z",
+            "dateModified": "2024-01-01T00:00:00Z",
+        },
+    }
+
+
+def test_process_item_batch_emits_chunked_ids(monkeypatch):
+    chroma = FakeChromaClient()
+    search = _build_search(monkeypatch, chroma=chroma)
+    item = _item("ITEM1", title="T", fulltext="body " * 2000)
+    stats = search._process_item_batch([item], force_rebuild=True)
+    assert stats["processed"] == 1
+    # All added ids are `ITEM1__<i>` and at least 2 chunks emitted
+    added_ids = [i for batch in chroma.added for i in batch[2]]
+    assert all(i.startswith("ITEM1__") for i in added_ids)
+    assert len(added_ids) >= 2
+    # Each chunk metadata has parent_item_key and chunk_index
+    metas = [m for batch in chroma.added for m in batch[1]]
+    assert all(m.get("parent_item_key") == "ITEM1" for m in metas)
+    indices = [m["chunk_index"] for m in metas]
+    assert indices == list(range(len(indices)))
+
+
+def test_process_item_batch_cleans_stale_chunks_before_upsert(monkeypatch):
+    chroma = FakeChromaClient(preloaded_ids=[
+        "ITEM1__0", "ITEM1__1", "ITEM1__2",  # stale chunks from prior run
+    ])
+    search = _build_search(monkeypatch, chroma=chroma)
+    item = _item("ITEM1", title="T", fulltext="body")  # short → 1 chunk
+    search._process_item_batch([item], force_rebuild=False)
+    # Cleanup called with parent key
+    assert "ITEM1" in chroma.deleted_by_parent
+
+
+# --------- Groupby rerank (_dedupe_by_parent + search) ---------
+
+def test_dedupe_by_parent_keeps_best_chunk(monkeypatch):
+    search = _build_search(monkeypatch)
+    raw = {
+        "ids": [["P1__0", "P1__2", "P2__0", "P1__1"]],
+        "distances": [[0.5, 0.3, 0.4, 0.1]],
+        "documents": [["d0", "d2", "p2d0", "d1"]],
+        "metadatas": [[
+            {"parent_item_key": "P1", "chunk_index": 0},
+            {"parent_item_key": "P1", "chunk_index": 2},
+            {"parent_item_key": "P2", "chunk_index": 0},
+            {"parent_item_key": "P1", "chunk_index": 1},
+        ]],
+    }
+    out = search._dedupe_by_parent(raw, keep=10)
+    ids = out["ids"][0]
+    # Expected: P1 best chunk = P1__1 (distance 0.1), P2 = P2__0 (0.4)
+    # Order after dedupe is by distance ascending
+    assert ids == ["P1__1", "P2__0"]
+
+
+def test_dedupe_by_parent_respects_keep_limit(monkeypatch):
+    search = _build_search(monkeypatch)
+    raw = {
+        "ids": [[f"P{i}__0" for i in range(10)]],
+        "distances": [[0.1 * i for i in range(10)]],
+        "documents": [[f"d{i}" for i in range(10)]],
+        "metadatas": [[{"parent_item_key": f"P{i}"} for i in range(10)]],
+    }
+    out = search._dedupe_by_parent(raw, keep=3)
+    assert len(out["ids"][0]) == 3
+
+
+def test_dedupe_by_parent_falls_back_to_id_prefix(monkeypatch):
+    """Legacy entries without parent_item_key metadata should still dedupe
+    via the `__` prefix convention."""
+    search = _build_search(monkeypatch)
+    raw = {
+        "ids": [["P1__0", "P1__1"]],
+        "distances": [[0.2, 0.1]],
+        "documents": [["d0", "d1"]],
+        "metadatas": [[{}, {}]],  # missing parent_item_key
+    }
+    out = search._dedupe_by_parent(raw, keep=10)
+    assert out["ids"][0] == ["P1__1"]  # best chunk kept
+
+
+def test_search_enriches_with_parent_key(monkeypatch):
+    """Enrichment must look up the parent item, not the chunk id."""
+    class RecordingZoteroClient:
+        def __init__(self):
+            self.calls = []
+
+        def item(self, key):
+            self.calls.append(key)
+            return {"key": key, "data": {"title": f"title-{key}"}}
+
+    zot = RecordingZoteroClient()
+    chroma = FakeChromaClient()
+    chroma.set_search_response(
+        ids=["PAPER__3"],
+        distances=[0.1],
+        documents=["matched paragraph content"],
+        metadatas=[{"parent_item_key": "PAPER", "chunk_index": 3, "title": "The Paper"}],
+    )
+    search = _build_search(monkeypatch, chroma=chroma, zotero_client=zot)
+    result = search.search("query", limit=5)
+    assert zot.calls == ["PAPER"]  # parent key, not chunk id
+    assert result["results"][0]["item_key"] == "PAPER"
+    assert result["results"][0]["chunk_id"] == "PAPER__3"
+    assert result["results"][0]["chunk_index"] == 3
+
+
+def test_search_oversamples_for_chunking(monkeypatch):
+    chroma = FakeChromaClient()
+    chroma.set_search_response(
+        ids=["X__0"], distances=[0.1], documents=["d"],
+        metadatas=[{"parent_item_key": "X"}],
+    )
+
+    class StubZotero:
+        def item(self, k):
+            return {"key": k, "data": {"title": "x"}}
+    search = _build_search(monkeypatch, chroma=chroma, zotero_client=StubZotero())
+    search.search("q", limit=5)
+    # Chunked oversample: max(limit * 5, 50) = 50 for small limits
+    assert chroma._last_query_kwargs["n_results"] == 50
+
+
+# --------- Throttle ---------
+
+def test_throttle_with_no_config_is_noop(monkeypatch):
+    search = _build_search(monkeypatch)
+    t0 = time.monotonic()
+    for _ in range(5):
+        search._throttle_embedding_request()
+    # Must complete near-instantly when no rps configured
+    assert time.monotonic() - t0 < 0.5
+
+
+def test_throttle_rate_limits_across_calls(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path, extra={"embedding_rate_limit_rps": 10.0})
+    search = _build_search(monkeypatch, config_path=config_path)
+    # 3 calls at 10 rps should take at least 2 * 0.1s = 0.2s total
+    t0 = time.monotonic()
+    for _ in range(3):
+        search._throttle_embedding_request()
+    elapsed = time.monotonic() - t0
+    # Lower bound check with some slack for scheduler jitter
+    assert elapsed >= 0.18, f"throttle too fast: {elapsed}s for 3 calls at 10 rps"
+    # Upper bound: shouldn't sleep much more than necessary
+    assert elapsed < 2.0
+
+
+def test_throttle_respects_invalid_rps(monkeypatch, tmp_path):
+    """Negative / zero / non-numeric values must be treated as 'no throttle'."""
+    for val in [0, -2, "bogus"]:
+        config_path = _write_config(tmp_path, extra={"embedding_rate_limit_rps": val})
+        search = _build_search(monkeypatch, config_path=config_path)
+        assert search._load_embedding_rate_limit() is None
+
+
+# --------- Legacy id-format migration ---------
+
+def test_legacy_id_format_triggers_rebuild(monkeypatch, tmp_path):
+    """A collection built by the pre-chunking code (ids = raw item keys with
+    no `__` delimiter) must be reset on next update_database call so the
+    new chunked format takes over cleanly."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 99})
+
+    class StubZotero:
+        def __init__(self):
+            self.scenario_items = [_item("X")]
+            self.versions = {"X": 99}
+
+        def items(self, start=0, limit=100, **_):
+            return self.scenario_items[start:start + limit]
+
+        def item(self, k):
+            return self.scenario_items[0]
+
+        def fulltext_item(self, k):
+            raise RuntimeError("no fulltext")
+
+        def children(self, k):
+            return []
+
+        def last_modified_version(self, **_):
+            return 99
+
+        def item_versions(self, since=None, **_):
+            if since is None:
+                return dict(self.versions)
+            return {k: v for k, v in self.versions.items() if v > since}
+
+    # Preload with legacy-format ids (no __ delimiter)
+    chroma = FakeChromaClient(preloaded_ids=["LEGACY_A", "LEGACY_B"])
+    search = _build_search(monkeypatch, chroma=chroma, zotero_client=StubZotero(),
+                           config_path=config_path)
+
+    search.update_database()
+
+    # reset_collection must have been called as part of the legacy migration
+    assert chroma.reset_calls >= 1
+
+
+def test_new_id_format_does_not_trigger_rebuild(monkeypatch, tmp_path):
+    """A collection already in chunked format must not be rebuilt."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 99})
+
+    class StubZotero:
+        def items(self, **_):
+            return []
+
+        def last_modified_version(self, **_):
+            return 99
+
+        def item_versions(self, since=None, **_):
+            return {}
+
+    chroma = FakeChromaClient(preloaded_ids=["A__0", "A__1", "B__0"])
+    search = _build_search(monkeypatch, chroma=chroma, zotero_client=StubZotero(),
+                           config_path=config_path)
+
+    search.update_database()
+    assert chroma.reset_calls == 0
+
+
+# --------- Config loaders ---------
+
+def test_load_chunking_settings_defaults(monkeypatch, tmp_path):
+    search = _build_search(monkeypatch, config_path=str(tmp_path / "missing.json"))
+    settings = search._load_chunking_settings()
+    assert settings == {"window": 1500, "overlap": 225}
+
+
+def test_load_chunking_settings_overrides(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path, extra={"chunking": {"window": 800, "overlap": 80}})
+    search = _build_search(monkeypatch, config_path=config_path)
+    settings = search._load_chunking_settings()
+    assert settings["window"] == 800
+    assert settings["overlap"] == 80
+
+
+def test_load_embedding_rate_limit_defaults_none(monkeypatch, tmp_path):
+    search = _build_search(monkeypatch, config_path=str(tmp_path / "missing.json"))
+    assert search._load_embedding_rate_limit() is None

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -380,10 +380,11 @@ def test_legacy_id_format_triggers_rebuild(monkeypatch, tmp_path):
     assert chroma.reset_calls >= 1
 
 
-def test_empty_collection_with_cached_sync_triggers_rebuild(monkeypatch, tmp_path):
+def test_empty_collection_with_cached_sync_is_gap_filled(monkeypatch, tmp_path):
     """If the collection was silently reset (e.g. embedding-model change)
-    but config still carries last_sync_version > 0, the incremental path
-    must NOT fast-path as noop — it must do a full rebuild."""
+    but config still carries last_sync_version > 0 and the library version
+    equals cached_sync, the diff-driven incremental path must still ingest
+    every library item via the gap-fill branch — NOT noop-return."""
     config_path = _write_config(tmp_path, extra={"last_sync_version": 7661})
 
     class StubZotero:
@@ -402,8 +403,11 @@ def test_empty_collection_with_cached_sync_triggers_rebuild(monkeypatch, tmp_pat
         def children(self, k):
             return []
 
+        def add_parameters(self, **_):
+            pass
+
         def last_modified_version(self, **_):
-            return 7661  # same as cached — noop trap
+            return 7661  # same as cached — noop trap for the old fast-path
 
         def item_versions(self, since=None, **_):
             if since is None:
@@ -415,10 +419,13 @@ def test_empty_collection_with_cached_sync_triggers_rebuild(monkeypatch, tmp_pat
     search = _build_search(monkeypatch, chroma=chroma, zotero_client=StubZotero(),
                            config_path=config_path)
 
-    search.update_database()
+    stats = search.update_database()
 
-    # Must have indexed the full library, not fast-pathed as noop
-    assert len(chroma.added) > 0, "Full rebuild did not ingest any items"
+    # Must have gap-filled the single library item
+    assert len(chroma.added) > 0, "Gap-fill did not ingest any items"
+    assert stats["gap_filled_items"] == 1
+    # Force-rebuild path should NOT have fired (no reset)
+    assert chroma.reset_calls == 0
 
 
 def test_new_id_format_does_not_trigger_rebuild(monkeypatch, tmp_path):

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -380,6 +380,47 @@ def test_legacy_id_format_triggers_rebuild(monkeypatch, tmp_path):
     assert chroma.reset_calls >= 1
 
 
+def test_empty_collection_with_cached_sync_triggers_rebuild(monkeypatch, tmp_path):
+    """If the collection was silently reset (e.g. embedding-model change)
+    but config still carries last_sync_version > 0, the incremental path
+    must NOT fast-path as noop — it must do a full rebuild."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 7661})
+
+    class StubZotero:
+        def __init__(self):
+            self.items_data = [_item("ONLY_ONE")]
+
+        def items(self, start=0, limit=100, **_):
+            return self.items_data[start:start + limit]
+
+        def item(self, k):
+            return self.items_data[0]
+
+        def fulltext_item(self, k):
+            raise RuntimeError("no fulltext")
+
+        def children(self, k):
+            return []
+
+        def last_modified_version(self, **_):
+            return 7661  # same as cached — noop trap
+
+        def item_versions(self, since=None, **_):
+            if since is None:
+                return {"ONLY_ONE": 7661}
+            return {}
+
+    # Collection is empty (e.g. model-change reset)
+    chroma = FakeChromaClient(preloaded_ids=[])
+    search = _build_search(monkeypatch, chroma=chroma, zotero_client=StubZotero(),
+                           config_path=config_path)
+
+    search.update_database()
+
+    # Must have indexed the full library, not fast-pathed as noop
+    assert len(chroma.added) > 0, "Full rebuild did not ingest any items"
+
+
 def test_new_id_format_does_not_trigger_rebuild(monkeypatch, tmp_path):
     """A collection already in chunked format must not be rebuilt."""
     config_path = _write_config(tmp_path, extra={"last_sync_version": 99})

--- a/tests/test_create_item.py
+++ b/tests/test_create_item.py
@@ -1,0 +1,187 @@
+"""Tests for zotero_create_item (create-from-scratch, arbitrary item types)."""
+
+from unittest.mock import patch
+
+import pytest
+from conftest import FakeZotero
+
+from zotero_mcp import server
+
+
+@pytest.fixture
+def patch_write_client():
+    """Patch _get_write_client to return one fake for both read and write."""
+    zot = FakeZotero()
+    with patch(
+        "zotero_mcp.tools._helpers._get_write_client", return_value=(zot, zot)
+    ):
+        yield zot
+
+
+# ---------------------------------------------------------------------------
+# conferencePaper (the LIPIcs / DataCite-DOI use case)
+# ---------------------------------------------------------------------------
+
+class TestCreateConferencePaper:
+
+    def test_conference_paper_with_datacite_doi(self, dummy_ctx, patch_write_client):
+        """A LIPIcs paper (DataCite DOI, not on CrossRef) can be created
+        directly as a conferencePaper with venue/volume/pages."""
+        zot = patch_write_client
+        result = server.create_item(
+            item_type="conferencePaper",
+            title="An Interesting AFT Paper",
+            doi="10.4230/LIPIcs.AFT.2025.29",
+            book_title="7th Conference on Advances in Financial Technologies (AFT 2025)",
+            volume="354",
+            pages="29:1--29:22",
+            ctx=dummy_ctx,
+        )
+
+        assert len(zot.created) == 1
+        d = zot.created[0]
+        assert d["itemType"] == "conferencePaper"
+        assert d["DOI"] == "10.4230/LIPIcs.AFT.2025.29"
+        # book_title lands in the conferencePaper venue field
+        assert d["proceedingsTitle"] == \
+            "7th Conference on Advances in Financial Technologies (AFT 2025)"
+        assert d["volume"] == "354"
+        assert d["pages"] == "29:1--29:22"
+        assert "Successfully" in result
+        assert "conferencePaper" in result
+
+    def test_conference_extra_fields(self, dummy_ctx, patch_write_client):
+        zot = patch_write_client
+        server.create_item(
+            item_type="conferencePaper",
+            title="Paper",
+            conference_name="AFT 2025",
+            place="Pisa, Italy",
+            series="LIPIcs",
+            ctx=dummy_ctx,
+        )
+        d = zot.created[0]
+        assert d["conferenceName"] == "AFT 2025"
+        assert d["place"] == "Pisa, Italy"
+        assert d["series"] == "LIPIcs"
+
+    def test_creators_applied(self, dummy_ctx, patch_write_client):
+        zot = patch_write_client
+        creators = [
+            {"creatorType": "author", "firstName": "Ada", "lastName": "Lovelace"},
+            {"creatorType": "author", "firstName": "Alan", "lastName": "Turing"},
+        ]
+        server.create_item(
+            item_type="conferencePaper",
+            title="Joint Work",
+            creators=creators,
+            ctx=dummy_ctx,
+        )
+        assert zot.created[0]["creators"] == creators
+
+    def test_creators_as_json_string(self, dummy_ctx, patch_write_client):
+        zot = patch_write_client
+        server.create_item(
+            item_type="conferencePaper",
+            title="Joint Work",
+            creators='[{"creatorType": "author", "name": "Anon"}]',
+            ctx=dummy_ctx,
+        )
+        assert zot.created[0]["creators"][0]["name"] == "Anon"
+
+    def test_tags_and_collections(self, dummy_ctx, patch_write_client):
+        zot = patch_write_client
+        server.create_item(
+            item_type="conferencePaper",
+            title="Tagged",
+            tags=["defi", "consensus"],
+            collections=["COLLKEY1"],
+            ctx=dummy_ctx,
+        )
+        d = zot.created[0]
+        assert {t["tag"] for t in d["tags"]} == {"defi", "consensus"}
+        assert "COLLKEY1" in d["collections"]
+
+    def test_collection_names_resolved(self, dummy_ctx, patch_write_client):
+        zot = patch_write_client
+        zot._collections = [{"key": "COLL01", "data": {"name": "My Papers"}}]
+        server.create_item(
+            item_type="conferencePaper",
+            title="Resolved",
+            collection_names=["My Papers"],
+            ctx=dummy_ctx,
+        )
+        assert "COLL01" in zot.created[0]["collections"]
+
+
+# ---------------------------------------------------------------------------
+# journalArticle
+# ---------------------------------------------------------------------------
+
+class TestCreateJournalArticle:
+
+    def test_journal_article_publication_title(self, dummy_ctx, patch_write_client):
+        zot = patch_write_client
+        server.create_item(
+            item_type="journalArticle",
+            title="A Study",
+            publication_title="Nature",
+            volume="600",
+            issue="7",
+            pages="1-10",
+            ctx=dummy_ctx,
+        )
+        d = zot.created[0]
+        assert d["itemType"] == "journalArticle"
+        assert d["publicationTitle"] == "Nature"
+        assert d["volume"] == "600"
+        assert d["issue"] == "7"
+        assert d["pages"] == "1-10"
+
+
+# ---------------------------------------------------------------------------
+# Validation and error handling
+# ---------------------------------------------------------------------------
+
+class TestCreateItemValidation:
+
+    def test_title_required(self, dummy_ctx, patch_write_client):
+        zot = patch_write_client
+        result = server.create_item(
+            item_type="conferencePaper",
+            title="",
+            ctx=dummy_ctx,
+        )
+        assert zot.created == []
+        assert "title" in result.lower()
+        assert "required" in result.lower()
+
+    def test_invalid_fields_skipped_not_sent(self, dummy_ctx, patch_write_client):
+        """Fields invalid for the type are reported as skipped and never put in
+        the payload (Zotero rejects unknown fields)."""
+        zot = patch_write_client
+        # book_title -> bookTitle is invalid for a journalArticle
+        result = server.create_item(
+            item_type="journalArticle",
+            title="X",
+            book_title="Should Not Apply",
+            ctx=dummy_ctx,
+        )
+        d = zot.created[0]
+        assert "bookTitle" not in d
+        assert "book_title" in result  # skip warning mentions the param
+
+    def test_local_only_rejected(self, dummy_ctx):
+        with patch(
+            "zotero_mcp.tools._helpers._get_write_client",
+            side_effect=ValueError(
+                "Cannot perform write operations in local-only mode. "
+                "Add ZOTERO_API_KEY and ZOTERO_LIBRARY_ID to enable hybrid mode."
+            ),
+        ):
+            result = server.create_item(
+                item_type="conferencePaper",
+                title="X",
+                ctx=dummy_ctx,
+            )
+        assert "local-only" in result.lower() or "cannot" in result.lower()

--- a/tests/test_fulltext_web_mode.py
+++ b/tests/test_fulltext_web_mode.py
@@ -1,0 +1,435 @@
+"""Tests for web-API fulltext ingest and since-based incremental sync.
+
+These tests cover the web-API branch introduced by the PR that adds fulltext
+fetching via pyzotero's `fulltext_item` endpoint and version-based incremental
+updates for users who don't have `ZOTERO_LOCAL=true` set (e.g. Claude Code on
+a headless Linux server talking to Zotero cloud).
+"""
+
+import json
+import sys
+
+import pytest
+
+if sys.version_info >= (3, 14):
+    pytest.skip(
+        "chromadb currently relies on pydantic v1 paths that are incompatible with Python 3.14+",
+        allow_module_level=True,
+    )
+
+from zotero_mcp import semantic_search
+
+
+class FakeChromaClient:
+    """Minimal ChromaClient stand-in that records operations for assertions."""
+
+    def __init__(self, preloaded_ids=None):
+        self.embedding_max_tokens = 8000
+        self._ids = set(preloaded_ids or [])
+        self.added = []  # list of (docs, metas, ids)
+        self.deleted = []  # list of ids deleted
+        self.reset_calls = 0
+
+    def truncate_text(self, text, max_tokens=None):
+        return text[:4000]
+
+    def get_existing_ids(self, ids):
+        return {i for i in ids if i in self._ids}
+
+    def get_all_ids(self):
+        return set(self._ids)
+
+    def get_document_metadata(self, doc_id):
+        return None
+
+    def upsert_documents(self, documents, metadatas, ids):
+        self.added.append((list(documents), list(metadatas), list(ids)))
+        for i in ids:
+            self._ids.add(i)
+
+    def add_documents(self, documents, metadatas, ids):
+        self.upsert_documents(documents, metadatas, ids)
+
+    def delete_documents(self, ids):
+        self.deleted.extend(list(ids))
+        for i in ids:
+            self._ids.discard(i)
+
+    def reset_collection(self):
+        self.reset_calls += 1
+        self._ids = set()
+
+
+class FakeZoteroClient:
+    """pyzotero client double with scripted responses."""
+
+    def __init__(self):
+        self.items_by_key = {}
+        self.fulltext_by_key = {}   # key -> dict (content, indexedChars, ...)
+        self.children_by_parent = {}  # parent_key -> list[item]
+        self.versions_state = {}    # key -> library_version (current state)
+        self.version_history = []   # (since_version, changed_dict) pairs
+        self.current_library_version = 0
+        # Pagination helper
+        self.items_order = []
+        # Recording calls for assertions
+        self.calls = []
+
+    # ---- setup helpers for tests ----
+
+    def load_scenario(self, items, fulltext=None, children=None, library_version=0):
+        """items: list of pyzotero-shaped dicts with top-level 'key' and 'data'."""
+        for it in items:
+            self.items_by_key[it["key"]] = it
+            self.items_order.append(it["key"])
+            self.versions_state[it["key"]] = library_version
+        for k, v in (fulltext or {}).items():
+            self.fulltext_by_key[k] = v
+        for k, v in (children or {}).items():
+            self.children_by_parent[k] = v
+        self.current_library_version = library_version
+
+    # ---- pyzotero surface used by the code under test ----
+
+    def items(self, start=0, limit=100, **kwargs):
+        self.calls.append(("items", start, limit))
+        chunk = self.items_order[start:start + limit]
+        return [self.items_by_key[k] for k in chunk]
+
+    def item(self, key):
+        self.calls.append(("item", key))
+        if key not in self.items_by_key:
+            raise LookupError(f"item {key} not found")
+        return self.items_by_key[key]
+
+    def children(self, key):
+        self.calls.append(("children", key))
+        return list(self.children_by_parent.get(key, []))
+
+    def fulltext_item(self, key):
+        self.calls.append(("fulltext_item", key))
+        if key not in self.fulltext_by_key:
+            raise RuntimeError(f"404 fulltext not found for {key}")
+        return self.fulltext_by_key[key]
+
+    def item_versions(self, since=None, **kwargs):
+        self.calls.append(("item_versions", since))
+        if since is None:
+            return dict(self.versions_state)
+        return {k: v for k, v in self.versions_state.items() if v > since}
+
+    def last_modified_version(self, **kwargs):
+        self.calls.append(("last_modified_version",))
+        return self.current_library_version
+
+
+def _paper(key, title="Paper", item_type="conferencePaper", version=1):
+    return {
+        "key": key,
+        "version": version,
+        "data": {
+            "key": key,
+            "itemType": item_type,
+            "title": title,
+            "abstractNote": f"abstract of {title}",
+            "creators": [{"creatorType": "author", "firstName": "A", "lastName": "Author"}],
+            "dateAdded": "2024-01-01T00:00:00Z",
+            "dateModified": "2024-01-01T00:00:00Z",
+        },
+    }
+
+
+def _build_search(monkeypatch, zot: FakeZoteroClient, chroma: FakeChromaClient,
+                  config_path: str | None = None) -> "semantic_search.ZoteroSemanticSearch":
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: zot)
+    monkeypatch.setattr(semantic_search, "is_local_mode", lambda: False)
+    return semantic_search.ZoteroSemanticSearch(
+        chroma_client=chroma,
+        config_path=config_path,
+    )
+
+
+# --------- Unit tests: fulltext fetch helper ----------
+
+def test_fetch_fulltext_via_web_api_parent_hit(monkeypatch):
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("AAA")], fulltext={"AAA": {"content": "Body text.", "indexedChars": 10, "totalChars": 10}})
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    text, source = search._fetch_fulltext_via_web_api("AAA")
+    assert text == "Body text."
+    assert source == "web-api:parent"
+
+
+def test_fetch_fulltext_via_web_api_attachment_fallback(monkeypatch):
+    """When parent has no fulltext (404), walk children and try PDF attachments."""
+    parent = _paper("PAR", title="Paper")
+    child = {
+        "key": "CHILD1",
+        "version": 1,
+        "data": {"key": "CHILD1", "itemType": "attachment", "contentType": "application/pdf"},
+    }
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [parent],
+        # parent lookup will fail (key not in fulltext_by_key -> raise)
+        fulltext={"CHILD1": {"content": "Attachment body."}},
+        children={"PAR": [child]},
+    )
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    text, source = search._fetch_fulltext_via_web_api("PAR")
+    assert text == "Attachment body."
+    assert source == "web-api:attachment:CHILD1"
+    # Verify we actually tried the parent first, then walked children
+    call_names = [c[0] for c in zot.calls]
+    assert "fulltext_item" in call_names and "children" in call_names
+
+
+def test_fetch_fulltext_via_web_api_returns_empty_when_nothing_available(monkeypatch):
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("X")])
+    # No fulltext, no children — every lookup fails
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    text, source = search._fetch_fulltext_via_web_api("X")
+    assert text == ""
+    assert source == ""
+
+
+def test_fetch_fulltext_skips_non_pdf_children(monkeypatch):
+    parent = _paper("PAR")
+    child_pdf = {"key": "PDF", "version": 1,
+                 "data": {"key": "PDF", "itemType": "attachment", "contentType": "application/pdf"}}
+    child_html = {"key": "HTM", "version": 1,
+                  "data": {"key": "HTM", "itemType": "attachment", "contentType": "text/html"}}
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [parent],
+        fulltext={"PDF": {"content": "PDF text."}, "HTM": {"content": "HTML text."}},
+        children={"PAR": [child_html, child_pdf]},  # HTML listed first
+    )
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    text, source = search._fetch_fulltext_via_web_api("PAR")
+    # Should skip the HTML attachment and return the PDF's content
+    assert text == "PDF text."
+    assert source == "web-api:attachment:PDF"
+
+
+# --------- Integration tests: _get_items_from_api ----------
+
+def test_get_items_from_api_without_fulltext_leaves_data_untouched(monkeypatch):
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("A"), _paper("B")], fulltext={"A": {"content": "Abody"}, "B": {"content": "Bbody"}})
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    items = search._get_items_from_api(include_fulltext=False)
+    assert len(items) == 2
+    for it in items:
+        assert "fulltext" not in it["data"]
+
+
+def test_get_items_from_api_with_fulltext_populates_data(monkeypatch):
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [_paper("A"), _paper("B")],
+        fulltext={"A": {"content": "Abody"}, "B": {"content": "Bbody"}},
+    )
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    items = search._get_items_from_api(include_fulltext=True)
+    by_key = {it["key"]: it for it in items}
+    assert by_key["A"]["data"]["fulltext"] == "Abody"
+    assert by_key["A"]["data"]["fulltextSource"] == "web-api:parent"
+    assert by_key["B"]["data"]["fulltext"] == "Bbody"
+
+
+def test_get_items_from_api_with_fulltext_marks_misses_as_attempted(monkeypatch):
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("A")], fulltext={})  # no fulltext for A
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    items = search._get_items_from_api(include_fulltext=True)
+    assert items[0]["data"].get("fulltext", "") == ""
+    assert items[0]["data"]["fulltext_attempted"] is True
+
+
+# --------- Integration tests: incremental fetch ----------
+
+def test_get_changed_items_from_api_returns_only_changed_keys(monkeypatch):
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [_paper("OLD"), _paper("NEW")],
+        library_version=5,
+    )
+    # Mark OLD as unchanged since v3, NEW as changed at v5
+    zot.versions_state = {"OLD": 3, "NEW": 5}
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    changed, current_keys = search._get_changed_items_from_api(since_version=3, include_fulltext=False)
+    assert [c["key"] for c in changed] == ["NEW"]
+    assert current_keys == {"OLD", "NEW"}
+
+
+def test_get_changed_items_filters_out_attachments_and_notes(monkeypatch):
+    zot = FakeZoteroClient()
+    note = _paper("N1", item_type="note")
+    ann = _paper("A1", item_type="annotation")
+    paper = _paper("P1", item_type="conferencePaper")
+    zot.load_scenario([note, ann, paper], library_version=10)
+    zot.versions_state = {"N1": 10, "A1": 10, "P1": 10}
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    changed, _ = search._get_changed_items_from_api(since_version=0, include_fulltext=False)
+    assert [c["key"] for c in changed] == ["P1"]
+
+
+# --------- Integration tests: update_database orchestration ----------
+
+def _write_config(tmp_path, extra: dict | None = None):
+    cfg = {
+        "semantic_search": {
+            "embedding_model": "default",
+            "update_config": {"auto_update": False, "update_frequency": "manual"},
+            "extraction": {"pdf_max_pages": 10},
+            "include_fulltext": True,
+        }
+    }
+    if extra:
+        cfg["semantic_search"].update(extra)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(cfg))
+    return str(config_path)
+
+
+def test_update_database_bootstrap_scans_full_library(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path)
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [_paper("P1"), _paper("P2")],
+        fulltext={"P1": {"content": "Paper one body"}, "P2": {"content": "Paper two body"}},
+        library_version=7,
+    )
+    chroma = FakeChromaClient()
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    stats = search.update_database()
+
+    assert stats["total_items"] == 2
+    assert stats["processed_items"] == 2
+    # last_sync_version should be persisted to config
+    saved = json.loads(open(config_path).read())
+    assert saved["semantic_search"]["last_sync_version"] == 7
+
+
+def test_update_database_incremental_only_fetches_changed(monkeypatch, tmp_path):
+    """Second run with last_sync_version set should only reindex changed items."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 5})
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [_paper("OLD"), _paper("NEW")],
+        fulltext={"NEW": {"content": "New body"}},
+        library_version=8,
+    )
+    zot.versions_state = {"OLD": 3, "NEW": 8}
+    chroma = FakeChromaClient(preloaded_ids=["OLD"])  # OLD was already indexed
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    stats = search.update_database()
+
+    # Only NEW should be processed, OLD untouched
+    assert stats["processed_items"] == 1
+    added_ids = [i for batch in chroma.added for i in batch[2]]
+    assert added_ids == ["NEW"]
+    saved = json.loads(open(config_path).read())
+    assert saved["semantic_search"]["last_sync_version"] == 8
+
+
+def test_update_database_incremental_deletes_removed_items(monkeypatch, tmp_path):
+    """Items present in ChromaDB but removed from the library should be deleted."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 5})
+    zot = FakeZoteroClient()
+    # Only NEW is still in the library; DELETED_ME was removed
+    zot.load_scenario([_paper("NEW")], fulltext={"NEW": {"content": "body"}}, library_version=9)
+    zot.versions_state = {"NEW": 9}
+    chroma = FakeChromaClient(preloaded_ids=["NEW", "DELETED_ME"])
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    stats = search.update_database()
+
+    assert "DELETED_ME" in chroma.deleted
+    assert stats["deleted_items"] == 1
+
+
+def test_update_database_incremental_noop_when_version_unchanged(monkeypatch, tmp_path):
+    """If last_modified_version == last_sync_version, skip ingest entirely."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 42})
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("X")], library_version=42)
+    zot.versions_state = {"X": 42}
+    chroma = FakeChromaClient(preloaded_ids=["X"])
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    stats = search.update_database()
+
+    assert stats["processed_items"] == 0
+    assert stats["added_items"] == 0
+    assert stats["deleted_items"] == 0
+    # No ingest calls (no items() fetch, no item_versions(since=...) etc.)
+    # Must have called last_modified_version to compare
+    assert ("last_modified_version",) in zot.calls
+
+
+def test_update_database_disables_fulltext_when_config_off(monkeypatch, tmp_path):
+    """Explicit include_fulltext=False should skip the web-API fulltext fetch."""
+    config_path = _write_config(tmp_path, extra={"include_fulltext": False})
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [_paper("A")],
+        fulltext={"A": {"content": "this should NOT appear"}},
+        library_version=3,
+    )
+    chroma = FakeChromaClient()
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    search.update_database()
+
+    # fulltext_item should never be called
+    assert not any(c[0] == "fulltext_item" for c in zot.calls)
+
+
+def test_update_database_force_rebuild_triggers_reset_and_full_scan(monkeypatch, tmp_path):
+    """force_full_rebuild should reset the collection and do a full scan."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 100})
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("A"), _paper("B")], library_version=120)
+    zot.versions_state = {"A": 120, "B": 120}
+    chroma = FakeChromaClient(preloaded_ids=["STALE"])
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    search.update_database(force_full_rebuild=True)
+
+    assert chroma.reset_calls == 1
+    # No since-based fetch: full scan used items() not item_versions(since=...)
+    assert not any(c[0] == "item_versions" and c[1] is not None for c in zot.calls)
+
+
+# --------- Config loaders ----------
+
+def test_load_include_fulltext_defaults_true(monkeypatch, tmp_path):
+    # No config file exists
+    search = _build_search(monkeypatch, FakeZoteroClient(), FakeChromaClient(),
+                           config_path=str(tmp_path / "missing.json"))
+    assert search._load_include_fulltext_setting() is True
+
+
+def test_load_include_fulltext_respects_opt_out(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path, extra={"include_fulltext": False})
+    search = _build_search(monkeypatch, FakeZoteroClient(), FakeChromaClient(),
+                           config_path=config_path)
+    assert search._load_include_fulltext_setting() is False
+
+
+def test_load_last_sync_version_defaults_zero(monkeypatch, tmp_path):
+    search = _build_search(monkeypatch, FakeZoteroClient(), FakeChromaClient(),
+                           config_path=str(tmp_path / "missing.json"))
+    assert search._load_last_sync_version() == 0
+
+
+def test_load_last_sync_version_reads_int(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 123})
+    search = _build_search(monkeypatch, FakeZoteroClient(), FakeChromaClient(),
+                           config_path=config_path)
+    assert search._load_last_sync_version() == 123

--- a/tests/test_fulltext_web_mode.py
+++ b/tests/test_fulltext_web_mode.py
@@ -402,6 +402,130 @@ def test_update_database_disables_fulltext_when_config_off(monkeypatch, tmp_path
     assert not any(c[0] == "fulltext_item" for c in zot.calls)
 
 
+def test_update_database_gap_fills_missing_items(monkeypatch, tmp_path):
+    """Resume case: ChromaDB is partially populated (e.g. killed mid-rebuild)
+    but last_sync_version equals library version. The old noop fast-path
+    would return "nothing to reindex"; the new diff-driven path detects
+    items in the library that are missing from ChromaDB and fetches them."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 100})
+    zot = FakeZoteroClient()
+    # Three items in library, all unchanged since version 100
+    zot.load_scenario(
+        [_paper("A"), _paper("B"), _paper("C")],
+        fulltext={"A": {"content": "Abody"}, "B": {"content": "Bbody"}, "C": {"content": "Cbody"}},
+        library_version=100,
+    )
+    zot.versions_state = {"A": 100, "B": 100, "C": 100}
+    # Only A was indexed before the interruption
+    chroma = FakeChromaClient(preloaded_ids=["A__0", "A__1"])
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    stats = search.update_database()
+
+    # B and C should have been gap-filled
+    assert stats["gap_filled_items"] == 2
+    # All gap items should be in ChromaDB now
+    added_ids = [i for batch in chroma.added for i in batch[2]]
+    added_parents = {i.split("__", 1)[0] for i in added_ids}
+    assert added_parents == {"B", "C"}
+    # A was left untouched
+    assert "A" not in added_parents
+    # Watermark advances to current library version
+    saved = json.loads(open(config_path).read())
+    assert saved["semantic_search"]["last_sync_version"] == 100
+
+
+def test_update_database_gap_fill_combined_with_since_changes(monkeypatch, tmp_path):
+    """Gap-fill + since-V changes should both land in the same run."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 50})
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [_paper("GAP"), _paper("CHANGED")],
+        fulltext={"GAP": {"content": "Gbody"}, "CHANGED": {"content": "Cbody"}},
+        library_version=80,
+    )
+    # CHANGED version 75 > 50, GAP version 40 < 50 but absent from ChromaDB
+    zot.versions_state = {"GAP": 40, "CHANGED": 75}
+    chroma = FakeChromaClient(preloaded_ids=[])  # completely empty
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    stats = search.update_database()
+
+    added_parents = {i.split("__", 1)[0]
+                     for batch in chroma.added for i in batch[2]}
+    assert added_parents == {"GAP", "CHANGED"}
+    assert stats["gap_filled_items"] == 1
+
+
+def test_update_database_true_noop_when_fully_synced(monkeypatch, tmp_path):
+    """Library unchanged AND ChromaDB has every library item => truly nothing to do."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 99})
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("X")], library_version=99)
+    zot.versions_state = {"X": 99}
+    chroma = FakeChromaClient(preloaded_ids=["X__0", "X__1"])
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    stats = search.update_database()
+
+    assert stats["processed_items"] == 0
+    assert stats["gap_filled_items"] == 0
+    assert stats["deleted_items"] == 0
+    # No items should have been re-upserted
+    assert chroma.added == []
+
+
+def test_fetch_items_by_keys_batches_requests(monkeypatch):
+    """Verifies itemKey= is used and the batch size of 50 is respected."""
+    zot = FakeZoteroClient()
+    # Preload 120 items
+    items = [_paper(f"K{i:03d}") for i in range(120)]
+    zot.load_scenario(items, library_version=1)
+
+    # Replace items() to record how itemKey param was passed
+    captured_keys: list[list[str]] = []
+    original_items = zot.items
+
+    def recording_items(start=0, limit=100, **kwargs):
+        # pyzotero's add_parameters stores url_params; fake it here
+        captured_keys.append([k for k in getattr(zot, "_fake_itemkey", "").split(",") if k])
+        return original_items(start=0, limit=len(captured_keys[-1]) or limit)
+
+    def fake_add_parameters(**params):
+        zot._fake_itemkey = params.get("itemKey", "")
+
+    zot.add_parameters = fake_add_parameters
+    zot.items = recording_items
+
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    keys_to_fetch = [f"K{i:03d}" for i in range(120)]
+    result = search._fetch_items_by_keys(keys_to_fetch)
+
+    # 120 keys -> 3 batches of 50 (50 + 50 + 20)
+    assert len(captured_keys) == 3
+    assert [len(b) for b in captured_keys] == [50, 50, 20]
+    assert len(result) > 0
+
+
+def test_fetch_items_by_keys_falls_back_to_per_key_on_batch_error(monkeypatch):
+    """If the batched itemKey request raises, each key is re-tried individually
+    so one malformed key can't stall the whole backfill."""
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("X"), _paper("Y")], library_version=1)
+
+    def boom_items(**kwargs):
+        raise RuntimeError("simulated batch failure")
+
+    zot.items = boom_items
+    zot.add_parameters = lambda **kw: None
+
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    result = search._fetch_items_by_keys(["X", "Y"])
+    # Fallback uses zot.item(key) per key, which FakeZoteroClient supports
+    returned_keys = {it["key"] for it in result}
+    assert returned_keys == {"X", "Y"}
+
+
 def test_update_database_force_rebuild_triggers_reset_and_full_scan(monkeypatch, tmp_path):
     """force_full_rebuild should reset the collection and do a full scan."""
     config_path = _write_config(tmp_path, extra={"last_sync_version": 100})

--- a/tests/test_fulltext_web_mode.py
+++ b/tests/test_fulltext_web_mode.py
@@ -406,6 +406,24 @@ def test_update_database_force_rebuild_triggers_reset_and_full_scan(monkeypatch,
     assert not any(c[0] == "item_versions" and c[1] is not None for c in zot.calls)
 
 
+def test_update_database_force_rebuild_updates_last_sync_version(monkeypatch, tmp_path):
+    """After force_full_rebuild, last_sync_version must advance to the library's
+    current version. Otherwise the next incremental run would use a stale
+    watermark and permanently lose items not modified since that older version.
+    """
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 50})
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("A")], library_version=200)
+    zot.versions_state = {"A": 200}
+    chroma = FakeChromaClient()
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+
+    search.update_database(force_full_rebuild=True)
+
+    saved = json.loads(open(config_path).read())
+    assert saved["semantic_search"]["last_sync_version"] == 200
+
+
 # --------- Config loaders ----------
 
 def test_load_include_fulltext_defaults_true(monkeypatch, tmp_path):

--- a/tests/test_fulltext_web_mode.py
+++ b/tests/test_fulltext_web_mode.py
@@ -55,6 +55,13 @@ class FakeChromaClient:
         for i in ids:
             self._ids.discard(i)
 
+    def delete_documents_by_parent(self, parent_item_key):
+        prefix = f"{parent_item_key}__"
+        victims = [i for i in self._ids if i == parent_item_key or i.startswith(prefix)]
+        if victims:
+            self.delete_documents(victims)
+        return len(victims)
+
     def reset_collection(self):
         self.reset_calls += 1
         self._ids = set()
@@ -324,7 +331,8 @@ def test_update_database_incremental_only_fetches_changed(monkeypatch, tmp_path)
         library_version=8,
     )
     zot.versions_state = {"OLD": 3, "NEW": 8}
-    chroma = FakeChromaClient(preloaded_ids=["OLD"])  # OLD was already indexed
+    # Preload with new-format chunk ids so the legacy-format detector stays silent
+    chroma = FakeChromaClient(preloaded_ids=["OLD__0"])
     search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
 
     stats = search.update_database()
@@ -332,7 +340,8 @@ def test_update_database_incremental_only_fetches_changed(monkeypatch, tmp_path)
     # Only NEW should be processed, OLD untouched
     assert stats["processed_items"] == 1
     added_ids = [i for batch in chroma.added for i in batch[2]]
-    assert added_ids == ["NEW"]
+    # Each item now emits one-or-more chunk ids
+    assert all(i.startswith("NEW__") for i in added_ids)
     saved = json.loads(open(config_path).read())
     assert saved["semantic_search"]["last_sync_version"] == 8
 
@@ -344,13 +353,16 @@ def test_update_database_incremental_deletes_removed_items(monkeypatch, tmp_path
     # Only NEW is still in the library; DELETED_ME was removed
     zot.load_scenario([_paper("NEW")], fulltext={"NEW": {"content": "body"}}, library_version=9)
     zot.versions_state = {"NEW": 9}
-    chroma = FakeChromaClient(preloaded_ids=["NEW", "DELETED_ME"])
+    # Chunked-format preloads — NEW has 1 chunk, DELETED_ME had 2
+    chroma = FakeChromaClient(preloaded_ids=["NEW__0", "DELETED_ME__0", "DELETED_ME__1"])
     search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
 
     stats = search.update_database()
 
-    assert "DELETED_ME" in chroma.deleted
-    assert stats["deleted_items"] == 1
+    # The deletion pass collapses chunks back to parent keys before diffing
+    assert "DELETED_ME__0" in chroma.deleted
+    assert "DELETED_ME__1" in chroma.deleted
+    assert stats["deleted_items"] == 1  # one parent removed
 
 
 def test_update_database_incremental_noop_when_version_unchanged(monkeypatch, tmp_path):
@@ -359,7 +371,7 @@ def test_update_database_incremental_noop_when_version_unchanged(monkeypatch, tm
     zot = FakeZoteroClient()
     zot.load_scenario([_paper("X")], library_version=42)
     zot.versions_state = {"X": 42}
-    chroma = FakeChromaClient(preloaded_ids=["X"])
+    chroma = FakeChromaClient(preloaded_ids=["X__0"])
     search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
 
     stats = search.update_database()

--- a/tests/test_fulltext_web_mode.py
+++ b/tests/test_fulltext_web_mode.py
@@ -283,6 +283,79 @@ def test_get_changed_items_filters_out_attachments_and_notes(monkeypatch):
     assert [c["key"] for c in changed] == ["P1"]
 
 
+def test_get_items_from_api_filters_out_annotations(monkeypatch):
+    """Regression guard: the bootstrap path used to exclude only
+    attachment+note, letting annotation items (PDF highlights / user
+    comments) sneak in as top-level chunks. Confirm they're gone."""
+    zot = FakeZoteroClient()
+    ann = _paper("A1", item_type="annotation")
+    attach = _paper("X1", item_type="attachment")
+    note = _paper("N1", item_type="note")
+    paper = _paper("P1", item_type="journalArticle")
+    zot.load_scenario([ann, attach, note, paper], library_version=3)
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    items = search._get_items_from_api(include_fulltext=False)
+    assert [it["key"] for it in items] == ["P1"]
+
+
+def test_fetch_items_by_keys_filters_out_annotations(monkeypatch):
+    """Gap-fill's batched fetch must also drop annotation items so
+    previous runs' filter bug can't replicate through the resume path."""
+    zot = FakeZoteroClient()
+    ann = _paper("A1", item_type="annotation")
+    paper = _paper("P1", item_type="journalArticle")
+    zot.load_scenario([ann, paper], library_version=5)
+    # Replace items() so it returns both when called (simulating batched
+    # itemKey fetch)
+    original_items = zot.items
+    zot.items = lambda **kw: [zot.items_by_key["A1"], zot.items_by_key["P1"]]
+    zot.add_parameters = lambda **kw: None
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    result = search._fetch_items_by_keys(["A1", "P1"])
+    assert [it["key"] for it in result] == ["P1"]
+
+
+def test_update_database_cleans_up_stale_annotation_chunks(monkeypatch, tmp_path):
+    """A user who ingested with the buggy filter ends up with orphan
+    annotation chunks in ChromaDB. update_database must purge them on
+    every run (it's idempotent / cheap) so the collection self-heals."""
+    config_path = _write_config(tmp_path, extra={"last_sync_version": 10})
+    zot = FakeZoteroClient()
+    zot.load_scenario([_paper("REAL", item_type="journalArticle")], library_version=10)
+    zot.versions_state = {"REAL": 10}
+
+    class CleanableChroma(FakeChromaClient):
+        def __init__(self, *a, **kw):
+            super().__init__(*a, **kw)
+            # Seed with a mix: 2 annotation chunks and 1 real paper chunk
+            self._chunks = {
+                "STALE_ANN_1__0": {"item_type": "annotation", "parent_item_key": "STALE_ANN_1"},
+                "STALE_ANN_2__0": {"item_type": "annotation", "parent_item_key": "STALE_ANN_2"},
+                "REAL__0": {"item_type": "journalArticle", "parent_item_key": "REAL"},
+            }
+            self._ids = set(self._chunks.keys())
+            self.deleted_by_type = []
+
+        def delete_documents_by_item_type(self, item_type):
+            victims = [i for i, m in self._chunks.items() if m.get("item_type") == item_type]
+            for v in victims:
+                self._ids.discard(v)
+                del self._chunks[v]
+            if victims:
+                self.deleted_by_type.append((item_type, len(victims)))
+            return len(victims)
+
+        def get_all_ids(self):
+            return set(self._ids)
+
+    chroma = CleanableChroma()
+    search = _build_search(monkeypatch, zot, chroma, config_path=config_path)
+    stats = search.update_database()
+
+    assert ("annotation", 2) in chroma.deleted_by_type
+    assert stats["cleaned_annotation_chunks"] == 2
+
+
 # --------- Integration tests: update_database orchestration ----------
 
 def _write_config(tmp_path, extra: dict | None = None):

--- a/tests/test_semantic_search_quality.py
+++ b/tests/test_semantic_search_quality.py
@@ -579,9 +579,13 @@ class TestReranking:
     def test_reranker_reorders_results(self):
         s = self._make_search_with_reranker(enabled=True)
 
-        # Mock reranker to reverse the order
+        # With chunking, search() inserts a dedupe-by-parent step between
+        # ChromaDB's raw result and the reranker. ChromaDB is already
+        # distance-sorted (0.1, 0.3, 0.2) so post-dedupe order becomes
+        # [Cats(0.1), Birds(0.2), Dogs(0.3)]. To reorder to Birds-first,
+        # the reranker must return [1, 0, 2].
         mock_reranker = MagicMock()
-        mock_reranker.rerank.return_value = [2, 0, 1]  # Birds, Cats, Dogs
+        mock_reranker.rerank.return_value = [1, 0, 2]
         s._reranker = mock_reranker
 
         # Mock the Zotero client to avoid API calls
@@ -592,7 +596,7 @@ class TestReranking:
 
         # Verify reranker was called
         mock_reranker.rerank.assert_called_once()
-        # First result should be "Birds" (index 2 in original)
+        # First result should be "Birds" after the reranker reorders
         assert result["results"][0]["metadata"]["title"] == "Birds"
 
     def test_search_overfetches_when_reranker_enabled(self):
@@ -605,8 +609,12 @@ class TestReranking:
 
         s.search("test", limit=2)
 
-        # candidate_multiplier=3, so n_results should be 2*3=6
-        assert s.chroma_client._last_query_kwargs["n_results"] == 6
+        # Chunking changes the oversample formula: the handler now fetches
+        # `max(limit * candidate_multiplier * 5, 50)` hits so enough distinct
+        # parents survive dedupe. For limit=2, cand_mult=3, that's
+        # max(30, 50) = 50.
+        assert s.chroma_client._last_query_kwargs["n_results"] >= 2 * 3
+        assert s.chroma_client._last_query_kwargs["n_results"] == 50
 
     def test_search_without_reranker_uses_original_limit(self):
         s = self._make_search_with_reranker(enabled=False)
@@ -616,4 +624,7 @@ class TestReranking:
 
         s.search("test", limit=5)
 
-        assert s.chroma_client._last_query_kwargs["n_results"] == 5
+        # Without a reranker, oversample is max(limit * 5, 50) = 50 for
+        # small limits. The final slice back to `limit` still happens
+        # inside search() before enrichment.
+        assert s.chroma_client._last_query_kwargs["n_results"] == 50

--- a/tests/test_semantic_stats.py
+++ b/tests/test_semantic_stats.py
@@ -17,11 +17,18 @@ class FakeChromaClient:
         self.embedding_max_tokens = 8000
 
     def get_existing_ids(self, ids):
-        # Pretend item A already exists and item B is new.
-        return {"ITEMA001"} & set(ids)
+        # Chunked-era ids are `<parent>__<chunk_index>`. Pretend ITEMA001's
+        # first chunk already exists and ITEMB002 is new.
+        return {"ITEMA001__0"} & set(ids)
+
+    def get_all_ids(self):
+        return {"ITEMA001__0"}
 
     def upsert_documents(self, documents, metadatas, ids):
         self.upserted_ids.extend(ids)
+
+    def delete_documents_by_parent(self, parent_item_key):
+        return 0
 
     def truncate_text(self, text, max_tokens=None):
         return text
@@ -96,11 +103,13 @@ def test_process_item_batch_defers_failures_when_failed_docs_provided(monkeypatc
     failed_docs = []
     stats = search._process_item_batch(items, force_rebuild=False, _failed_docs=failed_docs)
 
-    # All 3 items prepared successfully (text built, truncated, queued)
+    # All 3 items prepared successfully (text built, chunked, queued)
     assert stats["processed"] == 3
-    # All 3 items deferred to the retry list when the upsert raised
+    # Short items produce one chunk each, so exactly 3 chunk ids were queued
     assert len(failed_docs) == 3
-    assert {doc_id for _, _, doc_id in failed_docs} == {"ITEM000", "ITEM001", "ITEM002"}
+    # Chunked ids preserve the parent key + suffix; strip to check parents
+    deferred_parents = {doc_id.split("__", 1)[0] for _, _, doc_id in failed_docs}
+    assert deferred_parents == {"ITEM000", "ITEM001", "ITEM002"}
     # Errors bumped by the deferred count so the totals stay accurate
     assert stats["errors"] == 3
     # No items classified as added/updated because the batch never reached

--- a/tests/test_update_item.py
+++ b/tests/test_update_item.py
@@ -972,3 +972,144 @@ class TestUpdateItemSkippedFields:
 
         assert len(fake.update_calls) == 0
         assert "No changes" in result
+
+
+# ---------------------------------------------------------------------------
+# Item-type change (e.g. webpage -> conferencePaper) + field application
+# ---------------------------------------------------------------------------
+
+def _make_webpage_item(key="IQ7MARZI", version=7, title="AFT 2025 Paper",
+                       url="https://drops.dagstuhl.de/aft2025/29", date="2025"):
+    """Build a webpage item — the wrong type that needs repairing."""
+    return {
+        "key": key,
+        "version": version,
+        "data": {
+            "key": key,
+            "version": version,
+            "itemType": "webpage",
+            "title": title,
+            "creators": [{"creatorType": "author",
+                          "firstName": "Ada", "lastName": "Lovelace"}],
+            "date": date,
+            "abstractNote": "",
+            "url": url,
+            "accessDate": "2025-01-01",
+            "websiteTitle": "Dagstuhl",
+            "tags": [{"tag": "defi"}],
+            "collections": ["COL1"],
+            "DOI": "",
+            "extra": "",
+            "relations": {},
+        },
+    }
+
+
+class TestUpdateItemTypeChange:
+
+    def test_webpage_to_conference_paper_applies_fields(self, monkeypatch):
+        """item_type change applies book_title/volume/pages that would
+        otherwise be silently skipped on a webpage item."""
+        item = _make_webpage_item()
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="IQ7MARZI",
+            item_type="conferencePaper",
+            book_title="7th Conference on Advances in Financial Technologies (AFT 2025)",
+            volume="354",
+            pages="29:1--29:22",
+            ctx=DummyContext(),
+        )
+
+        assert len(fake.update_calls) == 1
+        d = fake.update_calls[0]["data"]
+        assert d["itemType"] == "conferencePaper"
+        # book_title lands in the conferencePaper venue field, NOT skipped
+        assert d["proceedingsTitle"] == \
+            "7th Conference on Advances in Financial Technologies (AFT 2025)"
+        assert d["volume"] == "354"
+        assert d["pages"] == "29:1--29:22"
+        assert "Successfully" in result
+        assert "Skipped" not in result
+
+    def test_type_change_carries_over_compatible_fields(self, monkeypatch):
+        """Compatible fields + creators/tags/collections survive the type
+        change; fields invalid for the new type are dropped."""
+        item = _make_webpage_item()
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        server.update_item(
+            item_key="IQ7MARZI",
+            item_type="conferencePaper",
+            volume="354",
+            ctx=DummyContext(),
+        )
+
+        d = fake.update_calls[0]["data"]
+        assert d["title"] == "AFT 2025 Paper"
+        assert d["url"].startswith("https://")
+        assert d["date"] == "2025"
+        assert d["creators"][0]["lastName"] == "Lovelace"
+        assert [t["tag"] for t in d["tags"]] == ["defi"]
+        assert d["collections"] == ["COL1"]
+        # webpage-only field dropped (not valid for conferencePaper)
+        assert "websiteTitle" not in d
+
+    def test_type_change_preserves_version(self, monkeypatch):
+        """The item version must survive a type change for optimistic locking."""
+        item = _make_webpage_item(version=42)
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        server.update_item(
+            item_key="IQ7MARZI",
+            item_type="conferencePaper",
+            volume="354",
+            ctx=DummyContext(),
+        )
+
+        sent = fake.update_calls[0]
+        assert sent["version"] == 42
+        assert sent["data"]["version"] == 42
+
+    def test_type_change_reported_in_diff(self, monkeypatch):
+        item = _make_webpage_item()
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="IQ7MARZI",
+            item_type="conferencePaper",
+            volume="354",
+            ctx=DummyContext(),
+        )
+
+        assert "itemType" in result
+        assert "webpage" in result
+        assert "conferencePaper" in result
+
+    def test_same_type_no_rebuild(self, monkeypatch):
+        """Passing item_type equal to the current type behaves like a normal
+        update with no spurious type-change entry."""
+        item = _make_item(title="Old")  # journalArticle
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="ABCD1234",
+            item_type="journalArticle",
+            title="New",
+            ctx=DummyContext(),
+        )
+
+        d = fake.update_calls[0]["data"]
+        assert d["title"] == "New"
+        assert "itemType" not in result


### PR DESCRIPTION
## Relation to #260

This PR is **stacked on top of #260** (fulltext via web API + since-based incremental sync). The diff against `main` therefore includes #260's two commits; reviewers can focus on the **six commits unique to this branch**:

- `a50f28c feat(semantic): chunked ingest + groupby rerank + embedding throttle`
- `acad0cd fix(embeddings): sub-batch OpenAI requests to respect provider caps`
- `13c784b fix(semantic): rebuild when collection reset but last_sync_version stays`
- `75cb347 fix(throttle): enforce rate limit at every HTTP request, including retry`
- `e979704 feat(semantic): diff-driven incremental sync with gap-fill / resume`
- `679f43d fix(ingest): exclude annotation items; self-heal stale annotation chunks`

I'll rebase onto `main` once #260 merges so only those six remain.

## Motivation

Even after #260 lands, a single Zotero item still gets one truncated embedding per upsert (`_process_item_batch` calls `truncate_text` to 8k tokens then writes a single document whose id equals the item key). For a 15k-token conference paper that loses the entire second half of the body. Semantic search can only score "title/abstract + first-chunk relevance", not "does this specific paragraph match my query".

## Summary

### 1. Chunked ingest
`ZoteroSemanticSearch._chunk_document(text, window=1500, overlap=225)` slices each document into overlapping token windows via tiktoken (cl100k_base — the tokenizer used by OpenAI and most OpenAI-compatible providers). 1500/225 fits comfortably inside `text-embedding-3-small`, `bge-m3`, etc. with room for prepended structured metadata. Falls back to char-based windowing when tiktoken is unavailable; clamps overlap < window to avoid infinite loops on malformed config.

`_process_item_batch` now emits one id per chunk (`<item_key>__<chunk_index>`); each chunk's metadata carries `parent_item_key`, `chunk_index`, `total_chunks`, plus the usual per-item fields. Before upsert, `delete_documents_by_parent(parent)` clears stale chunks so chunk count can shrink across runs when fulltext re-extraction yields less text.

### 2. Dedupe-then-rerank search handler
`search()` oversamples to `max(limit * rerank_multiplier * 5, 50)` hits from ChromaDB, collapses via a new `_dedupe_by_parent` that keeps the best chunk per parent, then runs the optional cross-encoder reranker on the deduped set. `_enrich_search_results` dereferences `parent_item_key` (not the chunk id) when calling `zot.item(key)` so callers never see chunk ids in the wrong place; result dicts gain `chunk_id` and `chunk_index` for diagnostics.

### 3. Sub-batched embedding requests
SiliconFlow caps `/v1/embeddings` at 64 inputs per POST; 25 items × 16 chunks = 400 inputs exceeds that. `OpenAIEmbeddingFunction.__call__` now slices `input` into `request_batch_size` (default 64, config-overridable) windows and concatenates vectors. Return order preserved.

### 4. Rate-limiting at the HTTP request boundary
Throttle moved from per-upsert (in `ZoteroSemanticSearch`) down to per-HTTP-request (in `OpenAIEmbeddingFunction._wait_for_rate_limit`). Two bugs that caused cascade failures on SiliconFlow free-tier rebuilds:

- Sub-batching inside a single upsert fired N back-to-back requests without throttle. Bursts hit TPM.
- The `update_database` retry loop called `chroma_client.upsert_documents([doc], ...)` directly, bypassing the throttle entirely. A rate-limit failure cascade dumped thousands of small requests into the retry pool unthrottled and logged permanent failures.

Both paths now call `_throttle_embedding_request` / `_wait_for_rate_limit` before every HTTP request. Config knob: `embedding_config.rate_limit_rps` (or the outer `semantic_search.embedding_rate_limit_rps` — the outer propagates into the embedding function at `create_chroma_client` time).

### 5. ID-format migration + empty-collection resume
When the chunked format is deployed on top of #260's single-embedding format, `update_database` samples existing ids on every run; if none contain `__`, it auto-triggers a `force_full_rebuild` so users don't have to invoke it manually.

### 6. Diff-driven incremental sync with gap-fill
The old fast-path noop in the incremental branch assumed ChromaDB was a consistent snapshot of the library at `last_sync_version`. That broke when:
- A rebuild was killed mid-run (watermark not advanced; ChromaDB partial)
- The embedding model changed (ChromaClient silently resets the collection; watermark still points at the old sync)
- Any crash left the collection inconsistent with the watermark

Users stuck with partial indexes had only `--force-rebuild` available, which throws away all prior progress.

Replaced with a diff-driven design: every run computes `changed ∪ missing` (ingest set) and `deleted`, where `missing` = items in the library but absent from ChromaDB (via a parent-key-aware scan of `get_all_ids()`). If all three sets are empty → true noop with a "Library fully synced" log; otherwise ingest runs. New helper `_fetch_items_by_keys(keys)` bulk-fetches via Zotero's `itemKey=K1,K2,...` query param, batched at 50 per request (Zotero's documented cap), with per-key fallback on batch failure. New stat `gap_filled_items`.

### 7. Annotation item self-heal
The original `_get_items_from_api` filter excluded only `itemType in {attachment, note}`, letting `annotation` items (PDF highlights and user comments, which Zotero exposes as top-level in the /items listing) slip through. On a representative 2402-item library, this produced **1018 zero-text annotation chunks** drowning out the 237 real research papers in dedup rankings. Tightened the filter to match the since-based and itemKey paths (all three now drop `annotation`) and added `delete_documents_by_item_type("annotation")` as a self-healing cleanup step on every `update_database` run. New stat `cleaned_annotation_chunks`.

## Verification

End-to-end on a 2402-item real Zotero library with web-API mode and `embedding_config` pointing at SiliconFlow bge-m3:

- **First pass (killed mid-run at ~17%)** to stress-test gap-fill resume. `update-db` restart with no `--force-rebuild`: detected 1631 missing items, fetched + indexed, ran to completion.
- **Second pass** triggered annotation cleanup (1018 chunks purged) plus true-noop report: `Library fully synced (version 7661); nothing to reindex`. Duration 1:28 with zero embedding API calls.
- **Final state**: 3952 chunks across **311 distinct parents**; of 237 research-paper parents, 100% have fulltext indexed. Remaining 74 non-fulltext parents are webpages / computer programs / blog posts / bookSections (genuinely have no PDF on Zotero cloud) or journal/conference papers whose PDFs haven't been opened in the user's desktop client yet (out of scope for this PR).
- **Paragraph-level semantic check** ("concurrent smart contract execution parallelism"): top-5 all highly relevant papers (cosine-sim 0.42–0.50 via bge-m3), different chunk indices per paper (`__0`, `__1`, `__2`...) confirming matches land in fulltext bodies, not just title/abstract.
- **Unit tests**: 486 passed. 23 new cases in `tests/test_chunking.py` + 12 new cases in `tests/test_fulltext_web_mode.py` cover chunking boundary behavior, groupby rerank, enrichment parent-key resolution, sub-batching, throttle, legacy-format migration, gap-fill resume, true-noop path, annotation filter + cleanup.

## Config surface added

- `semantic_search.chunking: {window: 1500, overlap: 225}` — tunable chunker parameters
- `semantic_search.embedding_rate_limit_rps: N` — per-HTTP-request throttle (defaults off)
- `semantic_search.embedding_config.request_batch_size: N` — per-provider inputs-per-POST cap (defaults 64, safe for SiliconFlow; real OpenAI can bump to 2048)

`setup_helper.setup_semantic_search` now writes the `chunking` and `embedding_rate_limit_rps` defaults into new config files so users discover and tune them.

## Backward compatibility

- Local-mode users (`ZOTERO_LOCAL=true`) see no behavior change — `extract_fulltext` still takes precedence and the local sqlite path is unaltered.
- Web-API users on PR #260's single-embedding format auto-upgrade on their next `update-db` run via the legacy-id detection → force_full_rebuild path.
- The `update_search_database` MCP tool and `zotero-mcp update-db` CLI signatures are unchanged — all new behavior is default-on but gated behind existing config.