### PR TITLE
fix(write): reconcile collection membership post-create in add_by_doi (#235)

### DIFF
--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -11,7 +11,6 @@ import requests
 from zotero_mcp import client as _client
 from zotero_mcp import utils as _utils
 
-
 # ---------------------------------------------------------------------------
 # Config file
 # ---------------------------------------------------------------------------
@@ -125,6 +124,38 @@ def _handle_write_response(response, ctx=None):
     if isinstance(response, dict):
         return bool(response.get("success"))
     return bool(response)
+
+
+def ensure_collection_membership(write_zot, item_key: str, coll_keys: list[str], ctx=None) -> list[str]:
+    """Force *item_key* into each collection in *coll_keys*; return keys we couldn't file.
+
+    Setting ``item["collections"]`` on ``create_items`` is supposed to atomically
+    file the new item, but reports show it intermittently no-ops — the item
+    lands in My Library root despite the request (#235). This is the
+    deterministic backstop: read the item back, diff against the requested
+    set, and ``addto_collection`` for any that didn't take.
+    """
+    if not coll_keys:
+        return []
+    try:
+        item = write_zot.item(item_key)
+    except Exception as e:
+        if ctx is not None:
+            ctx.warning(f"Could not re-fetch item {item_key} to verify collection membership: {e}")
+        return list(coll_keys)
+    actual = set(item.get("data", {}).get("collections") or [])
+    failed: list[str] = []
+    for coll_key in coll_keys:
+        if coll_key in actual:
+            continue
+        try:
+            write_zot.addto_collection(coll_key, item)
+            actual.add(coll_key)
+        except Exception as e:
+            failed.append(coll_key)
+            if ctx is not None:
+                ctx.warning(f"Could not file {item_key} in collection {coll_key}: {e}")
+    return failed
 
 
 # ---------------------------------------------------------------------------

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1,23 +1,22 @@
 """Write / mutation tool functions for the Zotero MCP server."""
 
-from typing import Annotated, Literal
 import json
 import os
 import re
 import tempfile
-import xml.etree.ElementTree as ET
-
 import time as _time
+import xml.etree.ElementTree as ET
+from typing import Annotated, Literal
 
 import requests
 from pydantic import Field
 
-from zotero_mcp._context import Context
-from zotero_mcp._app import mcp
-from zotero_mcp import client as _client
-from zotero_mcp.client import with_zotero_api_lock
-from zotero_mcp import utils as _utils
 from zotero_mcp import citation_import as _citation_import
+from zotero_mcp import client as _client
+from zotero_mcp import utils as _utils
+from zotero_mcp._app import mcp
+from zotero_mcp._context import Context
+from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp.tools import _helpers
 
 # Accessed as _helpers.X so that monkeypatch/mock on the module attribute works.
@@ -644,6 +643,22 @@ def add_by_doi(
             item_key = next(iter(result["success"].values()))
             title = item_data.get("title", normalized)
 
+            # Defensive: pyzotero's atomic ``item["collections"]`` filing is
+            # intermittent (#235) — reconcile membership before reporting success
+            # so the caller sees the real routing state.
+            missing = _helpers.ensure_collection_membership(
+                write_zot, item_key, coll_keys, ctx=ctx
+            )
+            if coll_keys and missing:
+                collections_status = (
+                    f"Filed in {sorted(set(coll_keys) - set(missing))}; "
+                    f"FAILED to file in {missing}"
+                )
+            elif coll_keys:
+                collections_status = f"Filed in {coll_keys}"
+            else:
+                collections_status = "My Library (no collection)"
+
             # Attempt open-access PDF attachment (pass CrossRef metadata for arXiv fallback)
             pdf_status = _helpers._try_attach_oa_pdf(write_zot, item_key, normalized, ctx,
                                             crossref_metadata=cr,
@@ -654,6 +669,7 @@ def add_by_doi(
                 f"Item key: `{item_key}`\n"
                 f"Type: {zot_type}\n"
                 f"DOI: {normalized}\n"
+                f"Collections: {collections_status}\n"
                 f"PDF: {pdf_status}\n\n"
                 "_Note: To include this item in semantic search, run "
                 "zotero_update_search_database._"
@@ -1368,7 +1384,7 @@ def update_item(
                 + "\n".join(changes)
             )
             return result + skip_warning
-        return f"Failed to update item: write operation returned failure"
+        return "Failed to update item: write operation returned failure"
 
     except ValueError as e:
         return f"Input error: {e}"
@@ -2124,13 +2140,13 @@ def add_item_relation(
         # Fetch the primary item
         try:
             item = write_zot.item(item_key)
-        except Exception as e:
+        except Exception:
             return f"Error: Item '{item_key}' not found."
 
         # Verify the related item exists
         try:
             related_item = write_zot.item(related_item_key)
-        except Exception as e:
+        except Exception:
             return f"Error: Related item '{related_item_key}' not found."
 
         data = item.get("data", {})
@@ -2239,7 +2255,7 @@ def remove_item_relation(
         # Fetch the primary item
         try:
             item = write_zot.item(item_key)
-        except Exception as e:
+        except Exception:
             return f"Error: Item '{item_key}' not found."
 
         data = item.get("data", {})

--- a/tests/test_collections_backstop.py
+++ b/tests/test_collections_backstop.py
@@ -1,0 +1,171 @@
+"""Regression tests for #235: collections parameter routing on zotero_add_by_doi.
+
+The reported symptom (silent failure when ``collections="KEY"``) is not a
+normalization bug — ``_normalize_str_list_input`` already handles the string
+form — but a routing bug downstream: pyzotero's atomic ``item["collections"]``
+filing on ``create_items`` intermittently no-ops, leaving the new item in
+My Library instead of the requested collection.
+
+The fix is a deterministic backstop: after create, read the item back, diff
+the actual collection membership against the requested set, and explicitly
+``addto_collection`` for any that didn't take.
+"""
+
+from unittest.mock import MagicMock
+
+from conftest import DummyContext, FakeZotero, _FakeResponse
+
+from zotero_mcp import server
+from zotero_mcp.tools import _helpers
+
+
+def _make_crossref_response():
+    msg = {
+        "type": "journal-article",
+        "title": ["Some Paper"],
+        "DOI": "10.1234/test",
+        "author": [{"given": "A", "family": "Author"}],
+    }
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"status": "ok", "message": msg}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class _RecordingZotero(FakeZotero):
+    """FakeZotero that records addto_collection calls and lets the test
+    decide whether pyzotero's atomic filing 'worked' on create_items.
+    """
+
+    def __init__(self, atomic_filing_works: bool = True):
+        super().__init__()
+        self._atomic = atomic_filing_works
+        self.addto_calls: list[tuple[str, str]] = []
+        self._created_items: dict[str, dict] = {}
+
+    def create_items(self, items, **kwargs):
+        self.created.extend(items)
+        result = {}
+        for i, item in enumerate(items):
+            key = f"KEY{i:04d}"
+            result[str(i)] = key
+            # Stash the created item so item(key) can read it back.
+            stored_collections = (
+                list(item.get("collections") or []) if self._atomic else []
+            )
+            self._created_items[key] = {
+                "key": key,
+                "version": 1,
+                "data": {**item, "key": key, "collections": stored_collections},
+            }
+        return {"success": result, "successful": {}, "failed": {}}
+
+    def item(self, item_key):
+        if item_key in self._created_items:
+            return self._created_items[item_key]
+        return super().item(item_key)
+
+    def addto_collection(self, collection_key, item, **kwargs):
+        key = item["key"] if isinstance(item, dict) else item
+        self.addto_calls.append((collection_key, key))
+        # Update the stored item so subsequent reads see the new membership.
+        stored = self._created_items.get(key)
+        if stored:
+            cols = stored["data"].setdefault("collections", [])
+            if collection_key not in cols:
+                cols.append(collection_key)
+        return _FakeResponse(204)
+
+
+# ---------------------------------------------------------------------------
+# ensure_collection_membership helper
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureCollectionMembership:
+    def test_empty_keys_is_noop(self):
+        z = _RecordingZotero()
+        assert _helpers.ensure_collection_membership(z, "X", []) == []
+        assert z.addto_calls == []
+
+    def test_when_atomic_filing_worked_no_addto_called(self, monkeypatch):
+        z = _RecordingZotero(atomic_filing_works=True)
+        z.create_items([{"itemType": "journalArticle", "collections": ["A75DWWBH"]}])
+        failed = _helpers.ensure_collection_membership(z, "KEY0000", ["A75DWWBH"])
+        assert failed == []
+        assert z.addto_calls == []  # nothing to do
+
+    def test_when_atomic_filing_failed_addto_is_called(self):
+        z = _RecordingZotero(atomic_filing_works=False)
+        z.create_items([{"itemType": "journalArticle", "collections": ["A75DWWBH"]}])
+        failed = _helpers.ensure_collection_membership(z, "KEY0000", ["A75DWWBH"])
+        assert failed == []
+        assert z.addto_calls == [("A75DWWBH", "KEY0000")]
+
+    def test_partial_membership_only_files_missing(self):
+        z = _RecordingZotero(atomic_filing_works=False)
+        z.create_items([{"itemType": "journalArticle", "collections": ["A75DWWBH"]}])
+        # Pre-seed one membership so only the second key needs addto.
+        z._created_items["KEY0000"]["data"]["collections"] = ["A75DWWBH"]
+        failed = _helpers.ensure_collection_membership(
+            z, "KEY0000", ["A75DWWBH", "BBBBBBBB"]
+        )
+        assert failed == []
+        assert z.addto_calls == [("BBBBBBBB", "KEY0000")]
+
+
+# ---------------------------------------------------------------------------
+# add_by_doi end-to-end
+# ---------------------------------------------------------------------------
+
+
+def _patch_write_client(monkeypatch, zot):
+    monkeypatch.setattr(
+        "zotero_mcp.tools._helpers._get_write_client", lambda ctx: (zot, zot)
+    )
+    monkeypatch.setattr("requests.get", lambda *a, **kw: _make_crossref_response())
+    # Bypass the OA-PDF lookup (it would hit Unpaywall / Semantic Scholar over the network).
+    monkeypatch.setattr(
+        "zotero_mcp.tools._helpers._try_attach_oa_pdf",
+        lambda *a, **kw: "skipped (test)",
+    )
+
+
+def test_add_by_doi_string_collection_routes_correctly(monkeypatch):
+    """The bare-string ``collections="KEY"`` form must produce the same routing
+    as the array form (#235)."""
+    z = _RecordingZotero(atomic_filing_works=True)
+    _patch_write_client(monkeypatch, z)
+
+    result = server.add_by_doi(
+        doi="10.1234/test", collections="A75DWWBH", ctx=DummyContext()
+    )
+
+    item = z.created[0]
+    assert item["collections"] == ["A75DWWBH"]
+    assert "Filed in ['A75DWWBH']" in result
+
+
+def test_add_by_doi_string_collection_with_atomic_failure_backstops(monkeypatch):
+    """If pyzotero's atomic filing on ``create_items`` no-ops, the backstop
+    must explicitly ``addto_collection`` so the item still lands correctly."""
+    z = _RecordingZotero(atomic_filing_works=False)
+    _patch_write_client(monkeypatch, z)
+
+    result = server.add_by_doi(
+        doi="10.1234/test", collections="A75DWWBH", ctx=DummyContext()
+    )
+
+    assert z.addto_calls == [("A75DWWBH", "KEY0000")]
+    assert "Filed in ['A75DWWBH']" in result
+
+
+def test_add_by_doi_no_collections_reports_my_library(monkeypatch):
+    z = _RecordingZotero()
+    _patch_write_client(monkeypatch, z)
+
+    result = server.add_by_doi(doi="10.1234/test", ctx=DummyContext())
+
+    assert z.addto_calls == []
+    assert "My Library (no collection)" in result


### PR DESCRIPTION
## Summary

#235 reports that ``collections="KEY"`` (the bare-string form) on ``zotero_add_by_doi`` silently routes items to My Library instead of the requested collection — inconsistently, even within the same session.

Investigation: the string-vs-array shape is a red herring. ``_normalize_str_list_input`` already wraps a bare string into a single-element list before reaching pyzotero, so both forms produce identical ``item["collections"] = ["KEY"]`` payloads. The actual failure mode is that pyzotero's *atomic* filing via that field on ``create_items`` intermittently no-ops — Zotero accepts the item but doesn't apply the collection membership. The success response masks the discrepancy.

## Fix

New helper in [tools/_helpers.py](src/zotero_mcp/tools/_helpers.py):

```python
def ensure_collection_membership(write_zot, item_key, coll_keys, ctx=None) -> list[str]:
    """Force item_key into each coll_key; return any that couldn't be filed."""
```

After a successful ``create_items``, it reads the item back, diffs the actual ``data.collections`` against the requested set, and ``addto_collection`` for any that didn't take. Idempotent — if pyzotero's atomic filing did work, no extra API calls fire.

``add_by_doi`` now calls this immediately after create, and the response includes a new ``Collections:`` line so the caller can see the actual routing state without a follow-up search.

Before:
```
Successfully added: **Title**
Item key: `ABCD1234`
PDF: …
```

After:
```
Successfully added: **Title**
Item key: `ABCD1234`
Collections: Filed in ['A75DWWBH']           ← or "My Library (no collection)"
PDF: …                                       ← or "Filed in [...]; FAILED to file in [...]"
```

## Scope

This PR fixes ``add_by_doi`` only. The same backstop should apply to ``add_by_url``, ``add_by_isbn``, ``add_by_bibtex``, ``add_by_csl_json``, ``add_from_file`` — happy to do those as follow-up PRs (the helper is shared and the call site is one-line per function).

## Test plan

- [x] ``tests/test_collections_backstop.py`` — 7 new cases. Helper unit tests cover the no-op / atomic-worked / atomic-failed / partial-membership branches. End-to-end ``add_by_doi`` tests cover (a) the string-form routes correctly when atomic filing works, (b) the backstop kicks in when atomic filing fails, and (c) the response says "My Library" when no collection was requested.
- [x] All 51 existing ``tests/test_add_by_doi.py`` tests still pass.

Fixes #235.