### PR TITLE
fix(arxiv): honor attach_mode='linked_url' in _add_by_arxiv

### DIFF
--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -568,7 +568,8 @@ def add_by_url(
         # arXiv URL routing
         arxiv_id = _helpers._normalize_arxiv_id(url)
         if arxiv_id:
-            return _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx)
+            return _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx,
+                                 attach_mode=attach_mode)
 
         # Generic webpage
         ctx.info(f"Creating webpage item for: {url}")
@@ -599,7 +600,7 @@ def add_by_url(
         return f"Error adding by URL: {e}"
 
 
-def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx):
+def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto"):
     """Add an arXiv paper by ID. Internal helper for add_by_url."""
     ctx.info(f"Fetching arXiv metadata for: {arxiv_id}")
 
@@ -681,23 +682,35 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx):
         # arXiv always has a free PDF — try to attach it
         pdf_url = f"https://arxiv.org/pdf/{arxiv_id}.pdf"
         pdf_status = "no PDF attached"
-        try:
-            pdf_resp = requests.get(pdf_url, timeout=30, stream=True)
-            pdf_resp.raise_for_status()
-            with tempfile.TemporaryDirectory() as tmpdir:
-                filename = f"arxiv_{arxiv_id.replace('/', '_')}.pdf"
-                filepath = os.path.join(tmpdir, filename)
-                with open(filepath, "wb") as f:
-                    for chunk in pdf_resp.iter_content(chunk_size=8192):
-                        f.write(chunk)
-                write_zot.attachment_both(
-                    [(filename, filepath)],
-                    parentid=item_key,
-                )
-            pdf_status = "PDF attached"
-        except Exception as e:
-            ctx.info(f"arXiv PDF attachment failed (non-fatal): {e}")
-            pdf_status = f"no PDF attached ({e})"
+        if attach_mode == "linked_url":
+            # Bookmark the PDF URL only — no binary upload. Useful for users who
+            # sync attachment files outside of Zotero's official storage (e.g. WebDAV).
+            try:
+                if _helpers._attach_pdf_linked_url(write_zot, pdf_url, item_key, ctx):
+                    pdf_status = "PDF linked (URL only, no upload)"
+                else:
+                    pdf_status = "linked URL attachment failed"
+            except Exception as e:
+                ctx.info(f"arXiv linked URL attachment failed (non-fatal): {e}")
+                pdf_status = f"no PDF attached ({e})"
+        else:
+            try:
+                pdf_resp = requests.get(pdf_url, timeout=30, stream=True)
+                pdf_resp.raise_for_status()
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    filename = f"arxiv_{arxiv_id.replace('/', '_')}.pdf"
+                    filepath = os.path.join(tmpdir, filename)
+                    with open(filepath, "wb") as f:
+                        for chunk in pdf_resp.iter_content(chunk_size=8192):
+                            f.write(chunk)
+                    write_zot.attachment_both(
+                        [(filename, filepath)],
+                        parentid=item_key,
+                    )
+                pdf_status = "PDF attached"
+            except Exception as e:
+                ctx.info(f"arXiv PDF attachment failed (non-fatal): {e}")
+                pdf_status = f"no PDF attached ({e})"
 
         return (
             f"Successfully added arXiv paper: **{title}**\n\n"

--- a/tests/test_add_by_url.py
+++ b/tests/test_add_by_url.py
@@ -561,13 +561,13 @@ class TestArxivAttachMode:
     not see those files locally, even though the metadata existed.
     """
 
-    def test_linked_url_skips_binary_upload(self, dummy_ctx, patch_write_client):
-        """attach_mode='linked_url' should call _attach_pdf_linked_url, not upload binary."""
+    def test_linked_url_skips_binary_download_and_upload(self, dummy_ctx, patch_write_client):
+        """attach_mode='linked_url' should neither download nor upload the PDF binary."""
         fake_zot = patch_write_client
         fake_zot.attachment_both = MagicMock()
 
         mock_resp = _make_arxiv_response(ARXIV_ATOM_XML)
-        with patch("zotero_mcp.tools.write.requests.get", return_value=mock_resp), \
+        with patch("zotero_mcp.tools.write.requests.get", return_value=mock_resp) as mock_get, \
              patch(
                  "zotero_mcp.tools._helpers._attach_pdf_linked_url",
                  return_value=True,
@@ -583,6 +583,15 @@ class TestArxivAttachMode:
         # _attach_pdf_linked_url(write_zot, pdf_url, parent_key, ctx)
         pdf_url_arg = mock_linked.call_args[0][1]
         assert "arxiv.org/pdf/2401.00001" in pdf_url_arg
+
+        # PDF must NOT be downloaded — only the arXiv metadata API may be hit
+        assert mock_get.call_count == 1
+        first_call_url = mock_get.call_args_list[0][0][0]
+        assert "export.arxiv.org" in first_call_url
+        for call in mock_get.call_args_list:
+            url_arg = call[0][0] if call[0] else call.kwargs.get("url", "")
+            assert "arxiv.org/pdf/" not in url_arg, \
+                f"PDF URL was fetched in linked_url mode: {url_arg}"
 
         # Binary upload path must NOT be invoked
         fake_zot.attachment_both.assert_not_called()

--- a/tests/test_add_by_url.py
+++ b/tests/test_add_by_url.py
@@ -545,3 +545,67 @@ class TestTagsAndCollections:
         item = fake_zot.created[0]
         tag_values = [t["tag"] for t in item.get("tags", [])]
         assert "reference" in tag_values
+
+
+# ---------------------------------------------------------------------------
+# arXiv attach_mode handling
+# ---------------------------------------------------------------------------
+
+
+class TestArxivAttachMode:
+    """The arXiv path should honor the attach_mode parameter.
+
+    Regression test for the case where ``_add_by_arxiv`` ignored ``attach_mode``
+    and unconditionally called ``write_zot.attachment_both``, which uploads PDF
+    binaries to Zotero's official cloud storage. WebDAV-syncing users could
+    not see those files locally, even though the metadata existed.
+    """
+
+    def test_linked_url_skips_binary_upload(self, dummy_ctx, patch_write_client):
+        """attach_mode='linked_url' should call _attach_pdf_linked_url, not upload binary."""
+        fake_zot = patch_write_client
+        fake_zot.attachment_both = MagicMock()
+
+        mock_resp = _make_arxiv_response(ARXIV_ATOM_XML)
+        with patch("zotero_mcp.tools.write.requests.get", return_value=mock_resp), \
+             patch(
+                 "zotero_mcp.tools._helpers._attach_pdf_linked_url",
+                 return_value=True,
+             ) as mock_linked:
+            result = server.add_by_url(
+                url="https://arxiv.org/abs/2401.00001",
+                attach_mode="linked_url",
+                ctx=dummy_ctx,
+            )
+
+        # Linked URL helper should be invoked exactly once with the arXiv PDF URL
+        assert mock_linked.call_count == 1
+        # _attach_pdf_linked_url(write_zot, pdf_url, parent_key, ctx)
+        pdf_url_arg = mock_linked.call_args[0][1]
+        assert "arxiv.org/pdf/2401.00001" in pdf_url_arg
+
+        # Binary upload path must NOT be invoked
+        fake_zot.attachment_both.assert_not_called()
+
+        # Result message reflects linked-URL mode
+        assert "PDF linked" in result
+
+    def test_default_mode_uploads_binary(self, dummy_ctx, patch_write_client):
+        """Default attach_mode='auto' should still call attachment_both (backward compat)."""
+        fake_zot = patch_write_client
+        fake_zot.attachment_both = MagicMock()
+
+        mock_resp = _make_arxiv_response(ARXIV_ATOM_XML)
+        with patch("zotero_mcp.tools.write.requests.get", return_value=mock_resp), \
+             patch(
+                 "zotero_mcp.tools._helpers._attach_pdf_linked_url",
+             ) as mock_linked:
+            server.add_by_url(
+                url="https://arxiv.org/abs/2401.00001",
+                ctx=dummy_ctx,
+            )
+
+        # Linked-URL helper must NOT be invoked in default mode
+        mock_linked.assert_not_called()
+        # Binary upload path is invoked
+        assert fake_zot.attachment_both.call_count == 1


### PR DESCRIPTION
## Problem

`_add_by_arxiv` (called by `add_by_url` for arXiv URLs) previously ignored the `attach_mode` argument and unconditionally used `write_zot.attachment_both()`, uploading PDF binaries to Zotero's official cloud storage via the Web API.

This breaks **WebDAV**-based file sync users (third-party storage like Box, Nutstore, custom WebDAV — anything other than Zotero's official paid storage): the metadata is created, but the binary lives in a storage path the local client never pulls from, so the PDF is invisible to the user.

The DOI path (`_attach_pdf_with_fallback`) already respects `attach_mode` correctly — this PR brings the arXiv path in line.

Fixes #274

## Changes

- Add `attach_mode` parameter to `_add_by_arxiv` (default `"auto"`, preserving existing behavior).
- Forward `attach_mode` from `add_by_url` to `_add_by_arxiv`.
- When `attach_mode == "linked_url"`, route to `_helpers._attach_pdf_linked_url` to create a linked-URL attachment pointing to the arXiv PDF URL — no binary download or upload.

Backward compatible — callers that don't pass `attach_mode` keep the same upload behavior as before.

## Test plan

- [x] Added `TestArxivAttachMode` to `tests/test_add_by_url.py` with two cases that mock `_attach_pdf_linked_url` and `attachment_both` to verify routing in both `linked_url` and default modes.
- [x] `pytest tests/` — 437 passed locally.
- [x] `ruff check` — no new warnings introduced.
- [x] End-to-end: added an arXiv item with `attach_mode="linked_url"` against a real Zotero account, confirmed attachment `linkMode=linked_url` and zero zotero.org storage usage delta.