### PR TITLE
fix(local_db): read .zotero-ft-cache and scan storage when filenames drift (#291)

### DIFF
--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -5,16 +5,15 @@ Provides direct SQLite access to Zotero's local database for faster semantic sea
 when running in local mode.
 """
 
-import os
-import sqlite3
-import platform
 import logging
+import os
+import platform
+import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from dataclasses import dataclass
-from urllib.parse import urlparse, unquote
 
-from .utils import is_local_mode, _normalize_for_search
+from .utils import _normalize_for_search, is_local_mode
 
 logger = logging.getLogger(__name__)
 
@@ -231,7 +230,7 @@ class LocalZoteroReader:
 
         # Linked file as URL: 'file:///path/to/file.pdf'
         if zotero_path.startswith("file://"):
-            from urllib.parse import urlparse, unquote
+            from urllib.parse import unquote, urlparse
             parsed = urlparse(zotero_path)
             decoded_path = unquote(parsed.path or "")
             # file:///C:/... on Windows
@@ -373,18 +372,96 @@ class LocalZoteroReader:
 
         return meta
 
+    def _read_zotero_ft_cache(self, attachment_key: str) -> str | None:
+        """Return the text in Zotero's ``.zotero-ft-cache`` for an attachment.
+
+        Zotero writes a plain-text full-text cache next to each indexed PDF /
+        EPUB at ``storage/<attachment_key>/.zotero-ft-cache``. Using it has
+        two upsides:
+        - it's already-extracted text (no pdfminer subprocess needed);
+        - it doesn't depend on filename matching, so it survives Zotero
+          file-naming drift / non-ASCII filename rewrites (#291).
+
+        Returns ``None`` if the cache file is absent, empty, or unreadable.
+        """
+        try:
+            cache_path = self._get_storage_dir() / attachment_key / ".zotero-ft-cache"
+        except Exception:
+            return None
+        if not cache_path.exists():
+            return None
+        try:
+            text = cache_path.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            return None
+        return text or None
+
+    def _scan_storage_for_attachment(
+        self, attachment_key: str, ctype: str | None
+    ) -> Path | None:
+        """Fallback path resolver: find a likely attachment file on disk.
+
+        ``itemAttachments.path`` in the Zotero sqlite is the filename Zotero
+        recorded at import time, but the on-disk filename can drift (renames,
+        non-ASCII normalization, external sync tools). When the recorded
+        path no longer resolves, scan the attachment's own storage folder
+        and pick the largest file whose extension is consistent with the
+        recorded content type (#291).
+        """
+        try:
+            attachment_dir = self._get_storage_dir() / attachment_key
+        except Exception:
+            return None
+        if not attachment_dir.is_dir():
+            return None
+
+        if ctype == "application/pdf":
+            wanted_suffixes = {".pdf"}
+        elif (ctype or "").startswith("text/html"):
+            wanted_suffixes = {".html", ".htm"}
+        elif (ctype or "").startswith("application/epub"):
+            wanted_suffixes = {".epub"}
+        else:
+            return None
+
+        candidates: list[Path] = [
+            child for child in attachment_dir.iterdir()
+            if child.is_file() and child.suffix.lower() in wanted_suffixes
+        ]
+        if not candidates:
+            return None
+        # Largest file wins — for PDFs this is almost always the body content
+        # rather than a stub or thumbnail.
+        return max(candidates, key=lambda p: p.stat().st_size)
+
     def _extract_fulltext_for_item(self, item_id: int) -> tuple[str, str] | None:
         """Attempt to extract fulltext and source from the item's best attachment.
 
-        Preference: use PDF when available; fall back to HTML when no PDF exists.
-        Returns (text, source) where source is 'pdf' or 'html'.
+        Preference order:
+        1. ``.zotero-ft-cache`` (Zotero's own already-indexed text — survives
+           filename drift, no subprocess needed) — source ``"zotero-cache"``.
+        2. PDF extraction — source ``"pdf"``.
+        3. HTML extraction — source ``"html"``.
+
+        If the sqlite-recorded filename doesn't resolve on disk, scan the
+        attachment's storage folder for a content-type-matching file before
+        giving up (#291).
         """
+        # 1. Zotero's own full-text cache — use it whenever present.
+        for key, _path, _ctype in self._iter_parent_attachments(item_id):
+            cached = self._read_zotero_ft_cache(key)
+            if cached:
+                return (cached, "zotero-cache")
+
         best_pdf = None
         best_html = None
         for key, path, ctype in self._iter_parent_attachments(item_id):
             resolved = self._resolve_attachment_path(key, path or "")
             if not resolved or not resolved.exists():
-                continue
+                # Filename drift fallback: scan the storage folder.
+                resolved = self._scan_storage_for_attachment(key, ctype)
+                if not resolved or not resolved.exists():
+                    continue
             if ctype == "application/pdf" and best_pdf is None:
                 best_pdf = resolved
             elif (ctype or "").startswith("text/html") and best_html is None:

--- a/tests/test_zotero_ft_cache.py
+++ b/tests/test_zotero_ft_cache.py
@@ -1,0 +1,165 @@
+"""Regression tests for #291: read .zotero-ft-cache; survive filename drift.
+
+Local fulltext extraction used to depend entirely on ``itemAttachments.path``
+matching a file on disk. If Zotero (or a sync tool, or a non-ASCII rename)
+changed the on-disk filename, ``_resolve_attachment_path`` returned ``None``,
+``_extract_fulltext_for_item`` returned ``None``, and the indexer marked the
+item ``has_fulltext='failed'`` — which incremental updates then skip until
+``--force-rebuild``.
+
+Two fixes here:
+
+- ``.zotero-ft-cache``: Zotero writes a plain-text already-extracted
+  full-text cache next to each indexed PDF. Reading it skips pdfminer
+  entirely and is immune to filename drift.
+- Storage-dir scan fallback: when the recorded path doesn't resolve, look
+  in the attachment's storage folder for a file whose extension matches
+  the recorded content type.
+"""
+
+from pathlib import Path
+
+from zotero_mcp.local_db import LocalZoteroReader
+
+
+class _Reader(LocalZoteroReader):
+    """LocalZoteroReader stub: no DB, attachments / storage dir injected."""
+
+    def __init__(self, attachments, storage_dir: Path):
+        self.db_path = "/dev/null"
+        self._connection = None
+        self.pdf_max_pages = 10
+        self.pdf_timeout = 30
+        self._attachments = attachments
+        self._storage_dir = storage_dir
+
+    def _iter_parent_attachments(self, _parent_item_id: int):
+        yield from self._attachments
+
+    def _get_storage_dir(self) -> Path:
+        return self._storage_dir
+
+
+# ---------------------------------------------------------------------------
+# .zotero-ft-cache fast path
+# ---------------------------------------------------------------------------
+
+
+def test_zotero_ft_cache_short_circuits_pdf_extraction(tmp_path):
+    """When Zotero has already cached the text, return it without invoking
+    pdfminer — even if the recorded PDF filename doesn't resolve on disk."""
+    storage = tmp_path / "storage"
+    attachment_dir = storage / "ABCDEFGH"
+    attachment_dir.mkdir(parents=True)
+    (attachment_dir / ".zotero-ft-cache").write_text(
+        "Full body text extracted by Zotero, including the conclusion."
+    )
+    # Recorded sqlite path points at a filename that no longer exists.
+    reader = _Reader(
+        attachments=[
+            ("ABCDEFGH", "storage:original-filename-renamed.pdf", "application/pdf")
+        ],
+        storage_dir=storage,
+    )
+
+    # If pdfminer were ever invoked we'd hit the missing file; ensure not.
+    def _boom(_path):
+        raise AssertionError("pdfminer must not be called when ft-cache exists")
+
+    reader._extract_text_from_pdf = _boom  # type: ignore[assignment]
+
+    result = reader._extract_fulltext_for_item(item_id=1)
+    assert result is not None
+    text, source = result
+    assert "Full body text" in text
+    assert source == "zotero-cache"
+
+
+def test_empty_zotero_ft_cache_is_skipped(tmp_path):
+    """An empty .zotero-ft-cache file shouldn't masquerade as fulltext."""
+    storage = tmp_path / "storage"
+    attachment_dir = storage / "EMPTYCAC"
+    attachment_dir.mkdir(parents=True)
+    (attachment_dir / ".zotero-ft-cache").write_text("")
+    reader = _Reader(
+        attachments=[("EMPTYCAC", "storage:p.pdf", "application/pdf")],
+        storage_dir=storage,
+    )
+    # No PDF on disk and the cache is empty — must return None, not fake hits.
+    assert reader._extract_fulltext_for_item(item_id=1) is None
+
+
+# ---------------------------------------------------------------------------
+# Storage-dir scan fallback
+# ---------------------------------------------------------------------------
+
+
+def test_storage_scan_recovers_from_renamed_pdf(tmp_path):
+    """If the recorded filename doesn't resolve but the storage folder
+    contains a PDF, use it instead of failing the extraction (#291)."""
+    storage = tmp_path / "storage"
+    attachment_dir = storage / "RENAMED1"
+    attachment_dir.mkdir(parents=True)
+    # The actual file has a different name than what sqlite recorded.
+    on_disk = attachment_dir / "actual-filename.pdf"
+    on_disk.write_bytes(b"%PDF-1.4 fake content")
+
+    reader = _Reader(
+        attachments=[
+            ("RENAMED1", "storage:recorded-name-but-not-on-disk.pdf", "application/pdf")
+        ],
+        storage_dir=storage,
+    )
+
+    captured: dict[str, Path] = {}
+
+    def _fake_extract(path):
+        captured["path"] = path
+        return "extracted via scan fallback"
+
+    reader._extract_text_from_pdf = _fake_extract  # type: ignore[assignment]
+
+    text, source = reader._extract_fulltext_for_item(item_id=1)
+    assert text == "extracted via scan fallback"
+    assert source == "pdf"
+    assert captured["path"] == on_disk
+
+
+def test_storage_scan_picks_largest_when_multiple_pdfs(tmp_path):
+    storage = tmp_path / "storage"
+    attachment_dir = storage / "MULTIPDF"
+    attachment_dir.mkdir(parents=True)
+    small = attachment_dir / "thumbnail.pdf"
+    small.write_bytes(b"%PDF-tiny")
+    big = attachment_dir / "body.pdf"
+    big.write_bytes(b"%PDF-" + b"x" * 500)
+
+    reader = _Reader(
+        attachments=[("MULTIPDF", "storage:missing.pdf", "application/pdf")],
+        storage_dir=storage,
+    )
+    chosen = reader._scan_storage_for_attachment("MULTIPDF", "application/pdf")
+    assert chosen == big
+
+
+def test_storage_scan_no_match_returns_none(tmp_path):
+    storage = tmp_path / "storage"
+    attachment_dir = storage / "WRONGSUF"
+    attachment_dir.mkdir(parents=True)
+    (attachment_dir / "metadata.json").write_text("{}")  # not a PDF
+    reader = _Reader(
+        attachments=[("WRONGSUF", "storage:missing.pdf", "application/pdf")],
+        storage_dir=storage,
+    )
+    assert reader._scan_storage_for_attachment("WRONGSUF", "application/pdf") is None
+
+
+def test_extract_returns_none_when_neither_cache_nor_scan_helps(tmp_path):
+    """Pure absence of both: cache missing AND scan finds nothing → None."""
+    storage = tmp_path / "storage"
+    storage.mkdir()
+    reader = _Reader(
+        attachments=[("ABSENT00", "storage:nope.pdf", "application/pdf")],
+        storage_dir=storage,
+    )
+    assert reader._extract_fulltext_for_item(item_id=1) is None


### PR DESCRIPTION
## Summary

#291: ``_extract_fulltext_for_item`` only knows how to resolve attachments via the sqlite-recorded ``itemAttachments.path``. When the on-disk filename drifts (Zotero re-name, non-ASCII normalization, sync tool rewrite, plugin rename), the path resolver returns ``None`` and the indexer marks the item ``has_fulltext='failed'``. Incremental updates then silently skip the item until the user runs ``--force-rebuild`` — and the file was right there on disk the whole time.

Both Zotero and the user reporter's local patch already showed the cleaner path: Zotero writes a plain-text full-text cache to ``storage/<attachment_key>/.zotero-ft-cache`` for every indexed PDF / EPUB. That file is keyed on the attachment key, not the filename, so it survives every kind of filename drift.

## Fix

Two helpers in [src/zotero_mcp/local_db.py](src/zotero_mcp/local_db.py):

- **``_read_zotero_ft_cache(attachment_key)``** — reads the cache file if present. Used as the *preferred* source in ``_extract_fulltext_for_item`` — short-circuits pdfminer entirely when Zotero has already done the work. Surfaces as new ``fulltext_source == \"zotero-cache\"``.
- **``_scan_storage_for_attachment(attachment_key, ctype)``** — when the recorded path doesn't resolve, scan the attachment's storage folder for a file whose extension matches the recorded content type. Picks the largest match (PDF body wins over thumbnail). Returns None if no plausible candidate.

The extractor now: cache → resolved path → scan fallback → give up.

## Test plan

- [x] ``tests/test_zotero_ft_cache.py`` — 6 new tests. Covers cache short-circuit (with a deliberate ``_extract_text_from_pdf`` assertion that pdfminer is *not* called), empty cache is skipped, scan recovers from renamed PDF, scan picks the largest of multiple PDFs, scan returns None when no content-type match, and the no-cache-no-scan-no-resolve path correctly returns None.
- [x] ``tests/test_local_db.py`` (15 tests) continues to pass.

Reporter's local patch verified the same approach worked end-to-end on real Zotero libraries (``LQX5DUU2 zotero-cache 55360 chars`` / ``C5HBQLCC zotero-cache 75736 chars``).

Fixes #291.