### PR TITLE
fix(local_db): extract fulltext from .txt/.vtt/.srt-style attachments (#265)

### DIFF
--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -5,16 +5,15 @@ Provides direct SQLite access to Zotero's local database for faster semantic sea
 when running in local mode.
 """
 
-import os
-import sqlite3
-import platform
 import logging
+import os
+import platform
+import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from dataclasses import dataclass
-from urllib.parse import urlparse, unquote
 
-from .utils import is_local_mode, _normalize_for_search
+from .utils import _normalize_for_search, is_local_mode
 
 logger = logging.getLogger(__name__)
 
@@ -231,7 +230,7 @@ class LocalZoteroReader:
 
         # Linked file as URL: 'file:///path/to/file.pdf'
         if zotero_path.startswith("file://"):
-            from urllib.parse import urlparse, unquote
+            from urllib.parse import unquote, urlparse
             parsed = urlparse(zotero_path)
             decoded_path = unquote(parsed.path or "")
             # file:///C:/... on Windows
@@ -353,6 +352,36 @@ class LocalZoteroReader:
         except Exception:
             return ""
 
+    # Extensions / MIME types we know we can read as plain text. Used by
+    # ``_is_extractable_attachment`` to gate non-PDF/HTML attachments into
+    # the fulltext extractor. Binary formats (.docx, .pptx, .epub, video,
+    # etc.) are intentionally excluded — ``read_text`` returns garbage for
+    # those and we don't want to pollute the semantic index with it.
+    _TEXTUAL_SUFFIXES = frozenset({
+        ".txt", ".vtt", ".srt", ".sbv", ".md", ".markdown", ".rst",
+        ".csv", ".tsv", ".json", ".xml", ".log", ".text",
+    })
+    _TEXTUAL_CONTENT_TYPES = frozenset({
+        "text/plain", "text/vtt", "text/markdown", "text/csv",
+        "text/tab-separated-values", "text/srt", "application/json",
+        "application/xml", "text/xml",
+    })
+
+    @classmethod
+    def _is_extractable_attachment(cls, file_path: Path, ctype: str | None) -> bool:
+        """Return True when ``_extract_text_from_file`` can return useful text.
+
+        PDF and HTML are handled by their dedicated extractors elsewhere. For
+        anything else, accept the attachment iff its MIME type or extension
+        is in the textual allowlist — never accept arbitrary binaries.
+        """
+        normalized_ctype = (ctype or "").lower()
+        if normalized_ctype.startswith("text/"):
+            return True
+        if normalized_ctype in cls._TEXTUAL_CONTENT_TYPES:
+            return True
+        return file_path.suffix.lower() in cls._TEXTUAL_SUFFIXES
+
     def _extract_text_from_file(self, file_path: Path) -> str:
         """Extract text content from a file based on extension, with fallbacks."""
         suffix = file_path.suffix.lower()
@@ -376,11 +405,18 @@ class LocalZoteroReader:
     def _extract_fulltext_for_item(self, item_id: int) -> tuple[str, str] | None:
         """Attempt to extract fulltext and source from the item's best attachment.
 
-        Preference: use PDF when available; fall back to HTML when no PDF exists.
-        Returns (text, source) where source is 'pdf' or 'html'.
+        Preference: PDF first, then HTML, then any textual attachment
+        (transcript .vtt, plain .txt, captions, etc. — see
+        ``_TEXTUAL_SUFFIXES``). Returns ``(text, source)`` where ``source``
+        is ``"pdf"``, ``"html"``, or ``"file"``.
+
+        Non-PDF/HTML attachments previously fell out of the candidate
+        collection entirely, so transcripts, plaintext notes, and similar
+        attachments were never indexed (#265).
         """
         best_pdf = None
         best_html = None
+        best_other = None
         for key, path, ctype in self._iter_parent_attachments(item_id):
             resolved = self._resolve_attachment_path(key, path or "")
             if not resolved or not resolved.exists():
@@ -389,8 +425,10 @@ class LocalZoteroReader:
                 best_pdf = resolved
             elif (ctype or "").startswith("text/html") and best_html is None:
                 best_html = resolved
-        # Prefer PDF, otherwise fall back to HTML
-        target = best_pdf or best_html
+            elif best_other is None and self._is_extractable_attachment(resolved, ctype):
+                best_other = resolved
+        # Prefer PDF, then HTML, then any extractable text file.
+        target = best_pdf or best_html or best_other
         if not target:
             return None
         text = self._extract_text_from_file(target)

--- a/tests/test_fulltext_non_pdf_html.py
+++ b/tests/test_fulltext_non_pdf_html.py
@@ -1,0 +1,149 @@
+"""Regression tests for #265: local fulltext for non-PDF/HTML attachments.
+
+Previously ``_extract_fulltext_for_item`` only collected PDF and HTML
+attachments as fulltext candidates. Any other attachment (``.txt``,
+``.vtt``, ``.srt``, transcripts, captions, plain markdown notes) was
+silently dropped — the local API can't serve raw bytes for them, so the
+upstream fallback also failed and the tool returned a misleading 404.
+
+Behavior we want: the gate accepts any plain-text attachment too;
+the existing ``_extract_text_from_file`` fallback already handles it.
+"""
+
+from pathlib import Path
+
+from zotero_mcp.local_db import LocalZoteroReader
+
+
+class _Reader(LocalZoteroReader):
+    """LocalZoteroReader stub with no DB and configurable attachments."""
+
+    def __init__(self, attachments, fake_path_for=None):
+        self.db_path = "/dev/null"
+        self._connection = None
+        self.pdf_max_pages = 10
+        self.pdf_timeout = 30
+        self._attachments = attachments
+        self._fake_path_for = fake_path_for or {}
+
+    def _iter_parent_attachments(self, parent_item_id: int):
+        yield from self._attachments
+
+    def _resolve_attachment_path(self, attachment_key: str, zotero_path: str):
+        return self._fake_path_for.get(attachment_key)
+
+
+# ---------------------------------------------------------------------------
+# _is_extractable_attachment classifier
+# ---------------------------------------------------------------------------
+
+
+class TestIsExtractableAttachment:
+    def test_text_plain_ctype(self):
+        assert LocalZoteroReader._is_extractable_attachment(Path("a.txt"), "text/plain")
+
+    def test_vtt_ctype(self):
+        assert LocalZoteroReader._is_extractable_attachment(Path("a.vtt"), "text/vtt")
+
+    def test_srt_extension_without_ctype(self):
+        assert LocalZoteroReader._is_extractable_attachment(Path("captions.srt"), None)
+
+    def test_unknown_text_subtype(self):
+        # Any ``text/*`` MIME is accepted (covers obscure transcript types).
+        assert LocalZoteroReader._is_extractable_attachment(Path("a.txt"), "text/x-asm")
+
+    def test_docx_rejected(self):
+        """Binary office formats are not accepted — read_text would return
+        garbage and pollute the semantic index."""
+        assert not LocalZoteroReader._is_extractable_attachment(
+            Path("paper.docx"),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+
+    def test_video_rejected(self):
+        assert not LocalZoteroReader._is_extractable_attachment(
+            Path("talk.mp4"), "video/mp4"
+        )
+
+    def test_pdf_returns_true_via_extension_set(self):
+        """PDFs are not in _TEXTUAL_SUFFIXES — the PDF path is handled
+        before this classifier ever runs. False here is correct."""
+        assert not LocalZoteroReader._is_extractable_attachment(
+            Path("a.pdf"), "application/pdf"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _extract_fulltext_for_item end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_extract_fulltext_uses_vtt_when_only_attachment(tmp_path):
+    """A solo .vtt attachment must yield fulltext (#265 main repro)."""
+    vtt = tmp_path / "lecture.vtt"
+    vtt.write_text(
+        "WEBVTT\n\n00:00:00.000 --> 00:00:05.000\nIntroduction to the topic.\n"
+    )
+    reader = _Reader(
+        attachments=[("ATTKEY01", "storage:lecture.vtt", "text/vtt")],
+        fake_path_for={"ATTKEY01": vtt},
+    )
+    result = reader._extract_fulltext_for_item(item_id=1)
+
+    assert result is not None
+    text, source = result
+    assert "Introduction to the topic" in text
+    assert source == "file"
+
+
+def test_extract_fulltext_prefers_pdf_over_textual(tmp_path):
+    """When both a PDF and a textual attachment exist, the PDF still wins."""
+    pdf = tmp_path / "paper.pdf"
+    pdf.touch()
+    txt = tmp_path / "notes.txt"
+    txt.write_text("plaintext fallback content")
+
+    class _ReaderWithPdfText(_Reader):
+        def _extract_text_from_pdf(self, file_path):
+            return "PDF content extracted"
+
+    reader = _ReaderWithPdfText(
+        attachments=[
+            ("PDF0001", "storage:paper.pdf", "application/pdf"),
+            ("TXT0001", "storage:notes.txt", "text/plain"),
+        ],
+        fake_path_for={"PDF0001": pdf, "TXT0001": txt},
+    )
+    text, source = reader._extract_fulltext_for_item(item_id=1)
+    assert text == "PDF content extracted"
+    assert source == "pdf"
+
+
+def test_extract_fulltext_falls_back_to_textual_when_no_pdf_html(tmp_path):
+    txt = tmp_path / "transcript.txt"
+    txt.write_text("transcript body")
+    reader = _Reader(
+        attachments=[("T0001", "storage:transcript.txt", "text/plain")],
+        fake_path_for={"T0001": txt},
+    )
+    text, source = reader._extract_fulltext_for_item(item_id=1)
+    assert text == "transcript body"
+    assert source == "file"
+
+
+def test_extract_fulltext_ignores_binary_attachment(tmp_path):
+    """A .docx-only item still returns None — we don't have a docx extractor
+    here and the read_text fallback would emit garbage."""
+    binary = tmp_path / "paper.docx"
+    binary.write_bytes(b"\x50\x4b\x03\x04binary garbage")
+    reader = _Reader(
+        attachments=[
+            (
+                "D0001",
+                "storage:paper.docx",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            )
+        ],
+        fake_path_for={"D0001": binary},
+    )
+    assert reader._extract_fulltext_for_item(item_id=1) is None


### PR DESCRIPTION
## Summary

#265: ``zotero_get_item_fulltext`` returned 404 in local mode for any attachment whose content type wasn't ``application/pdf`` or ``text/html*`` — even when the file was right there on disk. Same code path also silently dropped the attachment from semantic indexing.

Root cause: ``_extract_fulltext_for_item`` in [src/zotero_mcp/local_db.py](src/zotero_mcp/local_db.py:376) only collected PDF and HTML candidates. For non-PDF/HTML attachments ``target`` was ``None``, the caller in ``tools/retrieval.py`` fell through to ``zot.dump()``/``zot.file()`` — but pyzotero's local-API mode returns a ``file://localhost/...`` URL pointer rather than raw bytes, and the subsequent HTTP GET 404s. The misleading 404 looked identical to a missing attachment, masking that the file existed and was readable.

The ``_extract_text_from_file`` generic ``read_text(errors=\"ignore\")`` fallback already existed (lines 363–367) — the gate just never let non-PDF/HTML attachments reach it.

## Fix

Add a third "any textual attachment" bucket gated by a small allowlist on a new ``_is_extractable_attachment`` classmethod:

- Any ``text/*`` MIME type, plus a curated set (``text/vtt``, ``application/json``, ``application/xml``, …).
- Known textual extensions: ``.txt``, ``.vtt``, ``.srt``, ``.sbv``, ``.md``, ``.markdown``, ``.rst``, ``.csv``, ``.tsv``, ``.json``, ``.xml``, ``.log``, ``.text``.

Binary office formats (``.docx``, ``.pptx``, ``.xlsx``) and media (``.mp4`` etc.) are **not** accepted — the existing ``read_text(errors=\"ignore\")`` fallback would return garbage for those and pollute the semantic index. Those formats need format-specific extractors (markitdown / ebooklib etc.); could be a follow-up.

Preference order is unchanged: PDF first, then HTML, then any textual attachment.

## Test plan

- [x] ``tests/test_fulltext_non_pdf_html.py`` — 11 new tests. Covers the classifier (text/plain, text/vtt, .srt extension, unknown ``text/*`` subtype, .docx rejected, video rejected). End-to-end: solo ``.vtt`` yields fulltext (the #265 main repro), PDF still wins when both exist, ``.docx``-only item still returns None.
- [x] ``tests/test_local_db.py`` (15 tests) continues to pass.

Fixes #265.