### PR TITLE
feat: add items relation management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Zotero MCP 环境变量配置
+# 复制此文件为 .env 并填写你的配置
+
+# 必需配置
+ZOTERO_API_KEY=your_api_key_here
+ZOTERO_LIBRARY_ID=your_library_id_here
+
+# 可选配置 (默认为 user)
+# 个人库: user
+# 群组库: group
+ZOTERO_LIBRARY_TYPE=user
+
+# OpenAI API Key (用于语义搜索功能，可选)
+# OPENAI_API_KEY=your_openai_key_here
+
+# Google Gemini API Key (可选)
+# GEMINI_API_KEY=your_gemini_key_here

--- a/README.md
+++ b/README.md
@@ -332,6 +332,38 @@ For optimal annotation extraction, it is **highly recommended** to install the [
 
 The first time you use PDF annotation features, the necessary tools will be automatically downloaded.
 
+## 🔗 Managing Related Items
+
+Zotero MCP now supports managing relationships between items in your library. This is useful for linking related papers, tracking versions, or connecting preprints to their published versions.
+
+### View Related Items
+```
+zotero_get_item_related(item_key="ABCD1234")
+```
+
+### Add a Relation
+Create a bidirectional link between two items:
+```
+zotero_add_item_relation(
+    item_key="ABCD1234",
+    related_item_key="EFGH5678",
+    relation_type="dc:relation"  # Optional, defaults to "dc:relation"
+)
+```
+
+### Remove a Relation
+```
+zotero_remove_item_relation(
+    item_key="ABCD1234",
+    related_item_key="EFGH5678",
+    remove_bidirectional=True  # Also remove the reverse relation (default: true)
+)
+```
+
+**Relation Types:**
+- `dc:relation` — General related items (default)
+- `owl:sameAs` — Items that are the same work (e.g., preprint and published version)
+
 ## 📚 Available Tools
 
 ### 🧠 Semantic Search Tools
@@ -376,6 +408,11 @@ The first time you use PDF annotation features, the necessary tools will be auto
 - `zotero_merge_duplicates`: Merge duplicate items with dry-run preview; consolidates all child items
 - `zotero_get_pdf_outline`: Extract the table of contents / outline from a PDF attachment
 - `zotero_search_by_citation_key`: Look up items by BetterBibTeX citation key (with Extra field fallback)
+
+### 🔗 Related Items Tools
+- `zotero_get_item_related`: Get all related items for a specific Zotero item
+- `zotero_add_item_relation`: Add a related item relationship (creates bidirectional link)
+- `zotero_remove_item_relation`: Remove a related item relationship
 
 ## 🧪 Testing
 

--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -80,6 +80,7 @@ from zotero_mcp.tools.retrieval import (  # noqa: F401
     list_feeds,
     get_feed_items,
     get_recent,
+    get_item_related,
 )
 from zotero_mcp.tools.annotations import (  # noqa: F401
     get_annotations,
@@ -103,6 +104,8 @@ from zotero_mcp.tools.write import (  # noqa: F401
     merge_duplicates,
     get_pdf_outline,
     add_from_file,
+    add_item_relation,
+    remove_item_relation,
 )
 from zotero_mcp.tools.connectors import (  # noqa: F401
     chatgpt_connector_search,

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -4,6 +4,7 @@ from typing import Literal
 import json
 import logging as _logging
 import os
+import re
 import tempfile
 import time as _time
 from pathlib import Path
@@ -1076,3 +1077,112 @@ def get_recent(
     except Exception as e:
         ctx.error(f"Error fetching recent items: {str(e)}")
         return f"Error fetching recent items: {str(e)}"
+
+
+@mcp.tool(
+    name="zotero_get_item_related",
+    description="Get all related items for a specific Zotero item. Returns items that are linked via the relations field."
+)
+def get_item_related(
+    item_key: str,
+    *,
+    ctx: Context
+) -> str:
+    """
+    Get all related items for a specific Zotero item.
+
+    Args:
+        item_key: Zotero item key/ID
+        ctx: MCP context
+
+    Returns:
+        Markdown-formatted list of related items
+    """
+    try:
+        ctx.info(f"Fetching related items for {item_key}")
+        zot = _client.get_zotero_client()
+
+        # Fetch the item
+        try:
+            item = zot.item(item_key)
+        except Exception as e:
+            return f"Error: Item '{item_key}' not found."
+
+        data = item.get("data", {})
+        item_title = data.get("title", "Untitled")
+        relations = data.get("relations", {})
+
+        if not isinstance(relations, dict) or not relations:
+            return f"No related items found for: **{item_title}** (Key: `{item_key}`)"
+
+        # Extract related item keys from URIs
+        # Zotero uses URIs like: http://zotero.org/users/{library_id}/items/{item_key}
+        # or http://zotero.org/groups/{group_id}/items/{item_key}
+
+        related_keys = []
+        seen_keys = set()
+        for rel_type, rel_values in relations.items():
+            if not isinstance(rel_values, list):
+                rel_values = [rel_values]
+            for uri in rel_values:
+                if not isinstance(uri, str):
+                    continue
+                # Extract item key from URI
+                match = re.search(r'/items/([A-Z0-9]{8})$', uri)
+                if match:
+                    key = match.group(1)
+                    # Deduplicate: same key may appear with both users/ and groups/ prefix
+                    dedup_id = (rel_type, key)
+                    if dedup_id not in seen_keys:
+                        seen_keys.add(dedup_id)
+                        related_keys.append((rel_type, key, uri))
+
+        if not related_keys:
+            return f"No related items found for: **{item_title}** (Key: `{item_key}`)"
+
+        # Fetch details for related items
+        output = [f"# Related Items for: {item_title}", f"**Item Key:** `{item_key}`", ""]
+
+        # Group by relation type
+        by_type = {}
+        for rel_type, key, uri in related_keys:
+            if rel_type not in by_type:
+                by_type[rel_type] = []
+            by_type[rel_type].append((key, uri))
+
+        for rel_type, items in by_type.items():
+            output.append(f"## Relation Type: `{rel_type}`")
+            output.append("")
+
+            for rel_key, uri in items:
+                try:
+                    rel_item = zot.item(rel_key)
+                    rel_data = rel_item.get("data", {})
+                    rel_title = rel_data.get("title", "Untitled")
+                    rel_type_name = rel_data.get("itemType", "unknown")
+                    rel_date = rel_data.get("date", "")
+                    rel_creator = ""
+                    if rel_data.get("creators"):
+                        first_creator = rel_data["creators"][0]
+                        if "lastName" in first_creator:
+                            rel_creator = first_creator["lastName"]
+                        elif "name" in first_creator:
+                            rel_creator = first_creator["name"]
+
+                    creator_info = f", {rel_creator}" if rel_creator else ""
+                    date_info = f" ({rel_date})" if rel_date else ""
+
+                    output.append(f"- `{rel_key}` — **{rel_title}**{creator_info}{date_info}")
+                    output.append(f"  - Type: {rel_type_name}")
+                    if doi := rel_data.get("DOI"):
+                        output.append(f"  - DOI: {doi}")
+                    output.append("")
+                except Exception as e:
+                    output.append(f"- `{rel_key}` — (Could not fetch details: {e})")
+                    output.append("")
+
+        return "\n".join(output)
+
+    except Exception as e:
+        ctx.error(f"Error fetching related items: {str(e)}")
+        return f"Error fetching related items: {str(e)}"

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1293,3 +1293,264 @@ def add_from_file(
     except Exception as e:
         ctx.error(f"Error adding from file: {e}")
         return f"Error adding from file: {e}"
+
+
+def _build_relation_uri(library_type: str, library_id: str, item_key: str) -> str:
+    """Build a Zotero relation URI for the given item.
+
+    Uses the canonical format based on library_type:
+    - user library  → ``http://zotero.org/users/<id>/items/<key>``
+    - group library → ``http://zotero.org/groups/<id>/items/<key>``
+
+    Note: pyzotero internally pluralises the constructor argument
+    (``'user'`` → ``'users'``, ``'group'`` → ``'groups'``), so we
+    accept both singular and plural forms.
+    """
+    kind = "users" if library_type in ("user", "users") else "groups"
+    return f"http://zotero.org/{kind}/{library_id}/items/{item_key}"
+
+
+def _relation_exists(rel_list: list, library_id: str, item_key: str) -> bool:
+    """Check whether a relation to *item_key* already exists (either URI variant)."""
+    pattern = re.compile(
+        rf"http://zotero\.org/(?:users|groups)/{re.escape(str(library_id))}/items/{re.escape(item_key)}$"
+    )
+    return any(isinstance(uri, str) and pattern.search(uri) for uri in rel_list)
+
+
+def _find_matching_uri(rel_list: list, library_id: str, item_key: str) -> str | None:
+    """Find and return the actual URI string for *item_key* regardless of prefix."""
+    pattern = re.compile(
+        rf"http://zotero\.org/(?:users|groups)/{re.escape(str(library_id))}/items/{re.escape(item_key)}$"
+    )
+    for uri in rel_list:
+        if isinstance(uri, str) and pattern.search(uri):
+            return uri
+    return None
+
+
+@mcp.tool(
+    name="zotero_add_item_relation",
+    description="Add a related item relationship to a Zotero item. Creates a bidirectional link between two items."
+)
+def add_item_relation(
+    item_key: str,
+    related_item_key: str,
+    relation_type: str = "dc:relation",
+    *,
+    ctx: Context
+) -> str:
+    """
+    Add a related item relationship to a Zotero item.
+
+    Args:
+        item_key: The key of the primary item
+        related_item_key: The key of the item to relate to
+        relation_type: The type of relationship (default: "dc:relation").
+                       Common values: "dc:relation", "owl:sameAs"
+        ctx: MCP context
+
+    Returns:
+        Confirmation message
+    """
+    try:
+        read_zot, write_zot = _helpers._get_write_client(ctx)
+    except ValueError as e:
+        return str(e)
+
+    try:
+        if item_key == related_item_key:
+            return "Error: Cannot relate an item to itself."
+
+        ctx.info(f"Adding relation from {item_key} to {related_item_key}")
+
+        # Fetch the primary item
+        try:
+            item = write_zot.item(item_key)
+        except Exception as e:
+            return f"Error: Item '{item_key}' not found."
+
+        # Verify the related item exists
+        try:
+            related_item = write_zot.item(related_item_key)
+        except Exception as e:
+            return f"Error: Related item '{related_item_key}' not found."
+
+        data = item.get("data", {})
+        related_data = related_item.get("data", {})
+
+        # Get current relations or initialize empty dict
+        relations = data.get("relations", {})
+        if not isinstance(relations, dict):
+            relations = {}
+
+        # Build the relation URI using the canonical format for the library type
+        library_type = write_zot.library_type
+        library_id = write_zot.library_id
+        related_uri = _build_relation_uri(library_type, library_id, related_item_key)
+
+        # Add the relation to the primary item
+        if relation_type not in relations:
+            relations[relation_type] = []
+        if not isinstance(relations[relation_type], list):
+            relations[relation_type] = [relations[relation_type]]
+
+        # Check if relation already exists (match both URI prefix variants)
+        if _relation_exists(relations[relation_type], library_id, related_item_key):
+            return f"Relation already exists: '{item_key}' is already related to '{related_item_key}'."
+
+        relations[relation_type].append(related_uri)
+        data["relations"] = relations
+
+        # Update the primary item
+        resp = write_zot.update_item(item)
+        if not _helpers._handle_write_response(resp, ctx):
+            return f"Failed to add relation to item '{item_key}'."
+
+        # Also add reverse relation (bidirectional)
+        try:
+            # Re-fetch to get latest version
+            item = write_zot.item(item_key)
+            related_item = write_zot.item(related_item_key)
+            related_data = related_item.get("data", {})
+            reverse_relations = related_data.get("relations", {})
+            if not isinstance(reverse_relations, dict):
+                reverse_relations = {}
+
+            item_uri = _build_relation_uri(library_type, library_id, item_key)
+
+            if relation_type not in reverse_relations:
+                reverse_relations[relation_type] = []
+            if not isinstance(reverse_relations[relation_type], list):
+                reverse_relations[relation_type] = [reverse_relations[relation_type]]
+
+            if not _relation_exists(reverse_relations[relation_type], library_id, item_key):
+                reverse_relations[relation_type].append(item_uri)
+                related_data["relations"] = reverse_relations
+                write_zot.update_item(related_item)
+        except Exception as e:
+            ctx.warn(f"Could not add reverse relation: {e}")
+
+        item_title = data.get("title", "Untitled")
+        related_title = related_data.get("title", "Untitled")
+
+        return (
+            f"Successfully added relation:\n\n"
+            f"**From:** `{item_key}` — {item_title}\n"
+            f"**To:** `{related_item_key}` — {related_title}\n"
+            f"**Relation type:** `{relation_type}`"
+        )
+
+    except Exception as e:
+        ctx.error(f"Error adding item relation: {e}")
+        return f"Error adding item relation: {e}"
+
+
+@mcp.tool(
+    name="zotero_remove_item_relation",
+    description="Remove a related item relationship from a Zotero item."
+)
+def remove_item_relation(
+    item_key: str,
+    related_item_key: str,
+    relation_type: str = "dc:relation",
+    remove_bidirectional: bool = True,
+    *,
+    ctx: Context
+) -> str:
+    """
+    Remove a related item relationship from a Zotero item.
+
+    Args:
+        item_key: The key of the primary item
+        related_item_key: The key of the related item to unlink
+        relation_type: The type of relationship (default: "dc:relation")
+        remove_bidirectional: Also remove the reverse relation (default: True)
+        ctx: MCP context
+
+    Returns:
+        Confirmation message
+    """
+    try:
+        read_zot, write_zot = _helpers._get_write_client(ctx)
+    except ValueError as e:
+        return str(e)
+
+    try:
+        ctx.info(f"Removing relation from {item_key} to {related_item_key}")
+
+        # Fetch the primary item
+        try:
+            item = write_zot.item(item_key)
+        except Exception as e:
+            return f"Error: Item '{item_key}' not found."
+
+        data = item.get("data", {})
+        relations = data.get("relations", {})
+
+        if not isinstance(relations, dict):
+            return f"Item '{item_key}' has no relations to remove."
+
+        if relation_type not in relations:
+            return f"Item '{item_key}' has no relations of type '{relation_type}'."
+
+        # Match any URI variant (users/ or groups/) for this library
+        library_id = write_zot.library_id
+
+        rel_list = relations[relation_type]
+        if not isinstance(rel_list, list):
+            rel_list = [rel_list]
+
+        # Find the matching URI regardless of users/ vs groups/ prefix
+        matched_uri = _find_matching_uri(rel_list, library_id, related_item_key)
+        if matched_uri is None:
+            return f"Relation not found: '{item_key}' is not related to '{related_item_key}'."
+
+        # Remove the relation
+        rel_list.remove(matched_uri)
+        if not rel_list:
+            del relations[relation_type]
+        else:
+            relations[relation_type] = rel_list
+
+        data["relations"] = relations
+
+        # Update the item
+        resp = write_zot.update_item(item)
+        if not _helpers._handle_write_response(resp, ctx):
+            return f"Failed to remove relation from item '{item_key}'."
+
+        # Remove bidirectional relation if requested
+        if remove_bidirectional:
+            try:
+                related_item = write_zot.item(related_item_key)
+                related_data = related_item.get("data", {})
+                reverse_relations = related_data.get("relations", {})
+
+                if isinstance(reverse_relations, dict) and relation_type in reverse_relations:
+                    reverse_list = reverse_relations[relation_type]
+                    if not isinstance(reverse_list, list):
+                        reverse_list = [reverse_list]
+
+                    matched_reverse = _find_matching_uri(reverse_list, library_id, item_key)
+                    if matched_reverse is not None:
+                        reverse_list.remove(matched_reverse)
+                        if not reverse_list:
+                            del reverse_relations[relation_type]
+                        else:
+                            reverse_relations[relation_type] = reverse_list
+                        related_data["relations"] = reverse_relations
+                        write_zot.update_item(related_item)
+            except Exception as e:
+                ctx.warn(f"Could not remove reverse relation: {e}")
+
+        return (
+            f"Successfully removed relation:\n\n"
+            f"**From:** `{item_key}`\n"
+            f"**To:** `{related_item_key}`\n"
+            f"**Relation type:** `{relation_type}`"
+        )
+
+    except Exception as e:
+        ctx.error(f"Error removing item relation: {e}")
+        return f"Error removing item relation: {e}"

--- a/tests/test_item_related.py
+++ b/tests/test_item_related.py
@@ -1,0 +1,252 @@
+"""Tests for item related/relation functionality."""
+
+import pytest
+
+from zotero_mcp import server
+from conftest import DummyContext, FakeZotero, _FakeResponse
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+def _make_item(key="ABCD1234", version=10, title="Test Title",
+               relations=None, **kwargs):
+    """Build a Zotero item dict with optional relations."""
+    return {
+        "key": key,
+        "version": version,
+        "data": {
+            "key": key,
+            "version": version,
+            "itemType": "journalArticle",
+            "title": title,
+            "creators": [{"creatorType": "author",
+                          "firstName": "Jane", "lastName": "Doe"}],
+            "relations": relations or {},
+            **kwargs
+        },
+    }
+
+
+class FakeZoteroForRelations(FakeZotero):
+    """Extends FakeZotero with relation-specific behaviour."""
+
+    def __init__(self, items=None, library_type="user", library_id="12345"):
+        super().__init__()
+        self._items = {it["key"]: it for it in (items or [])}
+        self.update_calls = []
+        self.library_type = library_type
+        self.library_id = library_id
+
+    def item(self, item_key):
+        if item_key in self._items:
+            return self._items[item_key]
+        raise Exception(f"Item {item_key} not found")
+
+    def update_item(self, item, **kwargs):
+        self.update_calls.append(item)
+        # Update internal state
+        key = item.get("key")
+        if key in self._items:
+            self._items[key] = item
+        return _FakeResponse(204)
+
+
+# -----------------------------------------------------------------------------
+# Get Related Items Tests
+# -----------------------------------------------------------------------------
+
+class TestGetItemRelated:
+
+    def test_no_relations(self, monkeypatch):
+        """Item with no relations returns appropriate message."""
+        item = _make_item(key="ITEM0001", relations={})
+        fake = FakeZoteroForRelations(items=[item])
+
+        monkeypatch.setattr("zotero_mcp.tools.retrieval._client.get_zotero_client",
+                            lambda: fake)
+
+        result = server.get_item_related("ITEM0001", ctx=DummyContext())
+
+        assert "No related items found" in result
+        assert "ITEM0001" in result
+
+    def test_with_relations(self, monkeypatch):
+        """Item with relations returns formatted list."""
+        item1 = _make_item(key="ITEM0001", title="First Paper")
+        item2 = _make_item(key="ITEM0002", title="Second Paper")
+        item1["data"]["relations"] = {
+            "dc:relation": ["http://zotero.org/users/12345/items/ITEM0002"]
+        }
+
+        fake = FakeZoteroForRelations(items=[item1, item2])
+
+        monkeypatch.setattr("zotero_mcp.tools.retrieval._client.get_zotero_client",
+                            lambda: fake)
+
+        result = server.get_item_related("ITEM0001", ctx=DummyContext())
+
+        assert "Second Paper" in result
+        assert "ITEM0002" in result
+        assert "dc:relation" in result
+
+    def test_nonexistent_item(self, monkeypatch):
+        """Fetching relations for nonexistent item returns error."""
+        fake = FakeZoteroForRelations(items=[])
+
+        monkeypatch.setattr("zotero_mcp.tools.retrieval._client.get_zotero_client",
+                            lambda: fake)
+
+        result = server.get_item_related("NOTFOUND", ctx=DummyContext())
+
+        assert "not found" in result.lower()
+
+
+# -----------------------------------------------------------------------------
+# Add Relation Tests
+# -----------------------------------------------------------------------------
+
+class TestAddItemRelation:
+
+    def test_add_relation_success(self, monkeypatch):
+        """Successfully add a relation between two items."""
+        item1 = _make_item(key="ITEM0001", title="Paper One")
+        item2 = _make_item(key="ITEM0002", title="Paper Two")
+        fake = FakeZoteroForRelations(items=[item1, item2])
+
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.add_item_relation(
+            item_key="ITEM0001",
+            related_item_key="ITEM0002",
+            ctx=DummyContext(),
+        )
+
+        assert "Successfully added relation" in result
+        assert "ITEM0001" in result
+        assert "ITEM0002" in result
+        assert len(fake.update_calls) >= 1
+
+        # Verify the relation was added
+        updated_item = fake.update_calls[0]
+        relations = updated_item["data"]["relations"]
+        assert "dc:relation" in relations
+
+    def test_cannot_relate_to_self(self, monkeypatch):
+        """Cannot add relation from an item to itself."""
+        item1 = _make_item(key="ITEM0001")
+        fake = FakeZoteroForRelations(items=[item1])
+
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.add_item_relation(
+            item_key="ITEM0001",
+            related_item_key="ITEM0001",
+            ctx=DummyContext(),
+        )
+
+        assert "Cannot relate an item to itself" in result
+        assert len(fake.update_calls) == 0
+
+    def test_nonexistent_item(self, monkeypatch):
+        """Adding relation to nonexistent item returns error."""
+        item1 = _make_item(key="ITEM0001")
+        fake = FakeZoteroForRelations(items=[item1])
+
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.add_item_relation(
+            item_key="ITEM0001",
+            related_item_key="NOTFOUND",
+            ctx=DummyContext(),
+        )
+
+        assert "not found" in result.lower()
+
+    def test_duplicate_relation(self, monkeypatch):
+        """Adding duplicate relation returns informative message."""
+        item1 = _make_item(key="ITEM0001", relations={
+            "dc:relation": ["http://zotero.org/users/12345/items/ITEM0002"]
+        })
+        item2 = _make_item(key="ITEM0002")
+        fake = FakeZoteroForRelations(items=[item1, item2])
+
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.add_item_relation(
+            item_key="ITEM0001",
+            related_item_key="ITEM0002",
+            ctx=DummyContext(),
+        )
+
+        assert "already related" in result.lower()
+
+
+# -----------------------------------------------------------------------------
+# Remove Relation Tests
+# -----------------------------------------------------------------------------
+
+class TestRemoveItemRelation:
+
+    def test_remove_relation_success(self, monkeypatch):
+        """Successfully remove a relation."""
+        item1 = _make_item(key="ITEM0001", relations={
+            "dc:relation": ["http://zotero.org/users/12345/items/ITEM0002"]
+        })
+        item2 = _make_item(key="ITEM0002", relations={
+            "dc:relation": ["http://zotero.org/users/12345/items/ITEM0001"]
+        })
+        fake = FakeZoteroForRelations(items=[item1, item2])
+
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.remove_item_relation(
+            item_key="ITEM0001",
+            related_item_key="ITEM0002",
+            ctx=DummyContext(),
+        )
+
+        assert "Successfully removed relation" in result
+        assert "ITEM0001" in result
+        assert "ITEM0002" in result
+
+    def test_remove_nonexistent_relation(self, monkeypatch):
+        """Removing nonexistent relation returns error."""
+        item1 = _make_item(key="ITEM0001", relations={})
+        item2 = _make_item(key="ITEM0002")
+        fake = FakeZoteroForRelations(items=[item1, item2])
+
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.remove_item_relation(
+            item_key="ITEM0001",
+            related_item_key="ITEM0002",
+            ctx=DummyContext(),
+        )
+
+        assert "not related" in result.lower() or "no relations" in result.lower()
+
+    def test_no_relations_field(self, monkeypatch):
+        """Item with no relations field returns appropriate message."""
+        item1 = _make_item(key="ITEM0001")
+        item1["data"]["relations"] = {}  # Explicitly empty
+        item2 = _make_item(key="ITEM0002")
+        fake = FakeZoteroForRelations(items=[item1, item2])
+
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.remove_item_relation(
+            item_key="ITEM0001",
+            related_item_key="ITEM0002",
+            ctx=DummyContext(),
+        )
+
+        assert "no relations" in result.lower()


### PR DESCRIPTION
- Add zotero_get_item_related tool to retrieve related items for a given item
- Add zotero_add_item_relation tool to create bidirectional relations between items
- Add zotero_remove_item_relation tool to remove relations (with bidirectional support)
- Fix _build_relation_uri to handle pyzotero's pluralized library_type ('users'/'groups')
- Add helper functions: _relation_exists, _find_matching_uri for robust URI matching
- Add comprehensive unit tests for all relation operations
- Add .env.example with placeholder configuration
- Update README with related items documentation and tool listing