### PR TITLE
fix(client): pin HTTP/1.1 transport for Zotero local API to avoid 502 (#160)

### DIFF
--- a/src/zotero_mcp/client.py
+++ b/src/zotero_mcp/client.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import httpx
 from dotenv import load_dotenv
 from markitdown import MarkItDown
 from pyzotero import zotero
@@ -59,6 +60,21 @@ def clear_active_library() -> None:
 def get_active_library() -> dict[str, str]:
     """Return the current active library override (empty dict if using defaults)."""
     return dict(_active_library_override)
+
+
+def _make_local_http_client() -> httpx.Client:
+    """Return an httpx.Client pinned to HTTP/1.1 for the local Zotero server.
+
+    Zotero 8's local server (port 23119) only speaks HTTP/1.0. httpx defaults
+    to attempting HTTP/2 negotiation, which the local server rejects with 502
+    Bad Gateway — every tool call fails even though the MCP starts cleanly
+    (#160). Forcing http1=True / http2=False on the transport keeps requests
+    on HTTP/1.1 and the local API answers normally.
+    """
+    return httpx.Client(
+        transport=httpx.HTTPTransport(http1=True, http2=False),
+        follow_redirects=True,
+    )
 
 
 @dataclass
@@ -116,6 +132,7 @@ def get_zotero_client() -> zotero.Zotero:
         library_type=library_type,
         api_key=api_key,
         local=local,
+        client=_make_local_http_client() if local else None,
     )
 
 
@@ -131,12 +148,15 @@ def get_local_zotero_client() -> zotero.Zotero | None:
         A local Zotero client instance, or None if local Zotero is not available.
     """
     try:
-        # Create a local client - library_id 0 is the default for local
+        # Create a local client - library_id 0 is the default for local.
+        # HTTP/1.1-only transport for compatibility with Zotero 8's local
+        # server (#160) — httpx default HTTP/2 negotiation returns 502.
         client = zotero.Zotero(
             library_id="0",
             library_type="user",
             api_key=None,
             local=True,
+            client=_make_local_http_client(),
         )
         # Test connection by making a simple request
         client.items(limit=1)

--- a/tests/test_local_http1_transport.py
+++ b/tests/test_local_http1_transport.py
@@ -1,0 +1,93 @@
+"""Regression test for #160: force HTTP/1.1 for Zotero local API.
+
+Zotero 8's local server (port 23119) only speaks HTTP/1.0. httpx defaults
+to attempting HTTP/2 negotiation, which the local server rejects with
+**502 Bad Gateway** — every tool call fails even though the MCP starts
+cleanly. The fix pins the local pyzotero client's transport to HTTP/1.1.
+"""
+
+import httpx
+from pyzotero import zotero
+
+from zotero_mcp import client as zclient
+
+
+def test_make_local_http_client_pins_http1():
+    """The helper must return an httpx.Client whose transport is HTTP/1.1 only."""
+    c = zclient._make_local_http_client()
+    try:
+        assert isinstance(c, httpx.Client)
+        transport = c._transport
+        assert isinstance(transport, httpx.HTTPTransport)
+        # _pool is httpcore.ConnectionPool; http1/http2 are stored on it.
+        pool = transport._pool
+        assert pool._http1 is True
+        assert pool._http2 is False
+    finally:
+        c.close()
+
+
+def test_get_local_zotero_client_uses_http1_transport(monkeypatch):
+    """get_local_zotero_client must pass the HTTP/1.1 client to pyzotero."""
+    captured: dict = {}
+
+    real_init = zotero.Zotero.__init__
+
+    def spy_init(self, *args, **kwargs):
+        captured["kwargs"] = kwargs
+        # Make the constructor a no-op so we don't actually talk to Zotero.
+        # Set attributes pyzotero would normally populate (including .client,
+        # which pyzotero's __del__ references).
+        self.library_id = kwargs.get("library_id", "0")
+        self.library_type = kwargs.get("library_type", "users")
+        self.api_key = kwargs.get("api_key")
+        self.client = kwargs.get("client")
+
+    monkeypatch.setattr(zotero.Zotero, "__init__", spy_init)
+    # items() probe must not hit the network.
+    monkeypatch.setattr(zotero.Zotero, "items", lambda self, **_kw: [])
+
+    client = zclient.get_local_zotero_client()
+
+    assert client is not None
+    assert captured["kwargs"].get("local") is True
+    passed = captured["kwargs"].get("client")
+    assert isinstance(passed, httpx.Client)
+    assert isinstance(passed._transport, httpx.HTTPTransport)
+    assert passed._transport._pool._http2 is False
+
+    # Restore for hygiene.
+    monkeypatch.setattr(zotero.Zotero, "__init__", real_init)
+
+
+def test_get_zotero_client_uses_http1_only_when_local(monkeypatch):
+    """The general get_zotero_client should pass an HTTP/1.1 client only
+    when the underlying connection is local; the cloud Web API at
+    api.zotero.org speaks HTTP/2 fine, so no transport override is needed
+    in that case."""
+    captured: dict = {}
+
+    def spy_init(self, *args, **kwargs):
+        captured["kwargs"] = kwargs
+        self.library_id = kwargs.get("library_id", "0")
+        self.library_type = kwargs.get("library_type", "users")
+        self.api_key = kwargs.get("api_key")
+
+    monkeypatch.setattr(zotero.Zotero, "__init__", spy_init)
+    monkeypatch.setenv("ZOTERO_LOCAL", "true")
+    monkeypatch.setenv("ZOTERO_LIBRARY_ID", "0")
+    monkeypatch.delenv("ZOTERO_API_KEY", raising=False)
+
+    zclient.get_zotero_client()
+    local_client = captured["kwargs"].get("client")
+    assert isinstance(local_client, httpx.Client)
+    assert local_client._transport._pool._http2 is False
+
+    captured.clear()
+    monkeypatch.setenv("ZOTERO_LOCAL", "false")
+    monkeypatch.setenv("ZOTERO_API_KEY", "fake")
+
+    zclient.get_zotero_client()
+    assert captured["kwargs"].get("client") is None, (
+        "Cloud API path should not override the transport — only the local API needs HTTP/1.1."
+    )


### PR DESCRIPTION
## Summary

Zotero 8's local HTTP server (port 23119) only speaks HTTP/1.0. httpx — pyzotero's HTTP backend — defaults to attempting HTTP/2 negotiation, and the local server rejects that with **502 Bad Gateway**. The MCP starts and lists tools fine; every actual tool invocation 502s.

Direct repro from the issue:

\`\`\`bash
# curl works (HTTP/1.1)
curl -s -w "%{http_code}" "http://localhost:23119/api/users/0/items?q=test&limit=1&format=json"
# → 200

# httpx default (attempts HTTP/2) fails
python3 -c "import httpx; print(httpx.get('http://localhost:23119/api/users/0/items?limit=1&format=json').status_code)"
# → 502

# httpx pinned to HTTP/1.1 works
python3 -c "
import httpx
t = httpx.HTTPTransport(http1=True, http2=False)
print(httpx.Client(transport=t).get('http://localhost:23119/api/users/0/items?limit=1&format=json').status_code)
"
# → 200
\`\`\`

## Fix

[src/zotero_mcp/client.py](src/zotero_mcp/client.py): add a small helper that builds an \`httpx.Client(transport=httpx.HTTPTransport(http1=True, http2=False))\`. Pass that client to pyzotero in both \`get_zotero_client()\` (when \`local=True\`) and \`get_local_zotero_client()\`. \`get_web_zotero_client()\` is untouched — the cloud API supports HTTP/2.

This matches the issue's recommended fix #2 ("Apply the fix in zotero-mcp by passing a pre-configured httpx.Client to pyzotero"). Upstream pyzotero could also opt to default this when local=True, but doing it here unblocks Zotero 8 users today without waiting for a pyzotero release.

## Test plan

- [x] \`tests/test_local_http1_transport.py\` — 3 new tests. Helper returns a pinned-HTTP/1.1 client. \`get_local_zotero_client()\` passes that client through to pyzotero. \`get_zotero_client()\` passes the pinned client only when local, leaves the cloud path untouched.
- [x] \`tests/test_lifespan.py\` continues to pass.

Fixes #160. May also resolve part of #203, #264, #208 (other "502 with Zotero 8" reports).