### PR TITLE
Add CrossRef polite-pool support via ZOTERO_MCP_CONTACT_EMAIL

### DIFF
--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -409,10 +409,17 @@ def add_by_doi(
 
         ctx.info(f"Fetching metadata for DOI: {normalized}")
 
+        # CrossRef "polite pool": identifying via mailto gives higher rate limits
+        # and priority routing. See https://api.crossref.org/swagger-ui/index.html
+        crossref_url = f"https://api.crossref.org/works/{normalized}"
+        contact_email = os.environ.get("ZOTERO_MCP_CONTACT_EMAIL", "").strip()
+        if contact_email:
+            crossref_url += f"?mailto={contact_email}"
+
         resp = requests.get(
-            f"https://api.crossref.org/works/{normalized}",
+            crossref_url,
             headers={
-                "User-Agent": "zotero-mcp/1.0 (https://github.com/ehawkin/zotero-mcp)",
+                "User-Agent": "zotero-mcp/1.0 (https://github.com/54yyyu/zotero-mcp)",
                 "Accept": "application/json",
             },
             timeout=15,


### PR DESCRIPTION
# Add CrossRef polite-pool support via `ZOTERO_MCP_CONTACT_EMAIL`

## Summary

`add_by_doi` calls the CrossRef API anonymously, which routes the request through CrossRef's shared "public pool". That pool is heavily rate-limited and routinely returns HTTP 429 when the server is under load — even for low-volume callers.

CrossRef offers a free **polite pool** with higher limits and priority routing to clients that identify themselves with a contact email. The identification is opt-in via a `mailto` query parameter ([docs](https://api.crossref.org/swagger-ui/index.html)).

This PR makes `add_by_doi` honor an optional `ZOTERO_MCP_CONTACT_EMAIL` environment variable. When set, the email is appended as `?mailto=...` and the request goes to the polite pool. When unset, behavior is unchanged.

Also fixes a stale repo URL in the `User-Agent` header (`ehawkin/zotero-mcp` → `54yyyu/zotero-mcp`).

## Why an env var (not a hardcoded address)

CrossRef's guidance is that each *operator* identifies themselves, not each *project*. Hardcoding the maintainer's email would route every user's traffic under one address and could get that address throttled or contacted. An env var lets each deployer supply their own.

## Backwards compatibility

Fully backwards compatible:
- If `ZOTERO_MCP_CONTACT_EMAIL` is unset or empty, the URL is identical to before.
- No new dependencies.

## Documentation

Suggest adding to the README's configuration section:

> `ZOTERO_MCP_CONTACT_EMAIL` *(optional)* — your contact email. When set, CrossRef requests are sent through the [polite pool](https://api.crossref.org/swagger-ui/index.html) for higher rate limits. Recommended for any production deployment.

## Test plan

- [x] Unset env var: request URL is `https://api.crossref.org/works/<doi>` (unchanged).
- [x] Env var set: request URL is `https://api.crossref.org/works/<doi>?mailto=<email>`.
- [x] Env var set to empty string: treated as unset (no mailto appended).
