### PR TITLE
Bound the global API lock so a stuck op can't wedge every tool (fix opaque -32001 timeouts)

### DIFF
--- a/src/zotero_mcp/client.py
+++ b/src/zotero_mcp/client.py
@@ -30,13 +30,64 @@ load_dotenv()
 # of at the API (seconds/timeout). RLock allows nested calls from the same thread.
 _zotero_api_lock = threading.RLock()
 
+# Bound how long a tool will WAIT to acquire the lock before giving up. Without a
+# bound, a single slow/stuck op (e.g. a hung cloud write or PDF upload) holds the
+# lock and every other tool — reads included — blocks behind it until FastMCP's
+# ~60s client timeout fires, surfacing as an opaque "-32001 Request timed out" on
+# every queued call. A bounded acquire turns that into a fast, actionable error
+# for the *waiters* while leaving the in-flight op untouched. Keep this safely
+# below the client timeout. Override via ZOTERO_MCP_LOCK_TIMEOUT (seconds; <=0
+# restores the old unbounded behaviour).
+_DEFAULT_LOCK_TIMEOUT = 45.0
+
+
+def _lock_timeout() -> float:
+    raw = os.getenv("ZOTERO_MCP_LOCK_TIMEOUT", "").strip()
+    if not raw:
+        return _DEFAULT_LOCK_TIMEOUT
+    try:
+        return float(raw)
+    except ValueError:
+        return _DEFAULT_LOCK_TIMEOUT
+
+
+class ZoteroApiBusyError(RuntimeError):
+    """Raised when the per-process Zotero API lock can't be acquired in time.
+
+    Signals that another Zotero operation is still in flight (likely slow or
+    stuck) — not that this call itself failed. Callers should surface a clear,
+    retryable message rather than letting the request hang to a timeout.
+    """
+
 
 def with_zotero_api_lock(func):
-    """Serialize Zotero API access across concurrent MCP tool threads."""
+    """Serialize Zotero API access across concurrent MCP tool threads.
+
+    Acquires the shared RLock with a bounded wait so a stuck op can't wedge
+    every other tool into an opaque client timeout. The lock is reentrant, so
+    nested decorated calls on the same thread (e.g. add_by_url -> add_by_doi)
+    acquire instantly and are never blocked by this bound.
+    """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        with _zotero_api_lock:
+        timeout = _lock_timeout()
+        if timeout <= 0:
+            # Opt-out: original unbounded behaviour.
+            with _zotero_api_lock:
+                return func(*args, **kwargs)
+        acquired = _zotero_api_lock.acquire(timeout=timeout)
+        if not acquired:
+            raise ZoteroApiBusyError(
+                f"Another Zotero API operation is still in progress and did not "
+                f"release within {timeout:.0f}s. This usually means a previous "
+                f"call is slow or stuck (e.g. a large PDF upload or an "
+                f"unreachable Zotero cloud). Please retry shortly; if it "
+                f"persists, restart the Zotero MCP server."
+            )
+        try:
             return func(*args, **kwargs)
+        finally:
+            _zotero_api_lock.release()
     return wrapper
 
 

--- a/tests/test_api_lock_bounded.py
+++ b/tests/test_api_lock_bounded.py
@@ -1,0 +1,149 @@
+"""Tests for the bounded Zotero API lock (with_zotero_api_lock).
+
+Regression coverage for the wedge where one stuck op holding the process-global
+RLock made every other tool block until FastMCP's ~60s client timeout, surfacing
+as an opaque "-32001 Request timed out" on reads too. The lock now acquires with
+a bounded wait and raises ZoteroApiBusyError for waiters instead of hanging.
+"""
+
+import threading
+import time
+
+import pytest
+
+from zotero_mcp import client as _client
+from zotero_mcp.client import (
+    ZoteroApiBusyError,
+    with_zotero_api_lock,
+    _zotero_api_lock,
+)
+
+
+def test_uncontended_call_runs(monkeypatch):
+    """With no contention the wrapped function runs and returns normally."""
+    monkeypatch.setenv("ZOTERO_MCP_LOCK_TIMEOUT", "5")
+
+    @with_zotero_api_lock
+    def f(x):
+        return x + 1
+
+    assert f(41) == 42
+
+
+def test_reentrant_same_thread(monkeypatch):
+    """Nested decorated calls on one thread acquire the reentrant lock instantly."""
+    monkeypatch.setenv("ZOTERO_MCP_LOCK_TIMEOUT", "5")
+
+    @with_zotero_api_lock
+    def inner():
+        return "inner-ok"
+
+    @with_zotero_api_lock
+    def outer():
+        # Simulates add_by_url -> add_by_doi: a decorated call within a decorated call.
+        return inner()
+
+    assert outer() == "inner-ok"
+
+
+def test_waiter_fails_fast_when_lock_held(monkeypatch):
+    """A second thread gives up with ZoteroApiBusyError instead of hanging."""
+    monkeypatch.setenv("ZOTERO_MCP_LOCK_TIMEOUT", "0.3")
+
+    holder_has_lock = threading.Event()
+    release_holder = threading.Event()
+
+    def holder():
+        with _zotero_api_lock:
+            holder_has_lock.set()
+            # Hold past the waiter's bounded acquire window.
+            release_holder.wait(timeout=5)
+
+    t = threading.Thread(target=holder)
+    t.start()
+    assert holder_has_lock.wait(timeout=2), "holder never acquired the lock"
+
+    @with_zotero_api_lock
+    def blocked():
+        return "should-not-run"
+
+    start = time.monotonic()
+    with pytest.raises(ZoteroApiBusyError):
+        blocked()
+    elapsed = time.monotonic() - start
+
+    # Failed fast around the 0.3s bound, nowhere near a 60s client timeout.
+    assert elapsed < 3, f"waiter blocked too long: {elapsed:.1f}s"
+
+    release_holder.set()
+    t.join(timeout=5)
+
+
+def test_lock_released_after_busy_error(monkeypatch):
+    """A timed-out acquire must NOT leave the lock held by the waiter."""
+    monkeypatch.setenv("ZOTERO_MCP_LOCK_TIMEOUT", "0.3")
+
+    holder_has_lock = threading.Event()
+    release_holder = threading.Event()
+
+    def holder():
+        with _zotero_api_lock:
+            holder_has_lock.set()
+            release_holder.wait(timeout=5)
+
+    t = threading.Thread(target=holder)
+    t.start()
+    assert holder_has_lock.wait(timeout=2)
+
+    @with_zotero_api_lock
+    def blocked():
+        return "x"
+
+    with pytest.raises(ZoteroApiBusyError):
+        blocked()
+
+    # Let the holder release; the lock must now be fully free.
+    release_holder.set()
+    t.join(timeout=5)
+
+    @with_zotero_api_lock
+    def after():
+        return "after-ok"
+
+    assert after() == "after-ok"
+
+
+def test_zero_timeout_opt_out_blocks_until_free(monkeypatch):
+    """ZOTERO_MCP_LOCK_TIMEOUT<=0 restores unbounded behaviour (waits, no raise)."""
+    monkeypatch.setenv("ZOTERO_MCP_LOCK_TIMEOUT", "0")
+
+    holder_has_lock = threading.Event()
+    release_holder = threading.Event()
+
+    def holder():
+        with _zotero_api_lock:
+            holder_has_lock.set()
+            release_holder.wait(timeout=5)
+
+    t = threading.Thread(target=holder)
+    t.start()
+    assert holder_has_lock.wait(timeout=2)
+
+    result = {}
+
+    @with_zotero_api_lock
+    def waiter():
+        result["ran"] = True
+        return "ran"
+
+    w = threading.Thread(target=lambda: result.setdefault("rv", waiter()))
+    w.start()
+
+    # Briefly: waiter should still be blocked (no ZoteroApiBusyError raised).
+    time.sleep(0.5)
+    assert "ran" not in result, "opt-out should block, not fail fast"
+
+    release_holder.set()
+    w.join(timeout=5)
+    t.join(timeout=5)
+    assert result.get("ran") is True


### PR DESCRIPTION
## Summary

Bound the process-global Zotero API lock so a single slow/stuck operation can't wedge every other tool into an opaque client timeout.

## Problem

Every tool serializes on a process-global `threading.RLock` (`client.py`), because the Zotero local API (port 23119) is single-threaded. But the acquire was **unbounded**. If one operation got slow or stuck — a hung cloud write, a large PDF upload, an unreachable `api.zotero.org` — it held the lock and **every other tool, reads included, blocked behind it** until FastMCP's ~60s client timeout fired. The symptom is an opaque `-32001 Request timed out` on calls that never even started executing, with nothing pointing at the *prior* operation as the real culprit. (We hit this in practice: a single stuck `add_by_url` made every subsequent read time out too.)

## Fix

Acquire the lock with a bounded wait (default **45s**, safely under the client timeout; configurable via `ZOTERO_MCP_LOCK_TIMEOUT`, `<=0` restores the old unbounded behaviour). A waiter that can't acquire in time now raises a clear, retryable `ZoteroApiBusyError` that names the likely cause, instead of hanging to an opaque timeout.

- The **in-flight** operation is untouched — this only changes how *waiters* behave.
- `RLock` reentrancy is preserved, so nested decorated calls on the same thread (e.g. `add_by_url` → `add_by_doi`) still acquire instantly and are never subject to the bound.

This doesn't fix a stuck op itself (per-call network timeouts are a separate concern), but it stops one stuck op from taking the whole server down with it, and it makes the failure legible.

## Testing

New `tests/test_api_lock_bounded.py`: uncontended call, same-thread reentrancy, waiter-fails-fast-when-held (and fails in ~0.3s, not ~60s), lock-released-after-busy-error, and the zero-timeout opt-out. Full suite: **815 passed** (up from 810), with the same 5 pre-existing failures in `test_lifespan` / `test_place_field_reads` that also fail on a clean `main` (unrelated — `FakeZotero` lacks a `.client` attribute).
