### PR TITLE
fix(local_db): force UTF-8 on pdfminer subprocess for Windows (#286)

### DIFF
--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -5,16 +5,15 @@ Provides direct SQLite access to Zotero's local database for faster semantic sea
 when running in local mode.
 """
 
-import os
-import sqlite3
-import platform
 import logging
+import os
+import platform
+import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from dataclasses import dataclass
-from urllib.parse import urlparse, unquote
 
-from .utils import is_local_mode, _normalize_for_search
+from .utils import _normalize_for_search, is_local_mode
 
 logger = logging.getLogger(__name__)
 
@@ -231,7 +230,7 @@ class LocalZoteroReader:
 
         # Linked file as URL: 'file:///path/to/file.pdf'
         if zotero_path.startswith("file://"):
-            from urllib.parse import urlparse, unquote
+            from urllib.parse import unquote, urlparse
             parsed = urlparse(zotero_path)
             decoded_path = unquote(parsed.path or "")
             # file:///C:/... on Windows
@@ -311,11 +310,21 @@ class LocalZoteroReader:
         ):
             child_env.pop(_k, None)
 
+        # Force UTF-8 on the child's stdio. Without this, Windows consoles
+        # default to GBK/cp1252 and pdfminer extracting any non-ASCII text
+        # raises UnicodeEncodeError when ``sys.stdout.write`` flushes —
+        # turning a perfectly readable PDF into a "failed" extraction that
+        # the indexer then refuses to retry until force-rebuild (#286).
+        child_env.setdefault("PYTHONIOENCODING", "utf-8")
+        child_env.setdefault("PYTHONUTF8", "1")
+
         try:
             result = subprocess.run(
                 [sys.executable, "-c", script, str(file_path), str(maxpages)],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=timeout,
                 env=child_env,
             )

--- a/tests/test_pdf_subprocess_utf8.py
+++ b/tests/test_pdf_subprocess_utf8.py
@@ -1,0 +1,73 @@
+"""Regression test for #286 (Bug 2): force UTF-8 on the pdfminer subprocess.
+
+On Windows, the console / subprocess stdout defaults to GBK or cp1252.
+When pdfminer extracts a PDF that contains characters outside that
+codec's range, ``sys.stdout.write`` raises ``UnicodeEncodeError``, the
+child exits non-zero, and the parent marks the item ``has_fulltext='failed'``.
+Subsequent incremental updates then skip the item until force-rebuild.
+
+Fix: set ``PYTHONIOENCODING=utf-8`` + ``PYTHONUTF8=1`` in the child env
+and read the child's stdout as UTF-8.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from zotero_mcp.local_db import LocalZoteroReader
+
+
+class _BareReader(LocalZoteroReader):
+    """LocalZoteroReader stub that skips DB init."""
+
+    def __init__(self):
+        self.db_path = "/dev/null"
+        self._connection = None
+        self.pdf_max_pages = 10
+        self.pdf_timeout = 30
+
+
+def test_pdf_extraction_subprocess_pins_utf8(tmp_path):
+    """The pdfminer subprocess must receive a UTF-8 stdio env and the parent
+    must read its stdout as UTF-8 — required for non-ASCII PDFs on Windows
+    consoles (#286)."""
+    reader = _BareReader()
+    fake_pdf = tmp_path / "paper.pdf"
+    fake_pdf.touch()
+
+    fake_result = MagicMock(returncode=0, stdout="hello", stderr="")
+    with patch("subprocess.run", return_value=fake_result) as mock_run:
+        text = reader._extract_text_from_pdf(fake_pdf)
+
+    assert text == "hello"
+    assert mock_run.call_count == 1
+    _args, kwargs = mock_run.call_args
+
+    # Parent must decode child stdout as UTF-8 with replacement (so undecodable
+    # bytes don't kill the whole batch).
+    assert kwargs.get("encoding") == "utf-8"
+    assert kwargs.get("errors") == "replace"
+    assert kwargs.get("text") is True
+
+    # Child must use UTF-8 stdio.
+    env = kwargs.get("env") or {}
+    assert env.get("PYTHONIOENCODING") == "utf-8", (
+        f"PYTHONIOENCODING missing/wrong in child env; got {env.get('PYTHONIOENCODING')!r}. "
+        "Without this, pdfminer extracting non-ASCII text triggers "
+        "UnicodeEncodeError on Windows consoles (issue #286)."
+    )
+    assert env.get("PYTHONUTF8") == "1"
+
+
+def test_pdf_extraction_does_not_override_existing_pythonioencoding(tmp_path, monkeypatch):
+    """``setdefault`` semantics: respect an existing PYTHONIOENCODING in the
+    parent env rather than silently overwriting a deliberate user choice."""
+    monkeypatch.setenv("PYTHONIOENCODING", "utf-16")
+    reader = _BareReader()
+    fake_pdf = tmp_path / "paper.pdf"
+    fake_pdf.touch()
+
+    fake_result = MagicMock(returncode=0, stdout="", stderr="")
+    with patch("subprocess.run", return_value=fake_result) as mock_run:
+        reader._extract_text_from_pdf(fake_pdf)
+
+    env = mock_run.call_args.kwargs.get("env") or {}
+    assert env.get("PYTHONIOENCODING") == "utf-16"


### PR DESCRIPTION
## Summary

#286 (Bug 2): on Windows, the subprocess stdout defaults to GBK / cp1252. When pdfminer extracts a PDF whose text contains characters outside that codec (CJK, mathematical symbols, accented characters, etc.), ``sys.stdout.write`` raises ``UnicodeEncodeError``, the child exits non-zero, and the parent marks the item ``has_fulltext='failed'``.

The follow-on cost is worse than a one-time extraction failure: subsequent incremental ``update-db --fulltext`` runs skip the item because of the ``failed`` mark, so the user has no way to recover other than ``--force-rebuild``.

## Fix

In [src/zotero_mcp/local_db.py](src/zotero_mcp/local_db.py) ``_extract_text_from_pdf``:

- Set ``PYTHONIOENCODING=utf-8`` and ``PYTHONUTF8=1`` in the child env via ``setdefault`` (so an explicit user override still wins).
- Pass ``encoding=\"utf-8\", errors=\"replace\"`` to ``subprocess.run`` so the parent decodes child stdout as UTF-8 and a single undecodable byte can't kill a whole batch.

No change to extraction logic, page limits, timeout, API-key scrubbing, or the subprocess script itself — purely a stdio encoding fix.

## Test plan

- [x] ``tests/test_pdf_subprocess_utf8.py`` — 2 new tests. First asserts the subprocess.run kwargs include the UTF-8 encoding settings AND the child env has ``PYTHONIOENCODING=utf-8`` / ``PYTHONUTF8=1``. Second asserts ``setdefault`` semantics: an explicit ``PYTHONIOENCODING=utf-16`` in the parent env is preserved.
- [x] Existing ``tests/test_local_db.py`` (15 tests) still passes.

Fixes #286 (Bug 2). Bugs 1 and 3 from the same issue are separate scopes and will need their own PRs.