### PR TITLE
feat: add zotero_get_attachment_path tool

### DIFF
--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -627,6 +627,28 @@ class LocalZoteroReader:
     def extract_fulltext_for_item(self, item_id: int) -> tuple[str, str] | None:
         return self._extract_fulltext_for_item(item_id)
 
+    def get_attachment_paths(self, parent_key: str) -> list[dict]:
+        """Return resolved filesystem paths for a parent item's attachments.
+
+        Each entry has: ``key`` (attachment key), ``content_type``, ``zotero_path``
+        (the raw stored path like ``storage:foo.pdf``), ``resolved_path`` (a
+        ``Path`` or ``None`` if it could not be resolved), and ``exists`` (bool).
+        """
+        item = self.get_item_by_key(parent_key)
+        if not item:
+            return []
+        out: list[dict] = []
+        for att_key, zotero_path, ctype in self._iter_parent_attachments(item.item_id):
+            resolved = self._resolve_attachment_path(att_key, zotero_path or "")
+            out.append({
+                "key": att_key,
+                "content_type": ctype,
+                "zotero_path": zotero_path,
+                "resolved_path": resolved,
+                "exists": bool(resolved and resolved.exists()),
+            })
+        return out
+
     def get_item_by_key(self, key: str) -> ZoteroItem | None:
         """
         Get a specific item by its Zotero key.

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -4,11 +4,34 @@ import json
 import os
 import re
 import tempfile
+from pathlib import Path
 
 import requests
 
 from zotero_mcp import client as _client
 from zotero_mcp import utils as _utils
+
+
+# ---------------------------------------------------------------------------
+# Config file
+# ---------------------------------------------------------------------------
+
+ZOTERO_MCP_CONFIG_PATH = Path.home() / ".config" / "zotero-mcp" / "config.json"
+
+
+def _load_zotero_mcp_config() -> dict:
+    """Return the parsed ``~/.config/zotero-mcp/config.json``, or ``{}``.
+
+    Missing file or parse errors yield an empty dict so callers can use
+    ``.get(...)`` chains without guarding.
+    """
+    if not ZOTERO_MCP_CONFIG_PATH.exists():
+        return {}
+    try:
+        with open(ZOTERO_MCP_CONFIG_PATH, encoding="utf-8") as f:
+            return json.load(f) or {}
+    except (json.JSONDecodeError, OSError):
+        return {}
 
 
 # ---------------------------------------------------------------------------

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -99,26 +99,13 @@ def get_item_fulltext(
             from zotero_mcp.local_db import LocalZoteroReader
 
             if _utils.is_local_mode():
-                config_path = Path.home() / ".config" / "zotero-mcp" / "config.json"
-                zotero_db_path = None
-                pdf_max_pages = None
-                fulltext_display_max = None
-
-                if config_path.exists():
-                    try:
-                        with open(config_path, encoding="utf-8") as _f:
-                            _cfg = json.load(_f)
-                            semantic_cfg = _cfg.get("semantic_search", {})
-                            zotero_db_path = semantic_cfg.get("zotero_db_path")
-                            extraction_cfg = semantic_cfg.get("extraction", {})
-                            pdf_max_pages = extraction_cfg.get("pdf_max_pages")
-                            # Separate display limit for when Claude reads papers
-                            # (reduces token usage vs. indexing which can be higher)
-                            fulltext_display_max = extraction_cfg.get(
-                                "fulltext_display_max_pages"
-                            )
-                    except Exception:
-                        pass
+                semantic_cfg = _helpers._load_zotero_mcp_config().get("semantic_search", {})
+                zotero_db_path = semantic_cfg.get("zotero_db_path")
+                extraction_cfg = semantic_cfg.get("extraction", {})
+                pdf_max_pages = extraction_cfg.get("pdf_max_pages")
+                # Separate display limit for when Claude reads papers
+                # (reduces token usage vs. indexing which can be higher)
+                fulltext_display_max = extraction_cfg.get("fulltext_display_max_pages")
 
                 # Use display limit if configured, otherwise fall back to
                 # pdf_max_pages, with a default cap of 10 pages.
@@ -222,16 +209,11 @@ def get_attachment_path(
     try:
         from zotero_mcp.local_db import LocalZoteroReader
 
-        config_path = Path.home() / ".config" / "zotero-mcp" / "config.json"
-        zotero_db_path = None
-        if config_path.exists():
-            try:
-                with open(config_path, encoding="utf-8") as f:
-                    zotero_db_path = json.load(f).get("semantic_search", {}).get(
-                        "zotero_db_path"
-                    )
-            except Exception:
-                pass
+        zotero_db_path = (
+            _helpers._load_zotero_mcp_config()
+            .get("semantic_search", {})
+            .get("zotero_db_path")
+        )
 
         with LocalZoteroReader(db_path=zotero_db_path) as reader:
             attachments = reader.get_attachment_paths(item_key)

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -200,6 +200,62 @@ def get_item_fulltext(
 
 
 @mcp.tool(
+    name="zotero_get_attachment_path",
+    description=(
+        "Return the local filesystem path(s) of a Zotero item's attachments. "
+        "Local mode only. Useful when you want to read a large PDF directly "
+        "(e.g., a book) instead of going through zotero_get_item_fulltext, "
+        "which is page-limited."
+    )
+)
+def get_attachment_path(
+    item_key: str,
+    *,
+    ctx: Context
+) -> str:
+    """List resolved local paths for an item's attachments."""
+    if not _utils.is_local_mode():
+        return (
+            "Error: zotero_get_attachment_path requires local mode "
+            "(set ZOTERO_LOCAL=true). Cloud-only attachments have no local path."
+        )
+    try:
+        from zotero_mcp.local_db import LocalZoteroReader
+
+        config_path = Path.home() / ".config" / "zotero-mcp" / "config.json"
+        zotero_db_path = None
+        if config_path.exists():
+            try:
+                with open(config_path, encoding="utf-8") as f:
+                    zotero_db_path = json.load(f).get("semantic_search", {}).get(
+                        "zotero_db_path"
+                    )
+            except Exception:
+                pass
+
+        with LocalZoteroReader(db_path=zotero_db_path) as reader:
+            attachments = reader.get_attachment_paths(item_key)
+
+        if not attachments:
+            return f"No attachments found for item `{item_key}`."
+
+        lines = [f"# Attachments for `{item_key}`", ""]
+        for att in attachments:
+            lines.append(f"## `{att['key']}` ({att['content_type'] or 'unknown'})")
+            lines.append(f"- Zotero path: `{att['zotero_path']}`")
+            if att["resolved_path"] is not None:
+                marker = "" if att["exists"] else " (missing on disk)"
+                lines.append(f"- Local path: `{att['resolved_path']}`{marker}")
+            else:
+                lines.append("- Local path: *unresolved*")
+            lines.append("")
+        return "\n".join(lines).rstrip()
+    except Exception as e:
+        ctx.error(f"Error resolving attachment path: {e}")
+        return f"Error resolving attachment path: {e}"
+
+
+@mcp.tool(
     name="zotero_get_collections",
     description="List all collections in your Zotero library."
 )

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -137,3 +137,47 @@ class TestResolveAttachmentPath:
         """Unknown path format returns None."""
         reader = self._make_reader(tmp_path)
         assert reader._resolve_attachment_path("X", "ftp://something") is None
+
+
+class TestGetAttachmentPaths:
+    """Tests for the public get_attachment_paths helper."""
+
+    def _make_reader(self, tmp_path, attachments, item_key="PARENT"):
+        reader = FakeLocalZoteroReader()
+        reader.db_path = str(tmp_path / "zotero.sqlite")
+        reader._resolve_attachment_path = LocalZoteroReader._resolve_attachment_path.__get__(reader)
+        reader._get_storage_dir = LocalZoteroReader._get_storage_dir.__get__(reader)
+        reader._get_base_attachment_path = LocalZoteroReader._get_base_attachment_path.__get__(reader)
+
+        reader._iter_parent_attachments = lambda parent_id: iter(attachments)
+        reader.get_item_by_key = lambda key: ZoteroItem(item_id=1, key=key, item_type_id=1) if key == item_key else None
+        return reader
+
+    def test_returns_resolved_paths(self, tmp_path):
+        (tmp_path / "storage" / "ABC123").mkdir(parents=True)
+        pdf = tmp_path / "storage" / "ABC123" / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n")
+        reader = self._make_reader(tmp_path, [("ABC123", "storage:paper.pdf", "application/pdf")])
+        result = reader.get_attachment_paths("PARENT")
+        assert len(result) == 1
+        assert result[0]["key"] == "ABC123"
+        assert result[0]["content_type"] == "application/pdf"
+        assert result[0]["resolved_path"] == pdf
+        assert result[0]["exists"] is True
+
+    def test_marks_missing_files(self, tmp_path):
+        reader = self._make_reader(tmp_path, [("X", "storage:gone.pdf", "application/pdf")])
+        result = reader.get_attachment_paths("PARENT")
+        assert result[0]["exists"] is False
+
+    def test_unknown_item_returns_empty(self, tmp_path):
+        reader = self._make_reader(tmp_path, [])
+        assert reader.get_attachment_paths("MISSING") == []
+
+    def test_multiple_attachments(self, tmp_path):
+        reader = self._make_reader(tmp_path, [
+            ("A", "storage:a.pdf", "application/pdf"),
+            ("B", "storage:b.html", "text/html"),
+        ])
+        result = reader.get_attachment_paths("PARENT")
+        assert [a["key"] for a in result] == ["A", "B"]


### PR DESCRIPTION
## Summary

- Adds a new MCP tool `zotero_get_attachment_path(item_key)` that returns the local filesystem path(s) of a Zotero item's attachments. Local mode only.
- Exposes a public `LocalZoteroReader.get_attachment_paths(parent_key)` wrapping the existing `_iter_parent_attachments` + `_resolve_attachment_path` helpers.
- Factors the repeated "open `~/.config/zotero-mcp/config.json` + parse + guard" pattern into `_load_zotero_mcp_config()` in `tools/_helpers.py`, used by both `get_item_fulltext` and the new tool.

## Why

`zotero_get_item_fulltext` is page-capped (default 10 pages), which is fine for papers but truncates books. With this tool, a caller can resolve the attachment's filesystem path and read large PDFs directly (e.g. via Claude Code's PDF reader, which handles 20-page chunks).

Returns all attachments for the item with key, content type, raw Zotero path, resolved local path, and an existence flag --- so books with multiple files (e.g. a snapshot + the PDF) are visible.

## Test plan

- [x] New unit tests in `tests/test_local_db.py::TestGetAttachmentPaths` cover resolved paths, missing files, unknown items, and multiple attachments.
- [x] Existing `tests/test_local_db.py`, `tests/test_fulltext_local_mode.py`, `tests/test_pdf_outline.py`, `tests/test_shared_helpers.py` all pass (77 passed, 1 skipped).
- [x] Smoke-tested live against a local Zotero DB: returns `/Users/.../Zotero/storage/<KEY>/<filename>` for a real book item.