### PR TITLE
fix(write): make zotero_update_item.collections REPLACE membership (#231)

### DIFF
--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1132,7 +1132,8 @@ _UPDATE_ITEM_API_TO_PARAM = {
         "three are mutually exclusive — prefer `add_tags`/`remove_tags` "
         "for incremental edits. "
         "Similarly, collections/collection_names REPLACE the item's "
-        "collection memberships; for incremental moves use "
+        "collection memberships (pass collections=[] to clear all "
+        "memberships); for incremental moves use "
         "zotero_manage_collections instead. "
         "item_key: 8-character Zotero item key of the item to update. "
         "Editable fields include: title, creators, date, publisher, place, "
@@ -1335,20 +1336,35 @@ def update_item(
                 changes.append(f"- **tags**: removed {list(to_remove)}")
             data["tags"] = [{"tag": t} for t in sorted(existing)]
 
-        # Collections — both params ADD to existing collections (never replace)
-        if collections is not None:
-            coll_keys = _helpers._normalize_str_list_input(collections, "collections")
-            existing_colls = set(data.get("collections", []))
-            existing_colls.update(coll_keys)
-            data["collections"] = list(existing_colls)
-            changes.append(f"- **collections**: added {coll_keys}")
-        if collection_names is not None:
-            names = _helpers._normalize_str_list_input(collection_names, "collection_names")
-            resolved = _helpers._resolve_collection_names(read_zot, names, ctx=ctx)
-            existing_colls = set(data.get("collections", []))
-            existing_colls.update(resolved)
-            data["collections"] = list(existing_colls)
-            changes.append(f"- **collections**: added {resolved}")
+        # Collections — REPLACE membership (matches tags semantics and the
+        # docstring contract). For incremental moves use
+        # zotero_manage_collections. Passing collections=[] clears all
+        # memberships. ``collections`` and ``collection_names`` may both be
+        # supplied; the union of their resolved keys is the new membership.
+        if collections is not None or collection_names is not None:
+            new_collections: list[str] = []
+            if collections is not None:
+                new_collections.extend(
+                    _helpers._normalize_str_list_input(collections, "collections")
+                )
+            if collection_names is not None:
+                names = _helpers._normalize_str_list_input(
+                    collection_names, "collection_names"
+                )
+                new_collections.extend(
+                    _helpers._resolve_collection_names(read_zot, names, ctx=ctx)
+                )
+            # Preserve order while deduplicating.
+            seen: set[str] = set()
+            deduped = [
+                k for k in new_collections if not (k in seen or seen.add(k))
+            ]
+            old_collections = list(data.get("collections") or [])
+            if old_collections != deduped:
+                data["collections"] = deduped
+                changes.append(
+                    f"- **collections**: replaced {old_collections} -> {deduped}"
+                )
 
         skip_warning = ""
         if skipped:

--- a/tests/test_update_item.py
+++ b/tests/test_update_item.py
@@ -321,8 +321,13 @@ class TestUpdateItemTags:
 
 class TestUpdateItemCollections:
 
-    def test_collection_names_resolved(self, monkeypatch):
-        """collection_names should resolve names to keys and add them."""
+    def test_collection_names_resolved_replaces_membership(self, monkeypatch):
+        """collection_names should resolve to keys and REPLACE membership (#231).
+
+        Previously this parameter was additive; that contradicted both the
+        docstring ("REPLACE collection memberships") and the tags semantics
+        on the same tool. Use zotero_manage_collections for incremental moves.
+        """
         item = _make_item(collections=["EXISTCOL"])
         fake = FakeZoteroForUpdate(
             items=[item],
@@ -341,9 +346,61 @@ class TestUpdateItemCollections:
         )
 
         updated_colls = fake.update_calls[0]["data"]["collections"]
-        # Should contain BOTH the existing collection and the resolved one
-        assert "EXISTCOL" in updated_colls
-        assert "COL001" in updated_colls
+        # Replaces the prior ["EXISTCOL"] with the resolved single-element set.
+        assert updated_colls == ["COL001"]
+
+    def test_collections_replace_clears_with_empty_list(self, monkeypatch):
+        """collections=[] should clear membership (#231 repro)."""
+        item = _make_item(collections=["EXISTCOL"])
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="ABCD1234",
+            collections=[],
+            ctx=DummyContext(),
+        )
+
+        assert fake.update_calls[0]["data"]["collections"] == []
+        assert "replaced ['EXISTCOL'] -> []" in result
+
+    def test_collections_keys_replace_membership(self, monkeypatch):
+        """collections=[KEY] should drop any prior memberships, not merge."""
+        item = _make_item(collections=["OLDCOLL1", "OLDCOLL2"])
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        server.update_item(
+            item_key="ABCD1234",
+            collections=["NEWCOLL1"],
+            ctx=DummyContext(),
+        )
+
+        assert fake.update_calls[0]["data"]["collections"] == ["NEWCOLL1"]
+
+    def test_collections_and_collection_names_union(self, monkeypatch):
+        """When both are passed, the new membership is the union of resolved keys."""
+        item = _make_item(collections=["OLD"])
+        fake = FakeZoteroForUpdate(
+            items=[item],
+            collections=[{"key": "COL001", "data": {"name": "My Papers"}}],
+        )
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        server.update_item(
+            item_key="ABCD1234",
+            collections=["KEY12345"],
+            collection_names=["My Papers"],
+            ctx=DummyContext(),
+        )
+
+        updated = fake.update_calls[0]["data"]["collections"]
+        assert set(updated) == {"KEY12345", "COL001"}
+        # OLD is gone — replace, not additive.
+        assert "OLD" not in updated
 
     def test_collection_names_unknown_raises_error(self, monkeypatch):
         """Unknown collection name should produce an error."""
@@ -616,8 +673,12 @@ class TestUpdateItemFieldVariants:
 
         assert fake.update_calls[0]["data"]["creators"] == new_creators
 
-    def test_collections_additive(self, monkeypatch):
-        """collections= adds to existing collections (does not replace)."""
+    def test_collections_replaces_membership(self, monkeypatch):
+        """collections= REPLACES the existing membership (#231).
+
+        For incremental moves the caller should use
+        zotero_manage_collections instead.
+        """
         item = _make_item(collections=["OLD_COL"])
         fake = FakeZoteroForUpdate(items=[item])
         monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
@@ -630,9 +691,8 @@ class TestUpdateItemFieldVariants:
         )
 
         updated_colls = fake.update_calls[0]["data"]["collections"]
-        assert "OLD_COL" in updated_colls  # existing collection preserved
-        assert "NEW_COL1" in updated_colls
-        assert "NEW_COL2" in updated_colls
+        assert updated_colls == ["NEW_COL1", "NEW_COL2"]
+        assert "OLD_COL" not in updated_colls
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The docstring on ``zotero_update_item`` advertises:

> collections / collection_names REPLACE collection memberships; for incremental moves use zotero_manage_collections instead.

and the tags semantics on the same tool follow that contract (``tags`` replaces, ``add_tags``/``remove_tags`` are incremental). But the implementation was additive — it unioned new keys into the existing membership rather than overwriting it. Consequences from #231:

- ``collections=[]`` was a silent no-op (couldn't clear membership at all).
- Calling ``zotero_update_item(item_key, collections=[\"NEW\"])`` on an item already in ``[\"OLD\"]`` left it in ``[\"OLD\", \"NEW\"]``, not ``[\"NEW\"]``.
- The response message said ``added [...]``, which contradicted the docstring's REPLACE claim.

## Fix

Make ``collections`` and ``collection_names`` truly replacive. The union of the resolved key sets becomes the new membership; ``[]`` clears all memberships. Use ``zotero_manage_collections`` for incremental moves (the docstring already directs callers there).

Response now reads ``collections: replaced ['OLD'] -> ['NEW']`` instead of the misleading ``added`` form.

Docstring tightened to call out the empty-array semantics explicitly.

## Test plan

- [x] ``tests/test_update_item.py`` — updated ``test_collections_additive`` → ``test_collections_replaces_membership`` (encoded the old wrong behavior; now encodes the documented contract). Updated ``test_collection_names_resolved`` to reflect replace semantics.
- [x] Added ``test_collections_replace_clears_with_empty_list`` (the literal repro from #231).
- [x] Added ``test_collections_keys_replace_membership`` and ``test_collections_and_collection_names_union``.
- [x] All 55 ``tests/test_update_item.py`` tests pass.

## Breaking change note

Callers relying on the previous additive behavior must migrate to ``zotero_manage_collections(item_keys=[k], add_to=[...])``, which has always been the documented path for incremental moves.

Fixes #231.