### PR TITLE
feat: add `place` field to zotero_update_item

### DIFF
--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -723,6 +723,7 @@ _UPDATE_ITEM_API_TO_PARAM = {
     "issue": "issue",
     "pages": "pages",
     "publisher": "publisher",
+    "place": "place",
     "ISSN": "issn",
     "language": "language",
     "shortTitle": "short_title",
@@ -760,6 +761,7 @@ def update_item(
     issue: str | None = None,
     pages: str | None = None,
     publisher: str | None = None,
+    place: str | None = None,
     issn: str | None = None,
     language: str | None = None,
     short_title: str | None = None,
@@ -813,6 +815,8 @@ def update_item(
             field_updates["pages"] = pages
         if publisher is not None:
             field_updates["publisher"] = publisher
+        if place is not None:
+            field_updates["place"] = place
         if issn is not None:
             field_updates["ISSN"] = issn
         if language is not None:

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1,6 +1,6 @@
 """Write / mutation tool functions for the Zotero MCP server."""
 
-from typing import Literal
+from typing import Annotated, Literal
 import json
 import os
 import re
@@ -11,6 +11,7 @@ import time as _time
 
 import requests
 from fastmcp import Context
+from pydantic import Field
 
 from zotero_mcp._app import mcp
 from zotero_mcp import client as _client
@@ -737,6 +738,9 @@ _UPDATE_ITEM_API_TO_PARAM = {
     name="zotero_update_item",
     description=(
         "Update metadata for an existing item in your Zotero library. "
+        "Editable fields include title, creators, date, publisher, place, "
+        "publication_title, volume, issue, pages, DOI, ISBN, ISSN, url, "
+        "language, abstract, short_title, edition, book_title, and extra. "
         "To add tags without removing existing ones, use add_tags (not tags). "
         "To remove specific tags, use remove_tags. "
         "Using tags replaces ALL existing tags — use add_tags/remove_tags for incremental changes."
@@ -761,7 +765,10 @@ def update_item(
     issue: str | None = None,
     pages: str | None = None,
     publisher: str | None = None,
-    place: str | None = None,
+    place: Annotated[
+        str | None,
+        Field(description="Publication place (city), e.g., 'New York' or 'Cambridge, MA'."),
+    ] = None,
     issn: str | None = None,
     language: str | None = None,
     short_title: str | None = None,
@@ -771,6 +778,33 @@ def update_item(
     *,
     ctx: Context
 ) -> str:
+    """
+    Update metadata fields on an existing Zotero item.
+
+    Only fields you pass are modified; unspecified fields are left
+    untouched. Fields whose API key does not exist on the item's
+    itemType (e.g. ``place`` on a ``journalArticle``) are reported as
+    skipped rather than written.
+
+    Args:
+        item_key: 8-character Zotero item key of the item to update.
+        title, creators, date, publication_title, abstract, doi, url,
+        extra, volume, issue, pages, publisher, place, issn, language,
+        short_title, edition, isbn, book_title: per-field overrides;
+        ``place`` is the publication city (e.g. ``"New York"`` or
+        ``"Cambridge, MA"``) and is valid on book, bookSection, thesis,
+        manuscript, report, and conferencePaper item types.
+        tags / add_tags / remove_tags: mutually exclusive; ``tags``
+        REPLACES the full tag list, ``add_tags`` / ``remove_tags`` are
+        incremental. Prefer the incremental forms.
+        collections / collection_names: REPLACE collection memberships;
+        for incremental moves use zotero_manage_collections instead.
+        ctx: MCP context.
+
+    Returns:
+        A markdown-formatted summary of what changed (or a skip
+        warning for fields not valid on the item type).
+    """
     try:
         read_zot, write_zot = _helpers._get_write_client(ctx)
     except ValueError as e:

--- a/tests/test_update_item.py
+++ b/tests/test_update_item.py
@@ -735,6 +735,61 @@ class TestUpdateItemNewFields:
         assert fake.update_calls[0]["data"]["edition"] == "3rd"
         assert "3rd" in result
 
+    def test_update_place_on_book(self, monkeypatch):
+        # The book fixture pre-populates place="" so the update should
+        # land on the existing field rather than be skipped as
+        # "not valid for itemType".
+        item = _make_book_item()
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="BOOK1234",
+            place="New York",
+            ctx=DummyContext(),
+        )
+
+        assert fake.update_calls[0]["data"]["place"] == "New York"
+        assert "New York" in result
+
+    def test_update_place_on_book_section(self, monkeypatch):
+        # bookSection also carries place; ensure the field maps the same
+        # way across the parent item types that have it.
+        item = _make_book_section_item()
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="BSEC1234",
+            place="Cambridge, MA",
+            ctx=DummyContext(),
+        )
+
+        assert fake.update_calls[0]["data"]["place"] == "Cambridge, MA"
+        assert "Cambridge, MA" in result
+
+    def test_update_place_skipped_on_journal_article(self, monkeypatch):
+        # journalArticle has no place field, so passing place= should be
+        # reported as a skipped field rather than silently writing an
+        # invalid key, matching the existing skip-warning behaviour for
+        # issue= on a book.
+        item = _make_item()
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="ABCD1234",
+            place="New York",
+            ctx=DummyContext(),
+        )
+
+        assert len(fake.update_calls) == 0
+        assert "place" in result
+        assert "skip" in result.lower() or "not valid" in result.lower()
+
     def test_update_isbn_on_book(self, monkeypatch):
         item = _make_book_item()
         fake = FakeZoteroForUpdate(items=[item])


### PR DESCRIPTION
## Summary

Add `place` (publication place) to the set of writable fields on `zotero_update_item`. Today `zotero_update_item` exposes title, creators, date, publisher, publication_title, volume, issue, pages, DOI, ISBN, ISSN, url, language, abstract, short_title, edition, book_title, extra, item_type, and tag/collection helpers — but not `place`, which is a standard Zotero top-level field on `book`, `bookSection`, `thesis`, `manuscript`, `report`, `conferencePaper`, and several other parent item types. As a result, a common book/chapter metadata fix ("publisher city was concatenated into publisher, move it to place") can't currently be done via the MCP and has to be patched up in Zotero Desktop by hand.

## Changes

- `tools/write.py`:
  - Add `place: str | None = None` to the `update_item` signature parallel to `publisher` / `edition`.
  - Add `"place": "place"` to `_UPDATE_ITEM_API_TO_PARAM` so the skip-warning message uses the snake_case param name. (Zotero's API key is already `place` lowercase, so the mapping is identity — but the registration keeps the warning machinery consistent.)
  - Route `place` through the existing `field_updates` if-chain.
- `tests/test_update_item.py`:
  - `test_update_place_on_book` — round-trip on a book fixture.
  - `test_update_place_on_book_section` — same for bookSection.
  - `test_update_place_skipped_on_journal_article` — passing `place=` on a journalArticle (which doesn't carry the field) produces the same skip warning the rest of the per-itemtype fields emit.

## Test plan

- [x] Unit: 3 new tests for the place field, all passing.
- [x] Full suite: 438/438 passing locally.
- [ ] Manual round-trip against a real Zotero library — pending live verification on a book item.

## Notes

Mirrors the convention #195 established when ten other named fields were exposed. No behavioural changes for existing parameters; `place` is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)