### PR TITLE
Make add_by_url arXiv path resilient to arXiv outages (attach_mode=none + CrossRef fallback)

### DIFF
--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -894,7 +894,15 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
         # arXiv always has a free PDF — try to attach it
         pdf_url = f"https://arxiv.org/pdf/{arxiv_id}.pdf"
         pdf_status = "no PDF attached"
-        if attach_mode == "linked_url":
+        if attach_mode == "none":
+            # Honour the caller's explicit opt-out: skip the PDF download/upload
+            # entirely. Without this, the arXiv path always fetched + uploaded
+            # the PDF regardless of attach_mode (only "linked_url" was special-
+            # cased), so attach_mode="none" did far more network/cloud work than
+            # asked — a slow upload here is a prime candidate for wedging the
+            # process under the global API lock.
+            pdf_status = "skipped (attach_mode=none)"
+        elif attach_mode == "linked_url":
             # Bookmark the PDF URL only — no binary upload. Useful for users who
             # sync attachment files outside of Zotero's official storage (e.g. WebDAV).
             try:

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -813,28 +813,84 @@ def add_by_url(
 
 @with_zotero_api_lock
 def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto"):
-    """Add an arXiv paper by ID. Internal helper for add_by_url."""
+    """Add an arXiv paper by ID. Internal helper for add_by_url.
+
+    arXiv (export.arxiv.org) periodically sheds load — rate-limiting (429),
+    returning 5xx, or timing out outright. This helper degrades gracefully:
+    it retries transient failures with backoff, and if arXiv stays
+    unreachable it falls back to CrossRef via the arXiv DOI
+    (10.48550/arXiv.{id}), which serves the same metadata from independent
+    infrastructure. The fallback is best-effort — CrossRef may also lack a
+    very recent preprint — so a clear, actionable message is returned when
+    both routes fail, never a bare timeout.
+    """
     ctx.info(f"Fetching arXiv metadata for: {arxiv_id}")
 
     resp = None
+    last_error = None
     for attempt in range(3):
-        resp = requests.get(
-            f"https://export.arxiv.org/api/query?id_list={arxiv_id}",
-            timeout=30,
-        )
-        if resp.status_code == 429:
-            wait = 5 * (2 ** attempt)  # 5s, 10s, 20s
-            ctx.info(f"arXiv API rate limit hit — waiting {wait}s before retry {attempt + 1}/3...")
-            _time.sleep(wait)
+        try:
+            resp = requests.get(
+                f"https://export.arxiv.org/api/query?id_list={arxiv_id}",
+                timeout=20,
+            )
+        except requests.RequestException as e:
+            # Timeout / connection error — the classic "arXiv is overloaded"
+            # symptom. Retry with backoff rather than failing on the first miss.
+            last_error = e
+            resp = None
+            if attempt < 2:
+                wait = 3 * (2 ** attempt)  # 3s, 6s
+                ctx.info(
+                    f"arXiv API unreachable ({e}); retrying in {wait}s "
+                    f"({attempt + 1}/3)..."
+                )
+                _time.sleep(wait)
+            continue
+        # Retry rate-limits and server-side errors; 4xx (except 429) won't heal.
+        if resp.status_code == 429 or resp.status_code >= 500:
+            last_error = f"HTTP {resp.status_code}"
+            if attempt < 2:
+                wait = 5 * (2 ** attempt)  # 5s, 10s
+                ctx.info(
+                    f"arXiv API returned {resp.status_code}; retrying in {wait}s "
+                    f"({attempt + 1}/3)..."
+                )
+                _time.sleep(wait)
             continue
         break
 
-    if resp is None or resp.status_code == 429:
+    # arXiv exhausted its retries — fall back to CrossRef (independent infra).
+    if resp is None or resp.status_code == 429 or resp.status_code >= 500:
+        ctx.info(
+            f"arXiv unreachable after retries ({last_error}); "
+            f"falling back to CrossRef via the arXiv DOI."
+        )
+        arxiv_doi = f"10.48550/arXiv.{arxiv_id}"
+        try:
+            result = add_by_doi(
+                doi=arxiv_doi,
+                collections=collections,
+                tags=tags,
+                attach_mode=attach_mode,
+                ctx=ctx,
+            )
+        except Exception as e:  # noqa: BLE001 — fallback must not raise
+            result = None
+            ctx.info(f"CrossRef fallback errored: {e}")
+        # add_by_doi returns a human string; treat "not found"/"Error" as a miss.
+        if result and not result.startswith(("DOI not found", "Error")):
+            return result
         return (
-            f"arXiv API is rate-limiting requests. Please wait a moment and try again. "
+            f"arXiv is currently unreachable (last error: {last_error}) and the "
+            f"CrossRef fallback (DOI {arxiv_doi}) did not resolve it — this is "
+            f"often a transient arXiv overload. Please retry shortly. "
             f"(arXiv ID: {arxiv_id})"
         )
-    resp.raise_for_status()
+    try:
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        return f"arXiv API error for {arxiv_id}: {e}"
 
     root = ET.fromstring(resp.text)
     ns = {"atom": "http://www.w3.org/2005/Atom", "arxiv": "http://arxiv.org/schemas/atom"}

--- a/tests/test_add_by_url.py
+++ b/tests/test_add_by_url.py
@@ -311,12 +311,18 @@ class TestArxivErrors:
         assert "error" in result.lower() or "not found" in result.lower() or "no arxiv paper found" in result.lower()
 
     def test_timeout_on_arxiv_api(self, dummy_ctx, patch_write_client):
-        """Network timeout calling arXiv API should return an error."""
+        """Network timeout + a failing CrossRef fallback should return a clear,
+        non-crashing error (and create nothing)."""
         import requests as req_lib
 
-        with patch(
+        # arXiv times out on every attempt; the CrossRef fallback (which goes
+        # through add_by_doi) also can't resolve. Patch sleep so retries are fast.
+        with patch("zotero_mcp.tools.write._time.sleep"), patch(
             "zotero_mcp.tools.write.requests.get",
             side_effect=req_lib.exceptions.Timeout("Connection timed out"),
+        ), patch(
+            "zotero_mcp.tools.write.add_by_doi",
+            return_value="DOI not found on CrossRef: 10.48550/arXiv.2401.00001",
         ):
             result = server.add_by_url(
                 url="https://arxiv.org/abs/2401.00001",
@@ -324,7 +330,100 @@ class TestArxivErrors:
             )
 
         assert patch_write_client.created == []
-        assert "error" in result.lower() or "timeout" in result.lower()
+        assert "error" in result.lower() or "unreachable" in result.lower()
+
+
+class TestArxivCrossrefFallback:
+    """When arXiv (export.arxiv.org) is overloaded, _add_by_arxiv should fall
+    back to CrossRef via the arXiv DOI (10.48550/arXiv.{id}) — independent
+    infrastructure — rather than failing. Regression coverage for graceful
+    degradation during arXiv outages.
+    """
+
+    def test_timeout_falls_back_to_crossref(self, dummy_ctx, patch_write_client):
+        """arXiv timeout → delegate to add_by_doi with the arXiv DOI; surface its result."""
+        import requests as req_lib
+
+        with patch("zotero_mcp.tools.write._time.sleep"), patch(
+            "zotero_mcp.tools.write.requests.get",
+            side_effect=req_lib.exceptions.Timeout("timed out"),
+        ), patch(
+            "zotero_mcp.tools.write.add_by_doi",
+            return_value="Successfully added: **Attention Is All You Need**",
+        ) as mock_doi:
+            result = server.add_by_url(
+                url="https://arxiv.org/abs/2401.00001",
+                collections=["ABC12345"],
+                tags=["t1"],
+                ctx=dummy_ctx,
+            )
+
+        # Fallback fired with the arXiv DOI and forwarded collections/tags.
+        mock_doi.assert_called_once()
+        kwargs = mock_doi.call_args.kwargs
+        assert kwargs.get("doi") == "10.48550/arXiv.2401.00001"
+        assert kwargs.get("collections") == ["ABC12345"]
+        assert kwargs.get("tags") == ["t1"]
+        # The successful CrossRef result is surfaced to the caller.
+        assert "Successfully added" in result
+
+    def test_503_falls_back_to_crossref(self, dummy_ctx, patch_write_client):
+        """A persistent 5xx from arXiv should also trigger the CrossRef fallback."""
+        mock_resp = _make_arxiv_response("", status_code=503)
+
+        with patch("zotero_mcp.tools.write._time.sleep"), patch(
+            "zotero_mcp.tools.write.requests.get", return_value=mock_resp
+        ), patch(
+            "zotero_mcp.tools.write.add_by_doi",
+            return_value="Successfully added: **Paper**",
+        ) as mock_doi:
+            result = server.add_by_url(
+                url="https://arxiv.org/abs/2401.00001",
+                ctx=dummy_ctx,
+            )
+
+        mock_doi.assert_called_once()
+        assert mock_doi.call_args.kwargs.get("doi") == "10.48550/arXiv.2401.00001"
+        assert "Successfully added" in result
+
+    def test_both_routes_fail_returns_actionable_message(self, dummy_ctx, patch_write_client):
+        """arXiv down AND CrossRef miss → a clear retry message, nothing created, no raise."""
+        import requests as req_lib
+
+        with patch("zotero_mcp.tools.write._time.sleep"), patch(
+            "zotero_mcp.tools.write.requests.get",
+            side_effect=req_lib.exceptions.ConnectionError("conn refused"),
+        ), patch(
+            "zotero_mcp.tools.write.add_by_doi",
+            return_value="DOI not found on CrossRef: 10.48550/arXiv.2401.00001",
+        ):
+            result = server.add_by_url(
+                url="https://arxiv.org/abs/2401.00001",
+                ctx=dummy_ctx,
+            )
+
+        assert patch_write_client.created == []
+        assert "unreachable" in result.lower()
+        assert "retry" in result.lower()
+
+    def test_crossref_fallback_exception_is_caught(self, dummy_ctx, patch_write_client):
+        """If the fallback itself raises, _add_by_arxiv must not propagate it."""
+        import requests as req_lib
+
+        with patch("zotero_mcp.tools.write._time.sleep"), patch(
+            "zotero_mcp.tools.write.requests.get",
+            side_effect=req_lib.exceptions.Timeout("timed out"),
+        ), patch(
+            "zotero_mcp.tools.write.add_by_doi",
+            side_effect=RuntimeError("crossref blew up"),
+        ):
+            result = server.add_by_url(
+                url="https://arxiv.org/abs/2401.00001",
+                ctx=dummy_ctx,
+            )
+
+        assert patch_write_client.created == []
+        assert "unreachable" in result.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Make `zotero_add_by_url`'s arXiv path resilient to arXiv (`export.arxiv.org`) overloads, which have been frequent lately (429s, 5xx, timeouts). Two related fixes:

1. **Honor `attach_mode="none"` on the arXiv path.** `_add_by_arxiv` special-cased only `"linked_url"`; every other value — including the explicit opt-out `"none"` — fell through to the branch that always downloads `arxiv.org/pdf/{id}.pdf` and uploads it to Zotero cloud storage. So a metadata-only request still did a full PDF fetch + upload.

2. **Degrade gracefully when arXiv is unreachable.** Previously the metadata fetch retried *only* HTTP 429 — a timeout or connection error raised on the first miss, with no fallback. Now it:
   - retries transient failures (timeout, connection error, 5xx) with backoff, not just 429;
   - falls back to **CrossRef via the arXiv DOI** (`10.48550/arXiv.{id}`) by delegating to `add_by_doi` when arXiv stays unreachable — independent infrastructure serving the same metadata;
   - never raises from the fallback; when both routes fail it returns a clear "arXiv unreachable, please retry" message naming the cause, instead of a bare timeout/traceback.

## Why

During an arXiv overload, `add_by_url` on an `arxiv.org/abs/...` link would hang or hard-fail even though the same paper resolves fine through CrossRef. This mirrors a fallback our downstream CLI already relies on.

## Testing

`tests/test_add_by_url.py`: added `TestArxivCrossrefFallback` (timeout→CrossRef, 503→CrossRef, both-routes-fail→actionable message, fallback-raises→caught) and a `TestArxivAttachMode` case for `attach_mode="none"`; updated the existing timeout test for the new fallback path. Retry `sleep` is patched so tests stay fast. Full suite green locally (100 passed across add_by_url / add_by_doi / regression / v021).
