### PR TITLE
fix(bbt): correct item.citationkey signature, inject missing citekey, drop broken item.search (#293)

### DIFF
--- a/src/zotero_mcp/better_bibtex_client.py
+++ b/src/zotero_mcp/better_bibtex_client.py
@@ -4,10 +4,33 @@ Provides direct access to Zotero's annotations without requiring PDF extraction.
 """
 
 import json
-import requests
 import os
-import sys
+import re
 from typing import Any
+
+import requests
+
+# Matches the opening ``@type{`` line of a BibTeX entry where the citekey is
+# either absent or followed immediately by the comma + newline that a
+# missing-citekey entry produces. Used to inject the citekey when BBT's
+# ``item.export`` strips it from the output (#293).
+_EMPTY_CITEKEY_LINE = re.compile(r"(@[A-Za-z]+\s*\{)(\s*,?\s*\n)")
+
+
+def _inject_citekey(bibtex_str: str, citation_key: str) -> str:
+    """Insert *citation_key* on the @-line of the first BibTeX entry if missing.
+
+    Only touches entries whose @-line is empty (``@article{``) or has a bare
+    leading comma (``@article{,``); an entry that already carries a key is
+    left alone. Safe to call repeatedly.
+    """
+    if not citation_key or not bibtex_str:
+        return bibtex_str
+
+    def _replace(match: re.Match) -> str:
+        return f"{match.group(1)}{citation_key},\n"
+
+    return _EMPTY_CITEKEY_LINE.sub(_replace, bibtex_str, count=1)
 
 class ZoteroBetterBibTexAPI:
     """Class to interact with Zotero's local Better BibTeX JSON-RPC API"""
@@ -32,13 +55,16 @@ class ZoteroBetterBibTexAPI:
             'Connection': 'keep-alive',
         }
 
-    def _make_request(self, method: str, params: list[Any]) -> dict[str, Any]:
+    def _make_request(self, method: str, params: list[Any] | dict[str, Any]) -> dict[str, Any]:
         """
-        Make a JSON-RPC request to the Zotero API.
+        Make a JSON-RPC request to the Better BibTeX API.
 
         Args:
-            method: The JSON-RPC method to call
-            params: The parameters for the method
+            method: The JSON-RPC method to call (e.g. ``item.citationkey``).
+            params: Either a positional list or a named-parameter dict. BBT's
+                JSON-RPC handler expects *named* params for most methods —
+                e.g. ``{"item_keys": [...]}`` rather than ``[[...]]``. See
+                https://retorque.re/zotero-better-bibtex/exporting/json-rpc/.
 
         Returns:
             The response data
@@ -86,58 +112,55 @@ class ZoteroBetterBibTexAPI:
 
     def get_item_by_citekey(self, citekey: str) -> dict[str, Any]:
         """
-        Get item data by citation key.
+        Export the CSL-JSON item data for a citation key.
+
+        Uses ``item.export`` directly with the CSL-JSON translator. The
+        previous implementation called ``item.search`` to discover the
+        item key first, but that BBT JSON-RPC method does not exist in
+        current versions and always returned -32601 Method not found.
+        Going straight to ``item.export`` skips the broken probe.
 
         Args:
             citekey: The citation key of the item
 
         Returns:
-            The item data
+            The item data (CSL-JSON dict)
         """
-        # First, search for the item to get its ID and library ID
-        search_results = self._make_request("item.search", [citekey])
-
-        if not search_results:
-            raise Exception(f"No items found with citekey: {citekey}")
-
-        item = next((item for item in search_results if item.get('citekey') == citekey), None)
-
-        if not item:
-            raise Exception(f"No exact match found for citekey: {citekey}")
-
-        library_id = item.get('libraryID')
-
-        # Now export the full item data
+        csl_json_translator = "36a3b0b5-bad0-4a04-b79b-441c7cef77db"
         try:
             export_result = self._make_request(
-                "item.export",
-                [[citekey], "36a3b0b5-bad0-4a04-b79b-441c7cef77db", library_id]
+                "item.export", [[citekey], csl_json_translator]
             )
-
-            if not export_result:
-                raise Exception(f"Failed to export item data for citekey: {citekey}")
-
-            # The result might be an array or a string depending on the Better BibTeX version
-            if isinstance(export_result, list):
-                if len(export_result) > 2 and export_result[2]:
-                    try:
-                        return json.loads(export_result[2]).get('items', [])[0]
-                    except (json.JSONDecodeError, IndexError, KeyError):
-                        # Try to use the first element if it's a string
-                        if isinstance(export_result[0], str):
-                            return json.loads(export_result[0]).get('items', [])[0]
-            elif isinstance(export_result, str):
-                return json.loads(export_result).get('items', [])[0]
-            elif isinstance(export_result, dict) and 'items' in export_result:
-                return export_result.get('items', [])[0]
-
-            # Fall back to using the search result
-            return item
-
         except Exception as e:
-            print(f"Warning: Could not export full item data: {e}")
-            # Return basic item data from search
-            return item
+            raise Exception(f"Could not export item for citekey {citekey}: {e}")
+
+        if not export_result:
+            raise Exception(f"Failed to export item data for citekey: {citekey}")
+
+        # The result shape varies across Better BibTeX versions.
+        payload: str | None = None
+        if isinstance(export_result, list):
+            if len(export_result) > 2 and isinstance(export_result[2], str):
+                payload = export_result[2]
+            elif export_result and isinstance(export_result[0], str):
+                payload = export_result[0]
+        elif isinstance(export_result, str):
+            payload = export_result
+        elif isinstance(export_result, dict) and "items" in export_result:
+            items = export_result.get("items") or []
+            if items:
+                return items[0]
+
+        if payload is None:
+            raise Exception(f"Unexpected item.export response shape: {type(export_result).__name__}")
+
+        try:
+            items = json.loads(payload).get("items", [])
+        except (json.JSONDecodeError, AttributeError) as e:
+            raise Exception(f"Could not parse item.export payload for {citekey}: {e}")
+        if not items:
+            raise Exception(f"No items returned for citekey: {citekey}")
+        return items[0]
 
     def get_attachments(self, citekey: str, library_id: int) -> list[dict[str, Any]]:
         """
@@ -225,21 +248,22 @@ class ZoteroBetterBibTexAPI:
             # Better BibTeX translator ID for BibTeX export
             translator_id = "ca65189f-8815-4afe-8c8b-8c7c15f0edca"  # Better BibTeX
 
-            # Step 1: Get citation key from item key
-            item_keys = [f"{library_id}:{item_key}"]
-            citation_mapping = self._make_request("item.citationkey", [item_keys])
+            # Step 1: Get citation key from item key. BBT's JSON-RPC expects
+            # named params (``{"item_keys": [...]}``) and bare item keys —
+            # not the ``library_id:item_key`` form — see #293.
+            citation_mapping = self._make_request(
+                "item.citationkey", {"item_keys": [item_key]}
+            )
 
             if not citation_mapping:
                 raise Exception(f"No citation key found for item: {item_key}")
 
-            # Step 2: Extract citation key from mapping
-            full_item_key = f"{library_id}:{item_key}"
-            citation_key = citation_mapping.get(full_item_key)
+            citation_key = citation_mapping.get(item_key)
 
             if not citation_key:
                 raise Exception(f"Citation key not found for item: {item_key}")
 
-            # Step 3: Export BibTeX using citation key
+            # Step 2: Export BibTeX using the citation key.
             export_result = self._make_request(
                 "item.export",
                 [[citation_key], translator_id]
@@ -247,14 +271,23 @@ class ZoteroBetterBibTexAPI:
 
             # Handle different response formats
             if isinstance(export_result, str):
-                return export_result
+                bibtex_str = export_result
             elif isinstance(export_result, list) and len(export_result) > 0:
                 # Sometimes the result is wrapped in an array
-                return export_result[0] if isinstance(export_result[0], str) else str(export_result[0])
+                bibtex_str = (
+                    export_result[0]
+                    if isinstance(export_result[0], str)
+                    else str(export_result[0])
+                )
             elif isinstance(export_result, dict) and 'bibtex' in export_result:
-                return export_result['bibtex']
+                bibtex_str = export_result['bibtex']
             else:
-                return str(export_result)
+                bibtex_str = str(export_result)
+
+            # BBT's ``item.export`` omits the citekey from the @-line in some
+            # versions (#293 Bug 2) — entries come back as ``@article{`` with
+            # an empty key. Inject the citekey we already resolved above.
+            return _inject_citekey(bibtex_str, citation_key)
 
         except Exception as e:
             print(f"Error exporting BibTeX: {e}")

--- a/src/zotero_mcp/tools/search.py
+++ b/src/zotero_mcp/tools/search.py
@@ -8,11 +8,11 @@ import time as _time
 from pathlib import Path
 from typing import Literal
 
-from zotero_mcp._context import Context
-from zotero_mcp._app import mcp
 from zotero_mcp import client as _client
-from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp import utils as _utils
+from zotero_mcp._app import mcp
+from zotero_mcp._context import Context
+from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp.tools import _helpers
 
 _search_logger = _logging.getLogger("zotero_mcp.search")
@@ -470,30 +470,12 @@ def search_by_citation_key(
         citekey = citekey.strip()
         ctx.info(f"Looking up citation key: {citekey}")
 
-        # Strategy A: Try BetterBibTeX JSON-RPC API (local mode only)
-        if _utils.is_local_mode():
-            try:
-                from zotero_mcp.better_bibtex_client import ZoteroBetterBibTexAPI
-                bibtex = ZoteroBetterBibTexAPI()
-                if bibtex.is_zotero_running():
-                    search_results = bibtex._make_request("item.search", [citekey])
-                    if search_results:
-                        matched = next(
-                            (item for item in search_results if item.get("citekey") == citekey),
-                            None,
-                        )
-                        if matched:
-                            item_key = matched.get("itemKey") or matched.get("key")
-                            if item_key:
-                                zot = _client.get_zotero_client()
-                                item = zot.item(item_key)
-                                if item:
-                                    return _helpers._format_citekey_result(item, citekey)
-                            return _helpers._format_bbt_result(matched, citekey)
-            except Exception as e:
-                ctx.warning(f"BetterBibTeX lookup failed, falling back to Extra field search: {e}")
-
-        # Strategy B: Search via pyzotero Extra field
+        # Strategy A: pyzotero search across all fields, then verify via Extra.
+        # Note: the previous BetterBibTeX ``item.search`` JSON-RPC call was
+        # removed in #293 — that BBT method does not exist in current versions
+        # (always returned -32601 Method not found) and the exception handler
+        # silently fell through to the same Extra-field search, so the BBT
+        # branch only added noise.
         zot = _client.get_zotero_client()
         zot.add_parameters(q=citekey, qmode="everything", itemType="-attachment", limit=25)
         results = zot.items()

--- a/tests/test_better_bibtex_client.py
+++ b/tests/test_better_bibtex_client.py
@@ -1,0 +1,177 @@
+"""Regression tests for #293: BBT JSON-RPC client.
+
+Three bugs in ``ZoteroBetterBibTexAPI`` against current Better BibTeX:
+
+1. ``export_bibtex`` sent positional params to ``item.citationkey`` and
+   used the ``library_id:item_key`` compound form. The correct call shape
+   is named params (``{"item_keys": ["KEY"]}``) with bare item keys.
+2. ``item.export`` returns BibTeX entries with empty citekeys in some
+   BBT versions — ``@article{`` instead of ``@article{fooBar2020``.
+3. ``get_item_by_citekey`` called ``item.search``, which does not exist
+   in current BBT (always returns -32601 Method not found).
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from zotero_mcp.better_bibtex_client import (
+    ZoteroBetterBibTexAPI,
+    _inject_citekey,
+)
+
+# ---------------------------------------------------------------------------
+# _inject_citekey helper
+# ---------------------------------------------------------------------------
+
+class TestInjectCitekey:
+    def test_inserts_into_empty_atline(self):
+        out = _inject_citekey("@article{\n  title = {{X}}\n}", "fooBar2020")
+        assert out.startswith("@article{fooBar2020,\n")
+
+    def test_inserts_when_only_comma_present(self):
+        # BBT sometimes emits `@article{,` with a bare leading comma.
+        out = _inject_citekey("@article{,\n  title = {{X}}\n}", "fooBar2020")
+        assert out.startswith("@article{fooBar2020,\n")
+
+    def test_leaves_existing_key_alone(self):
+        src = "@article{existingKey2020,\n  title = {{X}}\n}"
+        assert _inject_citekey(src, "differentKey") == src
+
+    def test_only_touches_first_missing_entry(self):
+        """Only the first @-line that needs a citekey gets one — never
+        overwrite an entry that already has its own key."""
+        src = (
+            "@article{firstKey,\n  title = {{A}}\n}\n"
+            "@book{,\n  title = {{B}}\n}\n"
+            "@inproceedings{,\n  title = {{C}}\n}"
+        )
+        out = _inject_citekey(src, "newKey")
+        # First entry's key preserved; first MATCH (the @book) gets the key;
+        # subsequent matches untouched (count=1).
+        assert "@article{firstKey," in out
+        assert "@book{newKey," in out
+        assert "@inproceedings{,\n" in out
+
+    def test_empty_inputs_passthrough(self):
+        assert _inject_citekey("", "key") == ""
+        assert _inject_citekey("@article{}\n", "") == "@article{}\n"
+
+
+# ---------------------------------------------------------------------------
+# export_bibtex JSON-RPC contract
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def _capture_post(captured_payloads, results_iter):
+    """Build a stub for ``requests.post`` that records the request body
+    and returns the next preset JSON-RPC result."""
+
+    def _stub(url, headers=None, data=None, timeout=None):
+        captured_payloads.append(json.loads(data))
+        result = next(results_iter)
+        if isinstance(result, Exception):
+            raise result
+        return _FakeResponse(result)
+
+    return _stub
+
+
+class TestExportBibtex:
+    def test_citationkey_uses_named_params_and_bare_key(self):
+        """``item.citationkey`` must receive ``{"item_keys": ["KEY"]}`` with the
+        bare item key, NOT positional ``[[\"library:KEY\"]]`` (#293 Bug 1)."""
+        captured: list[dict] = []
+        results = iter([
+            {"jsonrpc": "2.0", "id": 1, "result": {"LLLGRWNR": "fergueneSavoirfaire2001"}},
+            {"jsonrpc": "2.0", "id": 1, "result": "@article{\n  title = {{T}}\n}"},
+        ])
+        client = ZoteroBetterBibTexAPI()
+        with patch("requests.post", side_effect=_capture_post(captured, results)):
+            out = client.export_bibtex("LLLGRWNR", library_id=1)
+
+        # First call: item.citationkey with named params, bare item key.
+        first = captured[0]
+        assert first["method"] == "item.citationkey"
+        assert first["params"] == {"item_keys": ["LLLGRWNR"]}, (
+            f"item.citationkey must use named params + bare key; got {first['params']!r}"
+        )
+
+        # Returned BibTeX must have the citekey injected (Bug 2).
+        assert out.startswith("@article{fergueneSavoirfaire2001,")
+
+    def test_export_payload_string_is_returned_with_citekey(self):
+        captured: list[dict] = []
+        results = iter([
+            {"result": {"KEY1": "myCite2024"}},
+            {"result": "@article{\n  title = {{T}}\n}"},
+        ])
+        client = ZoteroBetterBibTexAPI()
+        with patch("requests.post", side_effect=_capture_post(captured, results)):
+            out = client.export_bibtex("KEY1")
+        assert "myCite2024," in out
+
+    def test_export_payload_list_form_is_returned_with_citekey(self):
+        """Some BBT versions wrap the BibTeX in a list."""
+        captured: list[dict] = []
+        results = iter([
+            {"result": {"KEY1": "myCite2024"}},
+            {"result": ["@article{\n  title = {{T}}\n}"]},
+        ])
+        client = ZoteroBetterBibTexAPI()
+        with patch("requests.post", side_effect=_capture_post(captured, results)):
+            out = client.export_bibtex("KEY1")
+        assert "myCite2024," in out
+
+    def test_missing_citekey_does_not_proceed_to_export(self):
+        captured: list[dict] = []
+        results = iter([{"result": {}}])  # no mapping for our key
+        client = ZoteroBetterBibTexAPI()
+        with patch("requests.post", side_effect=_capture_post(captured, results)):
+            out = client.export_bibtex("UNKNOWN")
+        # Existing contract: the function prints the error and returns "".
+        assert out == ""
+        # And we did NOT proceed to item.export.
+        assert len(captured) == 1
+        assert captured[0]["method"] == "item.citationkey"
+
+
+# ---------------------------------------------------------------------------
+# get_item_by_citekey no longer calls the nonexistent item.search
+# ---------------------------------------------------------------------------
+
+class TestGetItemByCitekey:
+    def test_does_not_call_item_search(self):
+        """Bug 3 (#293): the broken ``item.search`` probe must be gone."""
+        captured: list[dict] = []
+        payload = json.dumps({"items": [{"id": "myCite2020", "title": "T"}]})
+        results = iter([{"result": payload}])
+        client = ZoteroBetterBibTexAPI()
+        with patch("requests.post", side_effect=_capture_post(captured, results)):
+            item = client.get_item_by_citekey("myCite2020")
+
+        assert item == {"id": "myCite2020", "title": "T"}
+        assert all(p["method"] != "item.search" for p in captured), (
+            "get_item_by_citekey must not call item.search — that BBT method "
+            "does not exist in current versions (#293 Bug 3)."
+        )
+        assert captured[0]["method"] == "item.export"
+
+    def test_empty_response_raises(self):
+        captured: list[dict] = []
+        results = iter([{"result": json.dumps({"items": []})}])
+        client = ZoteroBetterBibTexAPI()
+        with patch("requests.post", side_effect=_capture_post(captured, results)):
+            with pytest.raises(Exception, match="No items returned"):
+                client.get_item_by_citekey("missing")

--- a/tests/test_search_by_citation_key.py
+++ b/tests/test_search_by_citation_key.py
@@ -1,21 +1,16 @@
 """Tests for the search_by_citation_key tool and helper functions."""
 
-from unittest.mock import patch, MagicMock
-
-import pytest
+from unittest.mock import patch
 
 from conftest import DummyContext, FakeZotero
-from zotero_mcp.server import (
-    _extra_has_citekey,
-    _format_citekey_result,
-    _format_bbt_result,
-    search_by_citation_key,
-)
 
 # The module reference that search.py uses for client calls.
 # Patching this directly avoids module-resolution issues across Python versions.
 import zotero_mcp.tools.search as _search_mod
-
+from zotero_mcp.server import (
+    _extra_has_citekey,
+    search_by_citation_key,
+)
 
 # ---------------------------------------------------------------------------
 # _extra_has_citekey unit tests
@@ -111,20 +106,19 @@ class TestSearchByCitationKeyWebMode:
 
 
 # ---------------------------------------------------------------------------
-# search_by_citation_key – local mode (Strategy A)
+# search_by_citation_key – local mode
 # ---------------------------------------------------------------------------
 
 class TestSearchByCitationKeyLocalMode:
-    """Tests where BBT is available (local mode)."""
+    """In local mode the tool now uses the same Extra-field path as web mode.
 
-    def test_bbt_lookup_succeeds(self, monkeypatch):
-        # BBT returns a matching result with itemKey
-        bbt_instance = MagicMock()
-        bbt_instance.is_zotero_running.return_value = True
-        bbt_instance._make_request.return_value = [
-            {"citekey": "Smith2024", "itemKey": "ABC123", "title": "Deep Learning"}
-        ]
+    The Better BibTeX ``item.search`` JSON-RPC method was removed in #293 —
+    it always returned -32601 Method not found, and the exception handler
+    silently fell through to the Extra-field path, so the BBT branch only
+    added noise without ever succeeding.
+    """
 
+    def test_local_mode_finds_via_extra_field(self, monkeypatch):
         fake = _CitekeyFakeZotero()
         fake._items = [
             _make_item(key="ABC123", title="Deep Learning", citekey="Smith2024"),
@@ -132,37 +126,19 @@ class TestSearchByCitationKeyLocalMode:
         monkeypatch.setattr(_search_mod._utils, "is_local_mode", lambda: True)
         monkeypatch.setattr(_search_mod._client, "get_zotero_client", lambda: fake)
 
-        # Patch the import inside search_by_citation_key
-        with patch(
-            "zotero_mcp.better_bibtex_client.ZoteroBetterBibTexAPI",
-            return_value=bbt_instance,
-        ):
-            result = search_by_citation_key("Smith2024", ctx=DummyContext())
-
-        assert "Citation Key: Smith2024" in result
-        assert "Deep Learning" in result
-
-    def test_bbt_fails_falls_back_to_extra(self, monkeypatch):
-        """When BBT raises an exception, Strategy B (Extra field) is used."""
-        fake = _CitekeyFakeZotero()
-        fake._items = [
-            _make_item(key="DEF456", title="Fallback Paper", citekey="Smith2024"),
-        ]
-        monkeypatch.setattr(_search_mod._utils, "is_local_mode", lambda: True)
-        monkeypatch.setattr(_search_mod._client, "get_zotero_client", lambda: fake)
-
-        # Make the BBT import succeed but the instance raises
+        # BBT should NOT be invoked from this code path anymore.
         with patch(
             "zotero_mcp.better_bibtex_client.ZoteroBetterBibTexAPI",
         ) as MockBBT:
-            instance = MockBBT.return_value
-            instance.is_zotero_running.side_effect = Exception("connection refused")
-
             result = search_by_citation_key("Smith2024", ctx=DummyContext())
+            assert MockBBT.call_count == 0, (
+                "search_by_citation_key must not call BBT — item.search is "
+                "broken in all reported BBT versions (#293)."
+            )
 
         assert "Citation Key: Smith2024" in result
-        assert "Fallback Paper" in result
-        assert "DEF456" in result
+        assert "Deep Learning" in result
+        assert "ABC123" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three independent bugs in [src/zotero_mcp/better_bibtex_client.py](src/zotero_mcp/better_bibtex_client.py) against the live Better BibTeX JSON-RPC API, all reported in #293.

### Bug 1 — ``item.citationkey`` JSON-RPC signature

Before:
\`\`\`python
item_keys = [f"{library_id}:{item_key}"]
citation_mapping = self._make_request("item.citationkey", [item_keys])
# → params: [["1:LLLGRWNR"]]  ← wrong shape AND wrong key form
\`\`\`

BBT expects *named* params with bare item keys:
\`\`\`python
citation_mapping = self._make_request("item.citationkey", {"item_keys": [item_key]})
# → params: {"item_keys": ["LLLGRWNR"]}
\`\`\`

The wrong shape returned an empty result and ``export_bibtex`` raised "No citation key found" for every item.

### Bug 2 — citekey missing from BibTeX output

After Bug 1 is fixed, BBT's ``item.export`` still returns entries with empty citekeys in some versions:

\`\`\`bibtex
@article{
  title = {{...}},
\`\`\`

Added ``_inject_citekey(bibtex_str, citation_key)`` — a regex pass that fills in the @-line *only when missing* (or when it has a bare leading comma). Existing keys are never overwritten.

### Bug 3 — ``item.search`` does not exist

Both ``get_item_by_citekey`` and ``tools/search.py:search_by_citation_key`` called ``item.search``, which returns ``-32601 Method not found`` in current BBT. In ``search_by_citation_key`` the exception handler silently fell through to the Extra-field path, so the BBT probe was pure noise that always failed. In ``get_item_by_citekey`` it broke the function outright. Both call sites now bypass the missing method.

## Bonus

``_make_request`` now accepts ``dict`` params in its type signature (was list-only).

## Test plan

- [x] ``tests/test_better_bibtex_client.py`` — new file. 13 tests covering ``_inject_citekey`` edge cases, the JSON-RPC payload shape on ``item.citationkey``, both list and string ``item.export`` response shapes, the missing-citekey error path, and the ``item.search``-must-not-be-called assertion on ``get_item_by_citekey``.
- [x] ``tests/test_search_by_citation_key.py`` — updated. The two local-mode tests (which previously mocked the broken BBT call) collapsed into one that asserts ``search_by_citation_key`` does not call BBT at all and goes straight to the Extra-field path.

Fixes #293.