### PR TITLE
feat: add zotero_read_pdf_pages tool for page-range PDF extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`zotero_read_pdf_pages` tool** — read a specific page range from a PDF attachment after section identification via `zotero_get_pdf_outline`. Extracts text from the requested pages using PyMuPDF, avoiding the need to read the entire paper when only a few pages are relevant.
+
 ## [0.2.2] - 2026-03-26
 
 ### Added

--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -107,6 +107,9 @@ from zotero_mcp.tools.write import (  # noqa: F401
     get_pdf_outline,
     add_from_file,
 )
+from zotero_mcp.tools.read_pdf import (  # noqa: F401
+    read_pdf_pages,
+)
 from zotero_mcp.tools.connectors import (  # noqa: F401
     chatgpt_connector_search,
     connector_fetch,

--- a/src/zotero_mcp/tools/__init__.py
+++ b/src/zotero_mcp/tools/__init__.py
@@ -3,6 +3,7 @@
 from zotero_mcp.tools import (  # noqa: F401
     annotations,
     connectors,
+    read_pdf,
     retrieval,
     search,
     write,

--- a/src/zotero_mcp/tools/read_pdf.py
+++ b/src/zotero_mcp/tools/read_pdf.py
@@ -1,0 +1,184 @@
+"""Tool for reading specific page ranges from PDF attachments."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from fastmcp import Context
+
+from zotero_mcp import client as _client
+from zotero_mcp import utils as _utils
+from zotero_mcp._app import mcp
+from zotero_mcp.tools import _helpers
+
+
+def _cleanup_path(file_path: str) -> None:
+    """Remove a downloaded PDF and its parent temp directory."""
+    try:
+        parent = os.path.dirname(file_path)
+        if os.path.exists(parent) and parent.startswith(tempfile.gettempdir()):
+            import shutil
+
+            shutil.rmtree(parent, ignore_errors=True)
+    except Exception:
+        pass
+
+
+def _get_pdf_path(item_key: str, ctx: Context) -> tuple[str, str] | None:
+    """Download a PDF attachment and return (file_path, title).
+
+    Tries local storage first (via LocalZoteroReader), then downloads via API.
+    Returns None if no PDF attachment is found.
+    The caller is responsible for cleaning up the returned file_path.
+    """
+    zot = _client.get_zotero_client()
+    item = zot.item(item_key)
+
+    # Try local storage first (persists on disk — no cleanup needed)
+    try:
+        from zotero_mcp.local_db import LocalZoteroReader
+
+        if _utils.is_local_mode():
+            config_path = Path.home() / ".config" / "zotero-mcp" / "config.json"
+            zotero_db_path = None
+            if config_path.exists():
+                try:
+                    with open(config_path, encoding="utf-8") as _f:
+                        _cfg = json.load(_f)
+                        zotero_db_path = _cfg.get("semantic_search", {}).get("zotero_db_path")
+                except Exception:
+                    pass
+            with LocalZoteroReader(db_path=zotero_db_path) as reader:
+                local_item = reader.get_item_by_key(item_key)
+                if local_item:
+                    for att_key, path, ctype in reader._iter_parent_attachments(local_item.item_id):
+                        if ctype == "application/pdf":
+                            resolved = reader._resolve_attachment_path(att_key, path or "")
+                            if resolved and resolved.exists():
+                                return str(resolved), local_item.title or item_key
+    except Exception:
+        pass
+
+    # Fallback: download via API to a named temp file
+    attachment = _client.get_attachment_details(zot, item)
+    if not attachment:
+        return None
+
+    pdf_extensions = {".pdf", ".PDF"}
+    filename = attachment.filename or f"{attachment.key}.pdf"
+    if not any(filename.endswith(ext) for ext in pdf_extensions):
+        content_type = attachment.content_type or ""
+        if "pdf" not in content_type.lower():
+            return None
+
+    tmpdir = tempfile.mkdtemp(prefix="zotero_pdf_")
+    file_path = os.path.join(tmpdir, filename)
+    try:
+        zot.dump(attachment.key, filename=os.path.basename(file_path), path=tmpdir)
+        if os.path.exists(file_path) and os.path.getsize(file_path) > 0:
+            return file_path, attachment.title
+    except Exception:
+        _cleanup_path(file_path)
+        raise
+
+    _cleanup_path(file_path)
+    return None
+
+
+@mcp.tool(
+    name="zotero_read_pdf_pages",
+    description="Read specific page range(s) from a PDF attachment of a Zotero item. "
+    "Use this when you know which pages to read — for example after getting the PDF "
+    "outline via zotero_get_pdf_outline. Pages are 1-indexed. "
+    "Requires PyMuPDF: pip install zotero-mcp-server[pdf]",
+)
+def read_pdf_pages(
+    item_key: str,
+    start_page: int,
+    end_page: int | None = None,
+    *,
+    ctx: Context,
+) -> str:
+    """Extract and return text from a specific page range of a PDF.
+
+    Args:
+        item_key: Zotero item key/ID of the paper or its PDF attachment.
+        start_page: First page to read (1-indexed).
+        end_page: Last page to read (1-indexed). If omitted, reads only start_page.
+        ctx: MCP context.
+
+    Returns:
+        Markdown-formatted page content with metadata header.
+    """
+    try:
+        if not item_key or not item_key.strip():
+            return "Error: item_key cannot be empty."
+
+        if end_page is not None and end_page < start_page:
+            return "Error: end_page must be greater than or equal to start_page."
+
+        ctx.info(f"Reading PDF pages {start_page}-{end_page or start_page} for item {item_key}")
+
+        result = _get_pdf_path(item_key, ctx)
+        if result is None:
+            return f"No PDF attachment found for item: {item_key}"
+
+        pdf_path, title = result
+
+        try:
+            import fitz
+        except ImportError:
+            return "PyMuPDF is required for PDF page reading. Install it with: pip install zotero-mcp-server[pdf]"
+
+        doc = fitz.open(pdf_path)
+        total_pages = len(doc)
+        actual_end = end_page if end_page is not None else start_page
+
+        if start_page < 1 or start_page > total_pages:
+            doc.close()
+            _cleanup_path(pdf_path)
+            return f"Start page {start_page} is out of range. PDF has {total_pages} pages (1-{total_pages})."
+        if end_page is not None and end_page > total_pages:
+            doc.close()
+            _cleanup_path(pdf_path)
+            return f"End page {end_page} is out of range. PDF has {total_pages} pages (1-{total_pages})."
+
+        # Zero-indexed page numbers for PyMuPDF
+        zstart = start_page - 1
+        zend = actual_end - 1
+
+        output = [
+            f"# PDF Pages {start_page}-{actual_end} of {title}",
+            f"**Item Key:** {item_key}",
+            f"**Total pages in PDF:** {total_pages}",
+            "",
+        ]
+
+        page_count = zend - zstart + 1
+        if page_count > 50:
+            doc.close()
+            _cleanup_path(pdf_path)
+            return f"Requested {page_count} pages (max 50). Please narrow your page range."
+
+        for page_num in range(zstart, zend + 1):
+            page = doc[page_num]
+            text = page.get_text()
+            output.append(f"## Page {page_num + 1}")
+            output.append("")
+            if text.strip():
+                output.append(text.strip())
+            else:
+                output.append("*[No extractable text on this page]*")
+            output.append("")
+
+        doc.close()
+        _cleanup_path(pdf_path)
+        return _helpers._prepend_size_warning(
+            "\n".join(output),
+            "Consider using zotero_semantic_search to find specific content instead of reading full pages.",
+        )
+
+    except Exception as e:
+        ctx.error(f"Error reading PDF pages: {str(e)}")
+        return f"Error reading PDF pages: {str(e)}"

--- a/tests/test_read_pdf.py
+++ b/tests/test_read_pdf.py
@@ -1,0 +1,235 @@
+"""Tests for zotero_read_pdf_pages tool."""
+
+import sys
+import types
+
+import pytest
+from conftest import DummyContext, FakeZotero
+
+from zotero_mcp import server
+
+# ---------------------------------------------------------------------------
+# Helpers: fake fitz module and document
+# ---------------------------------------------------------------------------
+
+
+class FakePage:
+    def __init__(self, text):
+        self._text = text
+
+    def get_text(self):
+        return self._text
+
+
+class FakeDocument:
+    def __init__(self, pages, total=None):
+        self._pages = pages
+        self._total = total if total is not None else len(pages)
+
+    def __len__(self):
+        return self._total
+
+    def __getitem__(self, index):
+        return self._pages[index]
+
+    def close(self):
+        pass
+
+
+def _make_fake_fitz(pages, total=None):
+    fake_fitz = types.ModuleType("fitz")
+    fake_fitz.open = lambda *args, **kwargs: FakeDocument(pages, total)  # noqa: ARG005
+    return fake_fitz
+
+
+def _patch_fitz(monkeypatch, pages, total=None):
+    fake_fitz = _make_fake_fitz(pages, total)
+    monkeypatch.setitem(sys.modules, "fitz", fake_fitz)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dummy_ctx():
+    return DummyContext()
+
+
+@pytest.fixture
+def fake_zot():
+    return FakeZotero()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    """Single page and page range reads."""
+
+    def test_single_page(self, monkeypatch, dummy_ctx, fake_zot):
+        _patch_fitz(monkeypatch, [FakePage("Page 1 content.")] * 10, total=10)
+        monkeypatch.setattr(
+            "zotero_mcp.tools.read_pdf._get_pdf_path",
+            lambda _k, _c: ("/tmp/test.pdf", "Test Paper"),
+        )
+
+        result = server.read_pdf_pages(item_key="ITEM01", start_page=3, ctx=dummy_ctx)
+
+        assert "## Page 3" in result
+        assert "Page 1 content." in result
+
+    def test_page_range(self, monkeypatch, dummy_ctx, fake_zot):
+        pages = [
+            FakePage("Content of page 1."),
+            FakePage("Content of page 2."),
+            FakePage("Content of page 3."),
+            FakePage("Content of page 4."),
+            FakePage("Content of page 5."),
+        ]
+        _patch_fitz(monkeypatch, pages)
+        monkeypatch.setattr(
+            "zotero_mcp.tools.read_pdf._get_pdf_path",
+            lambda _k, _c: ("/tmp/test.pdf", "Test Paper"),
+        )
+
+        result = server.read_pdf_pages(item_key="ITEM01", start_page=2, end_page=4, ctx=dummy_ctx)
+
+        assert "## Page 2" in result
+        assert "Content of page 2." in result
+        assert "## Page 3" in result
+        assert "Content of page 3." in result
+        assert "## Page 4" in result
+        assert "Content of page 4." in result
+        assert "## Page 1" not in result
+        assert "## Page 5" not in result
+
+    def test_header_contains_metadata(self, monkeypatch, dummy_ctx, fake_zot):
+        _patch_fitz(monkeypatch, [FakePage("hello")])
+        monkeypatch.setattr(
+            "zotero_mcp.tools.read_pdf._get_pdf_path",
+            lambda _k, _c: ("/tmp/test.pdf", "My Paper Title"),
+        )
+
+        result = server.read_pdf_pages(item_key="KEY123", start_page=1, ctx=dummy_ctx)
+
+        assert "# PDF Pages 1-1 of My Paper Title" in result
+        assert "**Item Key:** KEY123" in result
+        assert "**Total pages in PDF:** 1" in result
+
+
+class TestErrors:
+    """Input validation and error cases."""
+
+    def test_empty_item_key(self, dummy_ctx):
+        result = server.read_pdf_pages(item_key="", start_page=1, ctx=dummy_ctx)
+        assert "item_key cannot be empty" in result
+
+    def test_whitespace_item_key(self, dummy_ctx):
+        result = server.read_pdf_pages(item_key="   ", start_page=1, ctx=dummy_ctx)
+        assert "item_key cannot be empty" in result
+
+    def test_end_page_less_than_start_page(self, dummy_ctx):
+        result = server.read_pdf_pages(item_key="ITEM01", start_page=5, end_page=3, ctx=dummy_ctx)
+        assert "end_page must be greater than or equal to start_page" in result
+
+    def test_no_pdf_attachment(self, monkeypatch, dummy_ctx, fake_zot):
+        monkeypatch.setattr(
+            "zotero_mcp.tools.read_pdf._get_pdf_path",
+            lambda _k, _c: None,
+        )
+
+        result = server.read_pdf_pages(item_key="ITEM01", start_page=1, ctx=dummy_ctx)
+
+        assert "No PDF attachment found" in result
+
+    def test_start_page_out_of_range(self, monkeypatch, dummy_ctx, fake_zot):
+        _patch_fitz(monkeypatch, [FakePage("p1")], total=1)
+        monkeypatch.setattr(
+            "zotero_mcp.tools.read_pdf._get_pdf_path",
+            lambda _k, _c: ("/tmp/test.pdf", "Paper"),
+        )
+
+        result = server.read_pdf_pages(item_key="ITEM01", start_page=5, ctx=dummy_ctx)
+
+        assert "out of range" in result
+        assert "1-1" in result
+
+    def test_end_page_out_of_range(self, monkeypatch, dummy_ctx, fake_zot):
+        _patch_fitz(monkeypatch, [FakePage("p1")] * 3, total=3)
+        monkeypatch.setattr(
+            "zotero_mcp.tools.read_pdf._get_pdf_path",
+            lambda _k, _c: ("/tmp/test.pdf", "Paper"),
+        )
+
+        result = server.read_pdf_pages(item_key="ITEM01", start_page=1, end_page=10, ctx=dummy_ctx)
+
+        assert "out of range" in result
+        assert "1-3" in result
+
+    def test_too_many_pages(self, monkeypatch, dummy_ctx, fake_zot):
+        _patch_fitz(monkeypatch, [FakePage("p")] * 100, total=100)
+        monkeypatch.setattr(
+            "zotero_mcp.tools.read_pdf._get_pdf_path",
+            lambda _k, _c: ("/tmp/test.pdf", "Paper"),
+        )
+
+        result = server.read_pdf_pages(item_key="ITEM01", start_page=1, end_page=55, ctx=dummy_ctx)
+
+        assert "max 50" in result
+
+    def test_missing_fitz_module(self, monkeypatch, dummy_ctx, fake_zot):
+        monkeypatch.setattr(
+            "zotero_mcp.tools.read_pdf._get_pdf_path",
+            lambda _k, _c: ("/tmp/test.pdf", "Paper"),
+        )
+        monkeypatch.setitem(sys.modules, "fitz", None)
+
+        result = server.read_pdf_pages(item_key="ITEM01", start_page=1, ctx=dummy_ctx)
+
+        assert "PyMuPDF" in result
+
+
+class TestEdgeCases:
+    """Edge case behaviors."""
+
+    def test_end_page_equals_start_page(self, monkeypatch, dummy_ctx, fake_zot):
+        """When end_page == start_page, should behave like single page."""
+        _patch_fitz(monkeypatch, [FakePage("p1"), FakePage("p2"), FakePage("p3")])
+        monkeypatch.setattr(
+            "zotero_mcp.tools.read_pdf._get_pdf_path",
+            lambda _k, _c: ("/tmp/test.pdf", "Test Paper"),
+        )
+
+        result = server.read_pdf_pages(item_key="ITEM01", start_page=2, end_page=2, ctx=dummy_ctx)
+
+        assert "## Page 2" in result
+        assert "## Page 1" not in result
+        assert "## Page 3" not in result
+
+    def test_reads_last_page(self, monkeypatch, dummy_ctx, fake_zot):
+        _patch_fitz(monkeypatch, [FakePage("first"), FakePage("last")])
+        monkeypatch.setattr(
+            "zotero_mcp.tools.read_pdf._get_pdf_path",
+            lambda _k, _c: ("/tmp/test.pdf", "Paper"),
+        )
+
+        result = server.read_pdf_pages(item_key="ITEM01", start_page=2, ctx=dummy_ctx)
+
+        assert "## Page 2" in result
+        assert "last" in result
+
+    def test_empty_page_text(self, monkeypatch, dummy_ctx, fake_zot):
+        _patch_fitz(monkeypatch, [FakePage(""), FakePage("has text"), FakePage("")])
+        monkeypatch.setattr(
+            "zotero_mcp.tools.read_pdf._get_pdf_path",
+            lambda _k, _c: ("/tmp/test.pdf", "Paper"),
+        )
+
+        result = server.read_pdf_pages(item_key="ITEM01", start_page=1, end_page=3, ctx=dummy_ctx)
+
+        assert "[No extractable text on this page]" in result
+        assert "has text" in result


### PR DESCRIPTION
## Summary
Adds `zotero_read_pdf_pages` tool for reading specific page ranges from PDF attachments, designed to work after `zotero_get_pdf_outline` identifies sections of interest. Avoids extracting entire papers when only a few pages are needed.

## Changes
- add `zotero_read_pdf_pages` tool in `src/zotero_mcp/tools/read_pdf.py`
- tries local storage first (LocalZoteroReader), falls back to API download
- uses PyMuPDF (fitz) — covered by existing `[pdf]` extra
- max 50 pages per call to prevent token overload
- register in `tools/__init__.py` and re-export in `server.py`
- add 14 unit tests covering happy path, validation errors, edge cases
- add CHANGELOG entry

## Verification
`uv run pytest tests/test_read_pdf.py tests/test_pdf_outline.py -q`
Result: `14 passed` (read_pdf) + `7 passed` (pdf_outline)

## Use Case: Read specific document sections without semantic search or fulltext

<img width="1082" height="1389" alt="image" src="https://github.com/user-attachments/assets/c9b4d397-4909-4882-b784-1ad3fe154f41" />

