### PR TITLE
fix(semantic): build annotation document text from annotation.text (#287)

### DIFF
--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -8,12 +8,12 @@ over research libraries.
 
 import contextlib
 import json
+import logging
 import os
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
-import logging
 
 try:
     import tiktoken
@@ -22,12 +22,11 @@ except Exception:
     tiktoken = None
     _tokenizer = None
 
-from pyzotero import zotero
 
 from .chroma_client import ChromaClient, create_chroma_client
 from .client import get_zotero_client
+from .local_db import LocalZoteroReader
 from .utils import format_creators, is_local_mode
-from .local_db import LocalZoteroReader, get_local_zotero_reader
 
 logger = logging.getLogger(__name__)
 
@@ -256,6 +255,17 @@ class ZoteroSemanticSearch:
             Combined text for embedding
         """
         data = item.get("data", {})
+        item_type = data.get("itemType", "")
+
+        # Annotations have no title / creators / abstract — they have
+        # ``annotationText`` (the highlighted passage) and an optional
+        # ``annotationComment``. The previous "title + creators + abstract"
+        # template fell back to ``format_creators([])`` → "No authors
+        # listed", which then embedded identically for every annotation in
+        # the library, collapsing them all to a single vector and
+        # dominating every semantic-search result (#287).
+        if item_type == "annotation":
+            return self._create_annotation_document_text(data)
 
         # Extract key fields for semantic search
         title = data.get("title", "")
@@ -287,6 +297,25 @@ class ZoteroSemanticSearch:
         # Combine all text fields
         text_parts = [title, creators_text, abstract] + extra_fields
         return " ".join(filter(None, text_parts))
+
+    def _create_annotation_document_text(self, data: dict[str, Any]) -> str:
+        """Build the embedding text for an annotation item.
+
+        Combines ``annotationText`` (highlighted passage) and
+        ``annotationComment`` (user's commentary), plus any tags. Returns
+        the empty string when nothing meaningful is present so the caller
+        can decide to skip the item rather than embedding noise.
+        """
+        parts: list[str] = []
+        if highlighted := (data.get("annotationText") or "").strip():
+            parts.append(highlighted)
+        if comment := (data.get("annotationComment") or "").strip():
+            parts.append(comment)
+        if tags := data.get("tags"):
+            tag_text = " ".join(t.get("tag", "") for t in tags if t.get("tag"))
+            if tag_text:
+                parts.append(tag_text)
+        return " ".join(parts)
 
     def _create_metadata(self, item: dict[str, Any]) -> dict[str, Any]:
         """
@@ -698,7 +727,7 @@ class ZoteroSemanticSearch:
                                 sys.stderr.write(f"    - {name}\n")
                             if len(_skipped_failed) > 5:
                                 sys.stderr.write(f"    ... and {len(_skipped_failed) - 5} more\n")
-                            sys.stderr.write(f"  (To retry these, run with --force-rebuild)\n")
+                            sys.stderr.write("  (To retry these, run with --force-rebuild)\n")
                     except Exception:
                         pass
 

--- a/tests/test_annotation_document_text.py
+++ b/tests/test_annotation_document_text.py
@@ -1,0 +1,123 @@
+"""Regression test for #287: annotation document text in semantic index.
+
+The previous ``_create_document_text`` template was
+``title + creators + abstract + tags + note``. For annotations:
+
+- ``title`` is empty (annotations don't have titles)
+- ``abstract`` is empty
+- ``creators`` is ``[]`` → ``format_creators([])`` returns ``"No authors listed"``
+
+so every annotation in the library was embedded with the literal string
+``"No authors listed"``, producing identical embedding vectors. With
+thousands of annotations all collapsed to one vector, semantic search
+returned those entries for every query — blocking real items from
+surfacing.
+
+Fix: route annotations through a dedicated builder that uses
+``annotationText`` + ``annotationComment`` + tags.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+# semantic_search depends on chromadb; skip the module on environments
+# where chroma isn't installed (it's an optional extra: ``[semantic]``).
+chromadb = pytest.importorskip("chromadb")  # noqa: F841
+
+
+from zotero_mcp.semantic_search import ZoteroSemanticSearch  # noqa: E402
+
+
+@pytest.fixture
+def search(monkeypatch):
+    # Avoid network / env requirements: stub both clients.
+    monkeypatch.setattr(
+        "zotero_mcp.semantic_search.get_zotero_client", lambda: MagicMock()
+    )
+    return ZoteroSemanticSearch(chroma_client=MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Annotation document text
+# ---------------------------------------------------------------------------
+
+
+def _annotation_item(text: str = "", comment: str = "", tags: list[str] | None = None) -> dict:
+    return {
+        "key": "ANNO0001",
+        "version": 1,
+        "data": {
+            "key": "ANNO0001",
+            "itemType": "annotation",
+            "annotationText": text,
+            "annotationComment": comment,
+            "annotationType": "highlight",
+            "tags": [{"tag": t} for t in (tags or [])],
+            "title": "",
+            "creators": [],
+            "abstractNote": "",
+        },
+    }
+
+
+class TestAnnotationDocumentText:
+    def test_uses_annotation_text_not_no_authors_listed(self, search):
+        """The headline regression for #287."""
+        ann = _annotation_item(
+            text="The pre-Columbian Pueblo economy depended on …"
+        )
+        out = search._create_document_text(ann)
+        assert "No authors listed" not in out
+        assert "Pueblo economy" in out
+
+    def test_includes_comment_when_present(self, search):
+        ann = _annotation_item(
+            text="The headline finding.",
+            comment="My critique: small sample size.",
+        )
+        out = search._create_document_text(ann)
+        assert "headline finding" in out
+        assert "critique" in out
+
+    def test_includes_tags(self, search):
+        ann = _annotation_item(text="text", tags=["important", "review"])
+        out = search._create_document_text(ann)
+        assert "important" in out
+        assert "review" in out
+
+    def test_empty_annotation_returns_empty_string(self, search):
+        """An annotation with no text or comment must yield empty document
+        text so the upsert loop skips it instead of indexing noise."""
+        ann = _annotation_item(text="", comment="")
+        assert search._create_document_text(ann) == ""
+
+    def test_two_annotations_produce_distinct_text(self, search):
+        """The whole bug: identical text → identical embeddings → cluster
+        of duplicates at the top of every search."""
+        a = _annotation_item(text="A unique highlighted passage about X.")
+        b = _annotation_item(text="A completely different passage about Y.")
+        assert search._create_document_text(a) != search._create_document_text(b)
+
+
+# ---------------------------------------------------------------------------
+# Non-annotation items still use the standard template
+# ---------------------------------------------------------------------------
+
+
+def test_journal_article_unchanged(search):
+    """Other item types must keep using title + creators + abstract."""
+    item = {
+        "key": "JART0001",
+        "data": {
+            "itemType": "journalArticle",
+            "title": "Some Paper",
+            "abstractNote": "We show that …",
+            "creators": [{"firstName": "A", "lastName": "Author", "creatorType": "author"}],
+            "tags": [],
+        },
+    }
+    out = search._create_document_text(item)
+    assert "Some Paper" in out
+    assert "Author" in out
+    assert "We show that" in out


### PR DESCRIPTION
## Summary

#287: ``_create_document_text`` is a "title + creators + abstract + tags + note" template that works for journal articles, books, and webpages but produces garbage for annotations — they have ``annotationText`` (the highlighted passage) and ``annotationComment``, none of the standard fields.

For every annotation in the library the template degenerated to:

\`\`\`text
"" + format_creators([]) + "" + ""   →   "No authors listed"
\`\`\`

So every annotation in the index got the bit-identical document string ``"No authors listed"`` and an identical embedding vector. Reporter measured **cosine similarity 1.000** across all 3,700 annotations in their library, and every semantic-search query returned that cluster of duplicate annotations at the top — blocking real items from surfacing.

## Fix

In [src/zotero_mcp/semantic_search.py](src/zotero_mcp/semantic_search.py): branch on ``item_type == \"annotation\"`` and route those items through a dedicated ``_create_annotation_document_text(data)`` helper that concatenates ``annotationText`` + ``annotationComment`` + tags. Empty annotations yield ``\"\"`` so the existing ``if not doc_text.strip(): skip`` guard in the upsert loop drops them instead of indexing noise.

Non-annotation items are unchanged — the existing template still runs.

Users will need to ``zotero-mcp update-db --fulltext --force-rebuild`` once to flush the bad embeddings and reindex annotations against their real text.

## Test plan

- [x] ``tests/test_annotation_document_text.py`` — 6 new tests covering: the headline regression (``"No authors listed"`` does not appear in annotation doc text), comment inclusion, tag inclusion, empty annotation yields empty string, two distinct annotations produce distinct text (the literal repro of the cluster bug), and non-annotation items still go through the standard template.

## Out of scope (mentioned in the issue body)

The reporter also flagged that ``filters`` is post-hoc-applied rather than passed to ChromaDB as ``where=``, and that HNSW soft-deletes survive on-disk pruning. Both are real but separate; this PR focuses on the doc-text root cause.

Fixes #287.