### PR TITLE
feat(semantic): throttle embeddings via --burst/--pause + 429 retry-with-backoff

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -6,10 +6,12 @@ for semantic search over Zotero libraries.
 """
 
 import json
+import logging
 import os
+import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
-import logging
 
 try:
     import chromadb
@@ -24,6 +26,53 @@ except ImportError as e:
 from zotero_mcp.utils import suppress_stdout
 
 logger = logging.getLogger(__name__)
+
+
+def _is_rate_limit_error(exc: BaseException) -> bool:
+    """Detect a rate-limit / quota error across OpenAI and Gemini SDK shapes.
+
+    Checks (in order): structured attributes (.code / .status_code == 429),
+    canonical substrings in str(exc) ("RESOURCE_EXHAUSTED" or "429"), and
+    openai.RateLimitError if the openai SDK is importable. The substring
+    checks are intentionally narrow to avoid false positives from arbitrary
+    user-facing messages that mention "rate limit".
+    """
+    if getattr(exc, "code", None) == 429:
+        return True
+    if getattr(exc, "status_code", None) == 429:
+        return True
+    msg = str(exc)
+    if "RESOURCE_EXHAUSTED" in msg or "429" in msg:
+        return True
+    try:
+        import openai
+        if isinstance(exc, openai.RateLimitError):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _with_retry(call: Callable, *, max_attempts: int = 3, base_sleep: float = 30.0):
+    """Retry `call` with exponential backoff on rate-limit errors.
+
+    Default schedule: 30s → 60s → 120s. The first wait is 30s (not 1s)
+    because Gemini's TPM/RPM windows are 60s — anything shorter is wasted.
+    Non rate-limit errors propagate immediately. The final attempt re-raises
+    so the caller sees the underlying exception.
+    """
+    for attempt in range(max_attempts):
+        try:
+            return call()
+        except Exception as exc:
+            if not _is_rate_limit_error(exc) or attempt == max_attempts - 1:
+                raise
+            sleep_s = base_sleep * (2 ** attempt)
+            logger.warning(
+                "Embedding rate-limited (%s); sleeping %.0fs before retry %d/%d",
+                type(exc).__name__, sleep_s, attempt + 2, max_attempts,
+            )
+            time.sleep(sleep_s)
 
 
 class OpenAIEmbeddingFunction(EmbeddingFunction):
@@ -64,10 +113,10 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
 
     def __call__(self, input: Documents) -> Embeddings:
         """Generate embeddings using OpenAI API."""
-        response = self.client.embeddings.create(
+        response = _with_retry(lambda: self.client.embeddings.create(
             model=self.model_name,
             input=input
-        )
+        ))
         return [data.embedding for data in response.data]
 
     def embed_query(self, text: str) -> list[float]:
@@ -191,19 +240,19 @@ class GeminiEmbeddingFunction(EmbeddingFunction):
         for start in range(0, len(prepared), self.GEMINI_MAX_BATCH):
             batch = prepared[start:start + self.GEMINI_MAX_BATCH]
             if is_v2:
-                response = self.client.models.embed_content(
+                response = _with_retry(lambda b=batch: self.client.models.embed_content(
                     model=self.model_name,
-                    contents=batch,
-                )
+                    contents=b,
+                ))
             else:
-                response = self.client.models.embed_content(
+                response = _with_retry(lambda b=batch: self.client.models.embed_content(
                     model=self.model_name,
-                    contents=batch,
+                    contents=b,
                     config=self.types.EmbedContentConfig(
                         task_type="retrieval_document",
                         title="Zotero library document",
                     ),
-                )
+                ))
             embeddings.extend(e.values for e in response.embeddings)
         return embeddings
 
@@ -218,18 +267,18 @@ class GeminiEmbeddingFunction(EmbeddingFunction):
         text = self.truncate(text, self.max_input_tokens)
         if self._is_v2():
             prompt_text = f"{self.V2_QUERY_PREFIX}{text}"
-            response = self.client.models.embed_content(
+            response = _with_retry(lambda: self.client.models.embed_content(
                 model=self.model_name,
                 contents=[prompt_text],
-            )
+            ))
         else:
-            response = self.client.models.embed_content(
+            response = _with_retry(lambda: self.client.models.embed_content(
                 model=self.model_name,
                 contents=[text],
                 config=self.types.EmbedContentConfig(
                     task_type="retrieval_query",
                 ),
-            )
+            ))
         return response.embeddings[0].values
 
     def truncate(self, text: str, max_tokens: int) -> str:

--- a/src/zotero_mcp/cli.py
+++ b/src/zotero_mcp/cli.py
@@ -221,6 +221,13 @@ def main():
                                  help="Path to semantic search configuration file")
     update_db_parser.add_argument("--db-path",
                                  help="Path to Zotero database file (zotero.sqlite), overrides config")
+    update_db_parser.add_argument("--burst", type=int, default=None,
+                                 help="Embedding rate-limit pacing: pause after this many items per burst. "
+                                      "Falls back to semantic_search.throttle.burst_items in config. "
+                                      "Both --burst and --pause must be set to engage throttling.")
+    update_db_parser.add_argument("--pause", type=float, default=None,
+                                 help="Embedding rate-limit pacing: seconds to sleep between bursts. "
+                                      "Falls back to semantic_search.throttle.pause_seconds in config.")
 
     # Database status command
     db_status_parser = subparsers.add_parser("db-status", help="Show semantic search database status")
@@ -416,7 +423,9 @@ def main():
             stats = search.update_database(
                 force_full_rebuild=args.force_rebuild,
                 limit=args.limit,
-                extract_fulltext=args.fulltext
+                extract_fulltext=args.fulltext,
+                burst_items=args.burst,
+                pause_seconds=args.pause,
             )
 
             print(f"\nDatabase update completed:")

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import sys
+import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -173,6 +174,25 @@ class ZoteroSemanticSearch:
             except Exception as e:
                 logger.warning(f"Error loading update config: {e}")
 
+        return config
+
+    def _load_throttle_config(self) -> dict[str, Any]:
+        """Load embedding throttle config (burst_items, pause_seconds).
+
+        Reads `semantic_search.throttle` from the config file. Both fields
+        default to None, which disables throttling. Explicit CLI args
+        override these values upstream.
+        """
+        config: dict[str, Any] = {"burst_items": None, "pause_seconds": None}
+        if self.config_path and os.path.exists(self.config_path):
+            try:
+                with open(self.config_path) as f:
+                    file_config = json.load(f)
+                    config.update(
+                        file_config.get("semantic_search", {}).get("throttle", {})
+                    )
+            except Exception as e:
+                logger.warning(f"Error loading throttle config: {e}")
         return config
 
     def _load_include_fulltext_setting(self) -> bool:
@@ -1034,7 +1054,9 @@ class ZoteroSemanticSearch:
                        force_full_rebuild: bool = False,
                        limit: int | None = None,
                        extract_fulltext: bool = False,
-                       include_fulltext: bool | None = None) -> dict[str, Any]:
+                       include_fulltext: bool | None = None,
+                       burst_items: int | None = None,
+                       pause_seconds: float | None = None) -> dict[str, Any]:
         """
         Update the semantic search database with Zotero items.
 
@@ -1048,6 +1070,14 @@ class ZoteroSemanticSearch:
                 `semantic_search.include_fulltext` config setting (True
                 unless explicitly disabled). Ignored in local mode since
                 `extract_fulltext` provides richer local extraction.
+            burst_items: Pause after embedding this many items to stay
+                within API rate limits. None falls back to the
+                `semantic_search.throttle.burst_items` config value;
+                if both are unset, no pacing is applied.
+            pause_seconds: Seconds to sleep between bursts. None falls
+                back to `semantic_search.throttle.pause_seconds`. Both
+                burst_items AND pause_seconds must resolve to truthy
+                values to engage throttling.
 
         Returns:
             Update statistics
@@ -1195,6 +1225,26 @@ class ZoteroSemanticSearch:
             batch_size = 25
             seen_items = 0
             _failed_docs = []  # Collect failures for end-of-run retry
+
+            # Resolve effective throttle settings: explicit args > config.
+            throttle_cfg = self._load_throttle_config()
+            effective_burst = burst_items if burst_items is not None else throttle_cfg.get("burst_items")
+            effective_pause = pause_seconds if pause_seconds is not None else throttle_cfg.get("pause_seconds")
+            throttle_on = bool(effective_burst) and effective_pause is not None and effective_pause > 0
+            if throttle_on:
+                try:
+                    sys.stderr.write(
+                        f"  Throttle: burst {int(effective_burst)} items, then pause {float(effective_pause):g}s\n"
+                    )
+                    sys.stderr.flush()
+                except Exception:
+                    pass
+            elif (burst_items is not None) ^ (pause_seconds is not None):
+                logger.warning(
+                    "Throttle requires BOTH --burst and --pause; only one was set, running without pacing."
+                )
+            items_since_pause = 0
+
             for i in range(0, len(all_items), batch_size):
                 batch = all_items[i:i + batch_size]
 
@@ -1220,6 +1270,22 @@ class ZoteroSemanticSearch:
                 stats["errors"] += batch_stats["errors"]
 
                 logger.info(f"Processed {seen_items}/{total} items (added: {stats['added_items']}, skipped: {stats['skipped_items']})")
+
+                # Throttle: pause between bursts to stay under API rate limits.
+                # Skip the pause when no items remain (final iteration).
+                if throttle_on:
+                    items_since_pause += len(batch)
+                    more_items_left = (i + batch_size) < len(all_items)
+                    if items_since_pause >= int(effective_burst) and more_items_left:
+                        try:
+                            sys.stderr.write(
+                                f"\n  Throttle: pausing {float(effective_pause):g}s after {items_since_pause} items...\n"
+                            )
+                            sys.stderr.flush()
+                        except Exception:
+                            pass
+                        time.sleep(float(effective_pause))
+                        items_since_pause = 0
 
             # Retry any documents that failed during the main run
             if _failed_docs:

--- a/tests/test_embedding_throttle.py
+++ b/tests/test_embedding_throttle.py
@@ -1,0 +1,161 @@
+"""Tests for embedding throttle (burst/pause) and 429 retry-with-backoff."""
+
+import sys
+import time
+
+import pytest
+
+if sys.version_info >= (3, 14):
+    pytest.skip(
+        "chromadb currently relies on pydantic v1 paths that are incompatible with Python 3.14+",
+        allow_module_level=True,
+    )
+
+from zotero_mcp import semantic_search
+from zotero_mcp.chroma_client import _is_rate_limit_error, _with_retry
+
+
+class _RateLimitErr(Exception):
+    code = 429
+
+
+def test_is_rate_limit_error_detects_common_shapes():
+    assert _is_rate_limit_error(_RateLimitErr("quota exceeded"))
+    assert _is_rate_limit_error(Exception("RESOURCE_EXHAUSTED"))
+    assert _is_rate_limit_error(Exception("HTTP 429 too many requests"))
+    assert not _is_rate_limit_error(Exception("some other error"))
+    # Narrow detector: free-text "rate limit" alone (no 429 / RESOURCE_EXHAUSTED)
+    # should NOT trigger a retry, to avoid false positives.
+    assert not _is_rate_limit_error(Exception("not a rate limit issue"))
+
+
+def test_with_retry_recovers_from_rate_limit():
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise _RateLimitErr("RESOURCE_EXHAUSTED")
+        return "ok"
+
+    start = time.monotonic()
+    result = _with_retry(flaky, max_attempts=3, base_sleep=0.05)
+    elapsed = time.monotonic() - start
+
+    assert result == "ok"
+    assert calls["n"] == 2
+    assert elapsed >= 0.05
+
+
+def test_with_retry_reraises_non_rate_limit_immediately():
+    calls = {"n": 0}
+
+    def boom():
+        calls["n"] += 1
+        raise ValueError("not a rate limit")
+
+    with pytest.raises(ValueError):
+        _with_retry(boom, max_attempts=3, base_sleep=10.0)
+
+    assert calls["n"] == 1  # no retry
+
+
+def test_with_retry_gives_up_after_max_attempts():
+    calls = {"n": 0}
+
+    def always_429():
+        calls["n"] += 1
+        raise _RateLimitErr("RESOURCE_EXHAUSTED")
+
+    with pytest.raises(_RateLimitErr):
+        _with_retry(always_429, max_attempts=3, base_sleep=0.01)
+
+    assert calls["n"] == 3
+
+
+class _FakeChroma:
+    embedding_max_tokens = 8000
+
+    def get_existing_ids(self, ids):
+        return set()
+
+    def upsert_documents(self, *_args, **_kwargs):
+        return None
+
+    def truncate_text(self, text, max_tokens=None):
+        return text
+
+    def get_collection_stats(self):
+        return {"total_documents": 0}
+
+
+def _build_search_with_fake_items(monkeypatch, n_items: int):
+    """Stub out Zotero + Chroma interaction so update_database runs in <1s."""
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: object())
+
+    # Bypass the cross-process update lock. In real usage it prevents the MCP
+    # server's auto-update from racing a manual `update-db`. Tests don't need
+    # it and a host machine where another zotero-mcp process is running would
+    # otherwise make these tests bail out before reaching the throttle loop.
+    import contextlib as _contextlib
+
+    @_contextlib.contextmanager
+    def _always_acquire(_lock_path):
+        yield True
+
+    monkeypatch.setattr(semantic_search, "_acquire_update_lock", _always_acquire)
+
+    search = semantic_search.ZoteroSemanticSearch(chroma_client=_FakeChroma())
+
+    fake_items = [
+        {"key": f"K{i:04d}", "data": {"title": f"item{i}"}, "version": 1}
+        for i in range(n_items)
+    ]
+    monkeypatch.setattr(search, "_get_items_from_source", lambda **_kw: fake_items)
+    monkeypatch.setattr(search, "_load_include_fulltext_setting", lambda: False)
+    monkeypatch.setattr(search, "_load_last_sync_version", lambda: 0)
+    monkeypatch.setattr(search, "_save_update_config", lambda **_kw: None)
+    monkeypatch.setattr(
+        search,
+        "_process_item_batch",
+        lambda batch, force, _failed: {
+            "processed": len(batch), "added": len(batch),
+            "updated": 0, "skipped": 0, "errors": 0,
+        },
+    )
+
+    class _ZC:
+        def last_modified_version(self):
+            return 1
+
+    search.zotero_client = _ZC()
+    return search
+
+
+def test_burst_pause_loop_sleeps_between_bursts(monkeypatch):
+    """60 items, burst=25 pause=0.5s → expect 2 pauses (after 25 and 50, not 60)."""
+    search = _build_search_with_fake_items(monkeypatch, n_items=60)
+    start = time.monotonic()
+    search.update_database(burst_items=25, pause_seconds=0.5)
+    elapsed = time.monotonic() - start
+    # Two 0.5s pauses expected; allow generous upper bound for CI jitter.
+    assert 0.9 <= elapsed <= 3.0, f"expected ~1.0s elapsed, got {elapsed:.2f}s"
+
+
+def test_burst_pause_disabled_when_args_missing(monkeypatch):
+    """No burst/pause passed → no sleep, completes instantly."""
+    search = _build_search_with_fake_items(monkeypatch, n_items=60)
+    start = time.monotonic()
+    search.update_database()
+    elapsed = time.monotonic() - start
+    assert elapsed < 0.5, f"unexpected delay {elapsed:.2f}s without throttle"
+
+
+def test_burst_pause_skips_final_pause(monkeypatch):
+    """Exactly 50 items with burst=25 → 1 pause only (after 25), NOT after 50."""
+    search = _build_search_with_fake_items(monkeypatch, n_items=50)
+    start = time.monotonic()
+    search.update_database(burst_items=25, pause_seconds=0.5)
+    elapsed = time.monotonic() - start
+    # Only one pause expected.
+    assert 0.4 <= elapsed <= 1.5, f"expected ~0.5s elapsed, got {elapsed:.2f}s"


### PR DESCRIPTION
## Summary

Adds two complementary ways to keep `zotero-mcp update-db` from tripping
embedding API rate limits — proactive pacing and reactive retry. Both
default to off so behavior is unchanged unless opted in.

Related to #152 (which asked for the inverse — higher-tier throughput).
This PR shares part of the same vocabulary (configurable batch/pause)
but the goal is rate-limit safety, not concurrency. Happy to fold or
split as the maintainer prefers.

## Problem

Gemini `gemini-embedding-001` free-tier limits are 100 RPM / 30k TPM
(Tier 1: 1500 RPM / 1M TPM). With `--fulltext`, a single 25-item outer
batch ships ~100-200k tokens in one `embed_content` call — guaranteed
TPM violation on free tier, and under bursty load Tier 1 trips too. The
existing end-of-run retry uses `time.sleep(1)` which is too short to
clear a Gemini quota window (60s).

## What's in this PR

### 1. Pacing (`--burst` / `--pause`)

New flags on `update-db`:

```
zotero-mcp update-db --fulltext --burst 500 --pause 10
```

Counter accumulates items processed since the last pause; when it
crosses `--burst`, sleep `--pause` seconds. Skips the final pause when
no items remain.

Config fallback under `semantic_search.throttle`:

```json
{
  "semantic_search": {
    "throttle": { "burst_items": 500, "pause_seconds": 10 }
  }
}
```

CLI args override config. Both `--burst` and `--pause` (or both config
keys) must be set to engage; passing one alone logs a warning and runs
without pacing.

### 2. Reactive retry-with-backoff

`OpenAIEmbeddingFunction.__call__` and `GeminiEmbeddingFunction.__call__`
/ `embed_query` are wrapped in `_with_retry`. Schedule: 30s → 60s → 120s,
3 attempts max. First wait is 30s (not 1s) because Gemini's TPM/RPM
windows are 60s.

Detector is intentionally narrow to avoid false positives:
- `getattr(exc, 'code', None) == 429`
- `getattr(exc, 'status_code', None) == 429`
- `'RESOURCE_EXHAUSTED' in str(exc)` or `'429' in str(exc)`
- `isinstance(exc, openai.RateLimitError)` (if openai SDK importable)

HuggingFace embeddings are untouched (local model, no API).

## Tests

New `tests/test_embedding_throttle.py` covers:

- `_is_rate_limit_error` recognizes code/status_code/canonical substring
  shapes; rejects arbitrary "rate limit" text without canonical markers.
- `_with_retry` recovers from a synthetic 429 within `max_attempts`,
  re-raises non-rate-limit errors immediately, gives up after exhausting
  attempts.
- Burst/pause loop pauses exactly 2× for 60 items at burst=25 (no final
  pause), exactly 1× for 50 items, and not at all when the flags aren't
  passed.

All 30 existing semantic tests (`test_semantic_stats.py`,
`test_semantic_search_quality.py`) still pass.

## Test plan

- [x] `pytest tests/test_embedding_throttle.py` — 7 new tests pass
- [x] `pytest tests/test_semantic_stats.py tests/test_semantic_search_quality.py` — 30 existing tests pass
- [x] `ruff check` on touched files — no new violations introduced
- [x] Verified end-to-end on real library (~Tier 1 Gemini key) with `--burst 500 --pause 10` — no more 429s during a `--fulltext` reindex
- [x] `zotero-mcp update-db --help` shows the new flags with documentation

## Notes for maintainer

- The `_with_retry` helper has no upper-bound timeout on individual sleeps
  beyond the max_attempts cap (so worst case: 30+60+120 = 210s extra wait
  before giving up). Happy to add a `max_total_sleep` if desired.
- If you'd prefer a single `--throttle "burst:pause"` flag over two flags,
  I can refactor.
- The detector swallows ImportError on `openai`; if you'd rather hard-require
  it, easy change.