### PR TITLE
fix(collections): surface trashed collections; reject writes against them (#233)

### DIFF
--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -11,7 +11,6 @@ import requests
 from zotero_mcp import client as _client
 from zotero_mcp import utils as _utils
 
-
 # ---------------------------------------------------------------------------
 # Config file
 # ---------------------------------------------------------------------------
@@ -113,6 +112,42 @@ def _get_write_client(ctx):
         "Cannot perform write operations in local-only mode. "
         "Add ZOTERO_API_KEY and ZOTERO_LIBRARY_ID to enable hybrid mode."
     )
+
+
+def fetch_trashed_collections(zot) -> list[dict]:
+    """Return collections in the active library's trash, or [] on failure.
+
+    Zotero's REST API exposes trashed collections at
+    ``/{users|groups}/{id}/collections/trash``. pyzotero doesn't have a
+    dedicated method for it (only ``trash()``, which returns items), so
+    fall back to ``_retrieve_data``. Non-fatal — callers should treat
+    failures as "no trash data available" rather than raising.
+    """
+    try:
+        resp = zot._retrieve_data(
+            f"/{zot.library_type}/{zot.library_id}/collections/trash"
+        )
+    except Exception:
+        return []
+    try:
+        data = resp.json()
+    except Exception:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def is_collection_trashed(zot, collection_key: str) -> bool | None:
+    """Return True if a collection is in the trash, False if live, None on error.
+
+    Reads a single collection by key and inspects ``data.deleted``. Used to
+    pre-validate ``zotero_manage_collections`` calls so the tool returns a
+    clear error instead of silently filing items into trashed parents.
+    """
+    try:
+        coll = zot.collection(collection_key)
+    except Exception:
+        return None
+    return bool(coll.get("data", {}).get("deleted"))
 
 
 def _handle_write_response(response, ctx=None):

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -1,19 +1,18 @@
 """Retrieval tool functions — read-only access to Zotero items, collections, tags, libraries, and feeds."""
 
-from typing import Literal
 import json
 import logging as _logging
 import os
 import re
 import tempfile
 import time as _time
-from pathlib import Path
+from typing import Literal
 
-from zotero_mcp._context import Context
-from zotero_mcp._app import mcp
 from zotero_mcp import client as _client
-from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp import utils as _utils
+from zotero_mcp._app import mcp
+from zotero_mcp._context import Context
+from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp.tools import _helpers
 
 
@@ -310,6 +309,9 @@ def get_attachment_path(
         "without truncation, so very deep trees can be long. "
         "limit: cap on collections returned; pass None (default) to use 100, "
         "or raise to 5000 for libraries with thousands of collections. "
+        "include_trashed: when True, also show collections in the Zotero "
+        "Trash (annotated as such). Default False, matching Zotero desktop's "
+        "default view. "
         "Example output:\n"
         "  - **Orals** (Key: MT53KB66)\n"
         "    - **Early America** (Key: 3249BZKE)\n"
@@ -319,6 +321,7 @@ def get_attachment_path(
 @with_zotero_api_lock
 def get_collections(
     limit: int | str | None = None,
+    include_trashed: bool = False,
     *,
     ctx: Context
 ) -> str:
@@ -327,6 +330,12 @@ def get_collections(
 
     Args:
         limit: Maximum number of collections to return
+        include_trashed: if True, merge collections currently in Zotero's
+            Trash into the listing, annotated with ``[trashed]``. Default
+            False matches the Zotero desktop default and the prior
+            behavior of this tool. Trashed collections are normally
+            invisible to automated clients (#233) — turn this on when you
+            need to know they exist.
         ctx: MCP context
 
     Returns:
@@ -339,6 +348,15 @@ def get_collections(
         limit = _helpers._normalize_limit(limit, default=100, max_val=5000)
 
         collections = _helpers._paginate(zot.collections, max_items=limit)
+        trashed_keys: set[str] = set()
+        if include_trashed:
+            trashed = _helpers.fetch_trashed_collections(zot)
+            existing_keys = {c.get("key") for c in collections}
+            for coll in trashed:
+                key = coll.get("key")
+                if key and key not in existing_keys:
+                    trashed_keys.add(key)
+                    collections.append(coll)
 
         # Always return the header, even if empty
         output = ["# Zotero Collections", ""]
@@ -370,10 +388,11 @@ def get_collections(
 
             coll = collection_map[key]
             name = coll["data"].get("name", "Unnamed Collection")
+            trash_marker = " *[trashed]*" if key in trashed_keys else ""
 
             # Create indentation for hierarchy
             indent = "  " * level
-            lines = [f"{indent}- **{name}** (Key: {key})"]
+            lines = [f"{indent}- **{name}** (Key: {key}){trash_marker}"]
 
             # Add children if they exist
             child_keys = hierarchy.get(key, [])
@@ -391,7 +410,8 @@ def get_collections(
             for coll in sorted(collections, key=lambda x: x["data"].get("name", "")):
                 name = coll["data"].get("name", "Unnamed Collection")
                 key = coll["key"]
-                output.append(f"- **{name}** (Key: {key})")
+                trash_marker = " *[trashed]*" if key in trashed_keys else ""
+                output.append(f"- **{name}** (Key: {key}){trash_marker}")
         else:
             # Display hierarchical structure
             for key in sorted(top_level_keys):
@@ -1378,7 +1398,7 @@ def get_item_related(
         # Fetch the item
         try:
             item = zot.item(item_key)
-        except Exception as e:
+        except Exception:
             return f"Error: Item '{item_key}' not found."
 
         data = item.get("data", {})

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1,23 +1,22 @@
 """Write / mutation tool functions for the Zotero MCP server."""
 
-from typing import Annotated, Literal
 import json
 import os
 import re
 import tempfile
-import xml.etree.ElementTree as ET
-
 import time as _time
+import xml.etree.ElementTree as ET
+from typing import Annotated, Literal
 
 import requests
 from pydantic import Field
 
-from zotero_mcp._context import Context
-from zotero_mcp._app import mcp
-from zotero_mcp import client as _client
-from zotero_mcp.client import with_zotero_api_lock
-from zotero_mcp import utils as _utils
 from zotero_mcp import citation_import as _citation_import
+from zotero_mcp import client as _client
+from zotero_mcp import utils as _utils
+from zotero_mcp._app import mcp
+from zotero_mcp._context import Context
+from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp.tools import _helpers
 
 # Accessed as _helpers.X so that monkeypatch/mock on the module attribute works.
@@ -362,6 +361,9 @@ def delete_collection(
         "searches. Leading/trailing whitespace is ignored and empty words "
         "are dropped. "
         "Returns the collection's key plus its parent (if any). "
+        "include_trashed: when True, also match collections currently in "
+        "the Zotero Trash (results annotated as such). Default False — "
+        "trashed collections are otherwise invisible to automated clients. "
         "Performance: scans all collections in the active library (O(n)); "
         "for very large libraries expect a full-list pagination under the "
         "hood. "
@@ -372,6 +374,7 @@ def delete_collection(
 @with_zotero_api_lock
 def search_collections(
     query: str,
+    include_trashed: bool = False,
     *,
     ctx: Context
 ) -> str:
@@ -380,6 +383,15 @@ def search_collections(
         ctx.info(f"Searching collections for '{query}'")
 
         collections = _helpers._paginate(zot.collections)
+        trashed_keys: set[str] = set()
+        if include_trashed:
+            trashed = _helpers.fetch_trashed_collections(zot)
+            existing_keys = {c.get("key") for c in collections}
+            for coll in trashed:
+                key = coll.get("key")
+                if key and key not in existing_keys:
+                    trashed_keys.add(key)
+                    collections.append(coll)
         if not collections:
             return "No collections found in your Zotero library."
 
@@ -397,7 +409,8 @@ def search_collections(
             name = coll["data"].get("name", "Unnamed")
             key = coll["key"]
             parent_key = coll["data"].get("parentCollection")
-            lines.append(f"## {i}. {name}")
+            trash_marker = " *[trashed]*" if key in trashed_keys else ""
+            lines.append(f"## {i}. {name}{trash_marker}")
             lines.append(f"**Key:** `{key}`")
             if parent_key:
                 try:
@@ -445,6 +458,30 @@ def manage_collections(
             return "Error: No item keys provided."
         if not add_colls and not remove_colls:
             return "Error: Must specify add_to and/or remove_from."
+
+        # Validate collection keys before doing any work — Zotero will happily
+        # accept add/remove against a trashed collection, leaving items
+        # parented under an invisible bucket so the caller sees "success" but
+        # nothing renders in the desktop client (#233).
+        validation_errors: list[str] = []
+        for coll_key in list(add_colls) + list(remove_colls):
+            trashed = _helpers.is_collection_trashed(write_zot, coll_key)
+            if trashed is None:
+                validation_errors.append(
+                    f"Collection '{coll_key}' was not found in the active "
+                    f"library. Use zotero_search_collections (with "
+                    f"include_trashed=True if needed) to find a valid key."
+                )
+            elif trashed:
+                validation_errors.append(
+                    f"Collection '{coll_key}' is in the Trash. Restore it "
+                    f"in Zotero (or create a new collection) before adding "
+                    f"or removing items — the underlying API will accept "
+                    f"the call but the change won't be visible in the "
+                    f"normal collection tree."
+                )
+        if validation_errors:
+            return "Error:\n" + "\n".join(validation_errors)
 
         results = []
 
@@ -1368,7 +1405,7 @@ def update_item(
                 + "\n".join(changes)
             )
             return result + skip_warning
-        return f"Failed to update item: write operation returned failure"
+        return "Failed to update item: write operation returned failure"
 
     except ValueError as e:
         return f"Input error: {e}"
@@ -2124,13 +2161,13 @@ def add_item_relation(
         # Fetch the primary item
         try:
             item = write_zot.item(item_key)
-        except Exception as e:
+        except Exception:
             return f"Error: Item '{item_key}' not found."
 
         # Verify the related item exists
         try:
             related_item = write_zot.item(related_item_key)
-        except Exception as e:
+        except Exception:
             return f"Error: Related item '{related_item_key}' not found."
 
         data = item.get("data", {})
@@ -2239,7 +2276,7 @@ def remove_item_relation(
         # Fetch the primary item
         try:
             item = write_zot.item(item_key)
-        except Exception as e:
+        except Exception:
             return f"Error: Item '{item_key}' not found."
 
         data = item.get("data", {})

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -9,12 +9,10 @@ the tool functions (create_collection, search_collections, manage_collections)
 are added to server.py.
 """
 
-import json
 import pytest
-
 from conftest import DummyContext, FakeZotero
-from zotero_mcp import server
 
+from zotero_mcp import server
 
 # ---------------------------------------------------------------------------
 # Extended FakeZotero for collection tests
@@ -432,6 +430,7 @@ class TestManageCollections:
             {"key": "COL001", "data": {"name": "Test", "parentCollection": False}},
         ]
         write_zot = FakeZoteroCollections()
+        write_zot._collections = list(read_zot._collections)  # both endpoints see the same collections
         write_zot._items = [
             {
                 "key": "ITEM0001",

--- a/tests/test_trashed_collections.py
+++ b/tests/test_trashed_collections.py
@@ -1,0 +1,240 @@
+"""Regression tests for #233: trashed-collection visibility & validation.
+
+Three behaviors covered:
+
+- ``zotero_get_collections(include_trashed=True)`` shows trashed
+  collections (annotated as such), while the default ``False`` preserves
+  the existing tree.
+- ``zotero_search_collections(include_trashed=True)`` matches trashed
+  collections too.
+- ``zotero_manage_collections`` pre-validates each ``add_to`` /
+  ``remove_from`` key and refuses if the key is in the Trash or missing,
+  instead of silently filing items into an invisible bucket.
+"""
+
+from unittest.mock import MagicMock
+
+from conftest import DummyContext, FakeZotero, _FakeResponse
+
+from zotero_mcp import server
+from zotero_mcp.tools import _helpers
+
+# ---------------------------------------------------------------------------
+# Test scaffolding
+# ---------------------------------------------------------------------------
+
+
+def _coll(key: str, name: str, deleted: bool = False, parent: str | None = None) -> dict:
+    data = {"name": name, "key": key, "parentCollection": parent or False}
+    if deleted:
+        data["deleted"] = True
+    return {"key": key, "version": 1, "data": data}
+
+
+class _CollectionFakeZotero(FakeZotero):
+    """FakeZotero with collection() lookups, trash fetch, and addto support."""
+
+    def __init__(self, live: list[dict], trashed: list[dict]):
+        super().__init__()
+        self._collections = live
+        self._trashed = trashed
+        self._all_by_key = {c["key"]: c for c in (live + trashed)}
+        self.addto_calls: list[tuple[str, str]] = []
+
+    def collection(self, key, **_kw):
+        if key in self._all_by_key:
+            return self._all_by_key[key]
+        raise KeyError(key)
+
+    # pyzotero's _retrieve_data returns an httpx.Response-like object.
+    # The helper only calls .json() on it.
+    def _retrieve_data(self, request: str, params=None):
+        if request.endswith("/collections/trash"):
+            resp = MagicMock()
+            resp.json.return_value = self._trashed
+            return resp
+        raise NotImplementedError(request)
+
+    def addto_collection(self, collection_key, item, **_kw):
+        key = item["key"] if isinstance(item, dict) else item
+        self.addto_calls.append((collection_key, key))
+        return _FakeResponse(204)
+
+    def deletefrom_collection(self, collection_key, item, **_kw):
+        return _FakeResponse(204)
+
+
+def _patch_clients(monkeypatch, zot):
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: zot)
+    monkeypatch.setattr(
+        "zotero_mcp.tools._helpers._get_write_client", lambda ctx: (zot, zot)
+    )
+
+
+# ---------------------------------------------------------------------------
+# fetch_trashed_collections / is_collection_trashed helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_fetch_trashed_returns_list(self):
+        z = _CollectionFakeZotero(
+            live=[_coll("LIVE0000", "Live")],
+            trashed=[_coll("DEAD0000", "Dead", deleted=True)],
+        )
+        out = _helpers.fetch_trashed_collections(z)
+        assert [c["key"] for c in out] == ["DEAD0000"]
+
+    def test_fetch_trashed_swallows_errors(self):
+        class Boom:
+            library_id = "1"
+            library_type = "users"
+
+            def _retrieve_data(self, *_a, **_kw):
+                raise RuntimeError("offline")
+
+        assert _helpers.fetch_trashed_collections(Boom()) == []
+
+    def test_is_collection_trashed_returns_true(self):
+        z = _CollectionFakeZotero(
+            live=[],
+            trashed=[_coll("DEAD0000", "Dead", deleted=True)],
+        )
+        assert _helpers.is_collection_trashed(z, "DEAD0000") is True
+
+    def test_is_collection_trashed_returns_false_for_live(self):
+        z = _CollectionFakeZotero(
+            live=[_coll("LIVE0000", "Live")], trashed=[]
+        )
+        assert _helpers.is_collection_trashed(z, "LIVE0000") is False
+
+    def test_is_collection_trashed_returns_none_for_missing(self):
+        z = _CollectionFakeZotero(live=[], trashed=[])
+        assert _helpers.is_collection_trashed(z, "GONE0000") is None
+
+
+# ---------------------------------------------------------------------------
+# zotero_manage_collections validation (the main user-visible bug)
+# ---------------------------------------------------------------------------
+
+
+class TestManageCollectionsValidation:
+    def test_rejects_trashed_collection_in_add_to(self, monkeypatch):
+        z = _CollectionFakeZotero(
+            live=[_coll("LIVE0000", "Live")],
+            trashed=[_coll("DEAD0000", "Trashed", deleted=True)],
+        )
+        _patch_clients(monkeypatch, z)
+
+        result = server.manage_collections(
+            item_keys=["ITEM0001"],
+            add_to=["DEAD0000"],
+            ctx=DummyContext(),
+        )
+        assert "Trash" in result
+        assert "DEAD0000" in result
+        # And nothing was actually filed.
+        assert z.addto_calls == []
+
+    def test_rejects_missing_collection_in_add_to(self, monkeypatch):
+        z = _CollectionFakeZotero(live=[], trashed=[])
+        _patch_clients(monkeypatch, z)
+
+        result = server.manage_collections(
+            item_keys=["ITEM0001"],
+            add_to=["NONESUCH"],
+            ctx=DummyContext(),
+        )
+        assert "not found" in result
+        assert "NONESUCH" in result
+        assert z.addto_calls == []
+
+    def test_live_collection_proceeds_normally(self, monkeypatch):
+        z = _CollectionFakeZotero(
+            live=[_coll("LIVE0000", "Live")], trashed=[]
+        )
+        _patch_clients(monkeypatch, z)
+
+        result = server.manage_collections(
+            item_keys=["ITEM0001"],
+            add_to=["LIVE0000"],
+            ctx=DummyContext(),
+        )
+        assert "Added ITEM0001 to LIVE0000" in result
+        assert z.addto_calls == [("LIVE0000", "ITEM0001")]
+
+    def test_validation_includes_both_add_and_remove_keys(self, monkeypatch):
+        z = _CollectionFakeZotero(
+            live=[_coll("LIVE0000", "Live")],
+            trashed=[_coll("DEAD0000", "Dead", deleted=True)],
+        )
+        _patch_clients(monkeypatch, z)
+
+        result = server.manage_collections(
+            item_keys=["ITEM0001"],
+            add_to=["LIVE0000"],
+            remove_from=["DEAD0000"],
+            ctx=DummyContext(),
+        )
+        # DEAD0000 is in remove_from → still rejected.
+        assert "Trash" in result
+        assert "DEAD0000" in result
+        # And nothing was filed because validation gates ALL collection keys.
+        assert z.addto_calls == []
+
+
+# ---------------------------------------------------------------------------
+# zotero_get_collections / zotero_search_collections include_trashed
+# ---------------------------------------------------------------------------
+
+
+class TestGetCollections:
+    def test_default_excludes_trashed(self, monkeypatch):
+        z = _CollectionFakeZotero(
+            live=[_coll("LIVE0000", "Live")],
+            trashed=[_coll("DEAD0000", "Dead", deleted=True)],
+        )
+        _patch_clients(monkeypatch, z)
+
+        result = server.get_collections(ctx=DummyContext())
+        assert "Live" in result
+        assert "Dead" not in result
+
+    def test_include_trashed_shows_them(self, monkeypatch):
+        z = _CollectionFakeZotero(
+            live=[_coll("LIVE0000", "Live")],
+            trashed=[_coll("DEAD0000", "Dead", deleted=True)],
+        )
+        _patch_clients(monkeypatch, z)
+
+        result = server.get_collections(include_trashed=True, ctx=DummyContext())
+        assert "Live" in result
+        assert "Dead" in result
+        assert "*[trashed]*" in result
+
+
+class TestSearchCollections:
+    def test_search_excludes_trashed_by_default(self, monkeypatch):
+        z = _CollectionFakeZotero(
+            live=[_coll("LIVE0000", "Unrelated Topic")],
+            trashed=[_coll("DEAD0000", "Important Stuff", deleted=True)],
+        )
+        _patch_clients(monkeypatch, z)
+
+        result = server.search_collections(query="important", ctx=DummyContext())
+        assert "No collections found matching" in result
+        assert "DEAD0000" not in result
+
+    def test_search_with_include_trashed_returns_it(self, monkeypatch):
+        z = _CollectionFakeZotero(
+            live=[],
+            trashed=[_coll("DEAD0000", "Important Stuff", deleted=True)],
+        )
+        _patch_clients(monkeypatch, z)
+
+        result = server.search_collections(
+            query="important", include_trashed=True, ctx=DummyContext()
+        )
+        assert "Important Stuff" in result
+        assert "DEAD0000" in result
+        assert "*[trashed]*" in result


### PR DESCRIPTION
## Summary

#233: trashed collections are invisible to every collection-listing tool, and ``zotero_manage_collections`` happily files items into trashed parents — the Zotero API accepts the call, returns success, and the item then sits under a parent that doesn't render in the desktop collection tree. From the user's perspective the add "didn't happen"; from an LLM's perspective the call "succeeded". A classic silent failure for automated workflows that look up collections by name and trust the listing.

The reporter's repro: trash a collection in Zotero desktop, then have an LLM workflow look it up by name (gets "no results"), create a new item, and call ``zotero_manage_collections(add_to=[<the_trashed_key_from_an_earlier_session>])`` — success message comes back, item lands invisibly under a trashed parent.

## Fix

### 1. New ``include_trashed`` parameter on listing tools

Added to ``zotero_get_collections`` and ``zotero_search_collections``. Defaults to ``False`` so existing behavior is preserved. When True, merges ``/collections/trash`` into the listing and annotates each trashed entry with ``*[trashed]*``:

\`\`\`
- **My Papers** (Key: ABC12345)
- **Old Drafts** (Key: DEF67890) *[trashed]*
\`\`\`

### 2. Pre-validation in ``zotero_manage_collections``

Every ``add_to`` / ``remove_from`` key is now checked against the active library *before* any operation runs. The validator returns either:

- ``"Collection 'XYZ' is in the Trash. Restore it ... before adding or removing items"`` (trashed)
- ``"Collection 'XYZ' was not found ..."`` (missing — points at ``zotero_search_collections(include_trashed=True)``)

If any key fails validation, the whole call is aborted with the error — no partial writes. This converts the silent-failure class into a loud error the client can react to.

### 3. Two helpers in [tools/_helpers.py](src/zotero_mcp/tools/_helpers.py)

- ``fetch_trashed_collections(zot)`` — uses pyzotero's ``_retrieve_data`` to hit ``/{users|groups}/{id}/collections/trash``. Returns ``[]`` on any error (non-fatal).
- ``is_collection_trashed(zot, key)`` — returns ``True`` / ``False`` / ``None``-for-missing.

## Test plan

- [x] ``tests/test_trashed_collections.py`` — 12 new tests. Helper unit tests cover the fetch + is-trashed-detector branches. End-to-end:
  - ``get_collections(include_trashed=True)`` shows trashed entries; ``=False`` (default) hides them.
  - ``search_collections(include_trashed=True)`` matches trashed names; default doesn't.
  - ``manage_collections`` rejects trashed ``add_to``, rejects missing ``add_to``, accepts live, and validates ``remove_from`` keys too.
- [x] ``tests/test_collections.py`` — pre-existing ``test_hybrid_mode_fetches_from_write_client`` adjusted so both endpoints see the same collection (realistic; the prior asymmetry only worked because validation didn't exist).

Fixes #233.