### PR TITLE
fix(annotations): normalize library_type to plural for group write paths (#272)

### DIFF
--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -11,7 +11,6 @@ import requests
 from zotero_mcp import client as _client
 from zotero_mcp import utils as _utils
 
-
 # ---------------------------------------------------------------------------
 # Config file
 # ---------------------------------------------------------------------------
@@ -87,6 +86,23 @@ CROSSREF_TYPE_MAP = {
 # Write-operation helpers
 # ---------------------------------------------------------------------------
 
+def apply_library_override(zot, override: dict | None) -> None:
+    """Apply an active-library override to *zot* in place.
+
+    pyzotero uses ``library_type`` as a URL path segment and expects the
+    plural form (``users`` / ``groups``), but the runtime override stores
+    the singular form (``user`` / ``group``) as used by Zotero's switch-
+    library tool. Without the normalization below, writes against a group
+    library hit ``/group/{id}/items`` and 404.
+    """
+    if not override:
+        return
+    zot.library_id = override.get("library_id", zot.library_id)
+    raw_type = override.get("library_type")
+    if raw_type:
+        zot.library_type = raw_type if raw_type.endswith("s") else raw_type + "s"
+
+
 def _get_write_client(ctx):
     """Return (read_client, write_client) for hybrid-mode operations.
 
@@ -99,15 +115,7 @@ def _get_write_client(ctx):
         return read_zot, read_zot
     web_zot = _client.get_web_zotero_client()
     if web_zot is not None:
-        override = _client.get_active_library()
-        if override:
-            web_zot.library_id = override.get("library_id", web_zot.library_id)
-            # pyzotero stores library_type with trailing "s" (e.g. "users", "groups")
-            # but the override stores the raw value (e.g. "user", "group"),
-            # so we must append "s" to match pyzotero's internal convention.
-            raw_type = override.get("library_type")
-            if raw_type:
-                web_zot.library_type = raw_type if raw_type.endswith("s") else raw_type + "s"
+        apply_library_override(web_zot, _client.get_active_library())
         return read_zot, web_zot
     raise ValueError(
         "Cannot perform write operations in local-only mode. "

--- a/src/zotero_mcp/tools/annotations.py
+++ b/src/zotero_mcp/tools/annotations.py
@@ -69,10 +69,7 @@ def _get_note_write_client(op_description: str):
                 "Please configure the following environment variables:\n"
                 + _WEB_API_ENV_VARS
             )
-        override = _client.get_active_library()
-        if override:
-            zot.library_id = override.get("library_id", zot.library_id)
-            zot.library_type = override.get("library_type", zot.library_type)
+        _helpers.apply_library_override(zot, _client.get_active_library())
     else:
         zot = _client.get_zotero_client()
     return zot, None
@@ -999,10 +996,7 @@ def create_note(
             web_zot = _client.get_web_zotero_client()
             if web_zot is not None:
                 # Propagate library override if user switched libraries
-                override = _client.get_active_library()
-                if override:
-                    web_zot.library_id = override.get("library_id", web_zot.library_id)
-                    web_zot.library_type = override.get("library_type", web_zot.library_type)
+                _helpers.apply_library_override(web_zot, _client.get_active_library())
                 result = web_zot.create_items([note_data])
                 if "success" in result and result["success"]:
                     successful = result["success"]
@@ -1272,10 +1266,7 @@ def create_annotation(
 
         # Propagate library override if user switched libraries
         if web_client:
-            override = _client.get_active_library()
-            if override:
-                web_client.library_id = override.get("library_id", web_client.library_id)
-                web_client.library_type = override.get("library_type", web_client.library_type)
+            _helpers.apply_library_override(web_client, _client.get_active_library())
 
         # REQUIREMENT: Web API is required for creating annotations
         # Zotero's local API (port 23119) is read-only
@@ -1573,10 +1564,7 @@ def create_area_annotation(
         web_client = _client.get_web_zotero_client()
 
         if web_client:
-            override = _client.get_active_library()
-            if override:
-                web_client.library_id = override.get("library_id", web_client.library_id)
-                web_client.library_type = override.get("library_type", web_client.library_type)
+            _helpers.apply_library_override(web_client, _client.get_active_library())
 
         if not web_client:
             return (

--- a/tests/test_group_library_url.py
+++ b/tests/test_group_library_url.py
@@ -1,0 +1,124 @@
+"""Regression tests for #272: group-library URL normalization.
+
+Verifies that write-path code does not leak the singular ``group`` form of
+``library_type`` into pyzotero clients, which builds ``/group/{id}/...`` URLs
+that 404 against the Zotero Web API (which expects ``/groups/{id}/...``).
+"""
+
+import pytest
+
+from zotero_mcp import server
+from zotero_mcp.tools import _helpers
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeClient:
+    def __init__(self, library_id="0", library_type="users"):
+        self.library_id = library_id
+        self.library_type = library_type
+
+
+class TestApplyLibraryOverride:
+    def test_no_override_is_noop(self):
+        zot = _FakeClient(library_id="1", library_type="users")
+        _helpers.apply_library_override(zot, None)
+        assert zot.library_id == "1"
+        assert zot.library_type == "users"
+
+    def test_empty_override_is_noop(self):
+        zot = _FakeClient(library_id="1", library_type="users")
+        _helpers.apply_library_override(zot, {})
+        assert zot.library_id == "1"
+        assert zot.library_type == "users"
+
+    def test_group_singular_is_normalized_to_plural(self):
+        zot = _FakeClient()
+        _helpers.apply_library_override(zot, {"library_id": "5910265", "library_type": "group"})
+        assert zot.library_id == "5910265"
+        assert zot.library_type == "groups"
+
+    def test_user_singular_is_normalized_to_plural(self):
+        zot = _FakeClient()
+        _helpers.apply_library_override(zot, {"library_id": "99", "library_type": "user"})
+        assert zot.library_type == "users"
+
+    def test_already_plural_is_unchanged(self):
+        zot = _FakeClient()
+        _helpers.apply_library_override(zot, {"library_id": "99", "library_type": "groups"})
+        assert zot.library_type == "groups"
+
+    def test_library_id_only_keeps_existing_library_type(self):
+        zot = _FakeClient(library_type="users")
+        _helpers.apply_library_override(zot, {"library_id": "42"})
+        assert zot.library_id == "42"
+        assert zot.library_type == "users"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: confirm switch_library + create_note routes to /groups/...
+# ---------------------------------------------------------------------------
+
+
+class DummyContext:
+    def info(self, *_args, **_kwargs):
+        return None
+
+    def error(self, *_args, **_kwargs):
+        return None
+
+    def warning(self, *_args, **_kwargs):
+        return None
+
+
+class FakeGroupZotero:
+    """Captures library_type when create_items is invoked."""
+
+    def __init__(self):
+        self.library_id = "0"
+        self.library_type = "users"
+        self.create_calls = []
+
+    def item(self, _item_key):
+        return {"data": {"title": "Parent Item"}}
+
+    def create_items(self, items):
+        self.create_calls.append({"library_id": self.library_id, "library_type": self.library_type})
+        return {"success": {"0": "NOTEKEY01"}}
+
+
+@pytest.fixture
+def force_local_mode(monkeypatch):
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: True)
+    monkeypatch.setattr("zotero_mcp.tools.annotations._utils.is_local_mode", lambda: True)
+
+
+def test_create_note_against_group_uses_plural_url(monkeypatch, force_local_mode):
+    """Switching to a group library must route create_note via /groups/{id}/items."""
+    from zotero_mcp import client as zclient
+
+    fake = FakeGroupZotero()
+    monkeypatch.setattr(zclient, "get_zotero_client", lambda: fake)
+    monkeypatch.setattr(zclient, "get_web_zotero_client", lambda: fake)
+
+    # Simulate the runtime override left by zotero_switch_library(..., "group").
+    zclient.set_active_library(library_id="5910265", library_type="group")
+    try:
+        result = server.create_note(
+            item_key="ITEM0001",
+            note_title="t",
+            note_text="body",
+            ctx=DummyContext(),
+        )
+    finally:
+        zclient.clear_active_library()
+
+    assert "Successfully created note" in result, result
+    assert fake.create_calls, "create_items was not called"
+    call = fake.create_calls[0]
+    assert call["library_id"] == "5910265"
+    assert call["library_type"] == "groups", (
+        f"library_type must be normalized to plural before the POST (got {call['library_type']!r}); see issue #272"
+    )


### PR DESCRIPTION
## Summary

In hybrid/local mode, `zotero_switch_library(library_type="group")` stores `"group"` (singular) in the active-library override. Four note/annotation write paths in `tools/annotations.py` then copied that raw value straight onto `pyzotero.library_type` — which pyzotero embeds as a URL path segment — so the resulting POST hit `/group/{id}/items` (singular) instead of `/groups/{id}/items` (plural) and returned **404 Not Found**.

This broke against any group library:
- `zotero_create_note`
- `zotero_create_annotation`
- `zotero_create_area_annotation`
- `zotero_update_note`, `zotero_delete_note`
- `zotero_update_annotation`, `zotero_delete_annotation`

The trailing-`s` normalization already lived in `_helpers._get_write_client`, which is why `zotero_update_item`, `zotero_create_collection`, `zotero_manage_collections`, and `zotero_add_by_url` worked fine on the same group library (this is exactly what issue #272 reports).

## Fix

Extract the existing comment + normalization into `_helpers.apply_library_override(zot, override)` and route every single override-applying site through it.

| Site (before) | After |
|---|---|
| `tools/_helpers.py:_get_write_client` (already correct, inlined) | calls helper |
| `tools/annotations.py:_get_note_write_client` (L75) | calls helper |
| `tools/annotations.py:create_note` (L1005) | calls helper |
| `tools/annotations.py:create_annotation` (L1278) | calls helper |
| `tools/annotations.py:create_area_annotation` (L1579) | calls helper |

This is the same diagnosis another commenter posted on the issue thread. No behavior change for user libraries or for already-plural inputs.

## Test plan

- [x] `tests/test_group_library_url.py` — new file. 7 cases: helper unit tests for `apply_library_override` (singular/plural/empty/none) plus an end-to-end `test_create_note_against_group_uses_plural_url` that switches to a group library and asserts the POST receives `library_type="groups"`.
- [x] Existing `tests/test_server_create_note.py`, `tests/test_server_annotation_crud.py`, `tests/test_server_get_annotations.py` still pass (regression check).

To repro the original bug pre-fix: switch to any group library and call `zotero_create_note(item_key="<any item>", ...)` — fails with `Code: 404 / URL: https://api.zotero.org/group/{id}/items / Method: POST`. After this patch the same call succeeds and the POST goes to `/groups/{id}/items`.

Fixes #272.