### PR TITLE
Add zotero_get_page_layout tool for figure/table region detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ zotero_remove_item_relation(
 - `zotero_get_notes`: Retrieve notes from your Zotero library
 - `zotero_search_notes`: Search in notes and annotations (including PDF-extracted)
 - `zotero_create_note`: Create a new note for an item (beta feature)
+- `zotero_get_page_layout`: Detect figure/table regions on a PDF page (with captions and normalized coordinates) for accurate area annotation placement
 
 ### 📊 Scite Citation Intelligence Tools
 - `scite_enrich_item`: Get Scite citation tallies and retraction alerts for a paper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ semantic = [
     "tiktoken>=0.7.0",
 ]
 pdf = [
-    "pymupdf>=1.24.0",
+    # >=1.24.2 for Page.cluster_drawings (vector figure detection in zotero_get_page_layout)
+    "pymupdf>=1.24.2",
     "ebooklib>=0.18",
 ]
 scite = [

--- a/src/zotero_mcp/pdf_layout.py
+++ b/src/zotero_mcp/pdf_layout.py
@@ -1,0 +1,499 @@
+"""
+PDF page layout detection for area annotation coordinate grounding.
+
+Detects candidate figure/table regions on a PDF page so that area
+annotations (zotero_create_area_annotation) can be placed on real detected
+content instead of guessed coordinates.
+
+Detection sources (all PyMuPDF):
+- raster images: page.get_image_info()
+- vector graphics: page.cluster_drawings() (PyMuPDF >= 1.24.2)
+- tables: page.find_tables()
+- captions: text blocks matching "Figure N:" / "Table N:" patterns
+
+Pipeline: collect raw candidates -> filter noise -> merge fragments ->
+de-duplicate -> associate captions by spatial scoring.
+
+Known limitation: detection is geometric, not semantic. Detected boxes
+cover the graphical core of a figure/table; text labels inside figures and
+unruled table header rows may fall outside the box.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Region filtering / merging thresholds (normalized page units)
+LAYOUT_MIN_REGION_AREA = 0.01       # drop regions smaller than 1% of page area
+LAYOUT_MAX_REGION_AREA = 0.95       # drop page-wide background artifacts
+LAYOUT_MERGE_GAP = 0.02             # merge fragments closer than 2% of page size
+LAYOUT_DEDUP_IOU = 0.8              # near-identical regions are duplicates
+LAYOUT_CAPTION_MAX_DISTANCE = 0.15  # max caption-to-region vertical gap
+LAYOUT_CAPTION_MIN_OVERLAP = 0.3    # min horizontal overlap ratio (column guard)
+
+# Source priority when de-duplicating overlapping detections
+_LAYOUT_SOURCE_PRIORITY = {"table": 3, "image": 2, "drawing": 1, "merged": 0}
+
+# Real captions start a text block with "Figure N:", "Fig. N.", "Table N:" etc.
+# The trailing [.:] separator requirement rejects in-text sentences such as
+# "Figure 3 shows the results".
+_CAPTION_PATTERN = re.compile(
+    r"^(?P<prefix>(?:Extended\s+Data\s+)?(?:Figure|Fig\.?|Table))\s+"
+    r"(?P<number>[A-Za-z]?\d+[a-z]?)\s*[.:]\s+",
+    re.IGNORECASE,
+)
+
+
+def _parse_caption_block(text: str) -> dict | None:
+    """
+    Parse a text block as a figure/table caption.
+
+    Args:
+        text: Full text of a PDF text block
+
+    Returns:
+        {"label": "Figure 3", "kind": "figure" | "table", "text": <block text>}
+        or None if the block is not a caption.
+    """
+    if not text:
+        return None
+
+    stripped = text.strip()
+    match = _CAPTION_PATTERN.match(stripped)
+    if not match:
+        return None
+
+    prefix = match.group("prefix")
+    kind = "table" if "tab" in prefix.lower() else "figure"
+    return {
+        "label": f"{prefix} {match.group('number')}",
+        "kind": kind,
+        "text": stripped,
+    }
+
+
+def _bbox_iou(box_a: list[float], box_b: list[float]) -> float:
+    """Intersection-over-union of two normalized [x, y, width, height] boxes."""
+    ax, ay, aw, ah = box_a
+    bx, by, bw, bh = box_b
+
+    inter_x1 = max(ax, bx)
+    inter_y1 = max(ay, by)
+    inter_x2 = min(ax + aw, bx + bw)
+    inter_y2 = min(ay + ah, by + bh)
+
+    if inter_x2 <= inter_x1 or inter_y2 <= inter_y1:
+        return 0.0
+
+    intersection = (inter_x2 - inter_x1) * (inter_y2 - inter_y1)
+    union = aw * ah + bw * bh - intersection
+    if union <= 0:
+        return 0.0
+    return intersection / union
+
+
+def _bbox_union(box_a: list[float], box_b: list[float]) -> list[float]:
+    """Smallest [x, y, width, height] box containing both boxes."""
+    ax, ay, aw, ah = box_a
+    bx, by, bw, bh = box_b
+
+    x1 = min(ax, bx)
+    y1 = min(ay, by)
+    x2 = max(ax + aw, bx + bw)
+    y2 = max(ay + ah, by + bh)
+    return [x1, y1, x2 - x1, y2 - y1]
+
+
+def _boxes_overlap_or_near(
+    box_a: list[float],
+    box_b: list[float],
+    gap: float,
+) -> bool:
+    """True if two boxes overlap or are within `gap` of each other on both axes."""
+    ax, ay, aw, ah = box_a
+    bx, by, bw, bh = box_b
+
+    return not (
+        bx > ax + aw + gap
+        or bx + bw < ax - gap
+        or by > ay + ah + gap
+        or by + bh < ay - gap
+    )
+
+
+def _horizontal_overlap_ratio(box_a: list[float], box_b: list[float]) -> float:
+    """Overlap of two boxes' x-ranges, relative to the narrower box."""
+    ax, _, aw, _ = box_a
+    bx, _, bw, _ = box_b
+
+    overlap = min(ax + aw, bx + bw) - max(ax, bx)
+    if overlap <= 0:
+        return 0.0
+    narrower = min(aw, bw)
+    if narrower <= 0:
+        return 0.0
+    return overlap / narrower
+
+
+def _merge_candidate_regions(
+    regions: list[dict],
+    *,
+    min_area: float = LAYOUT_MIN_REGION_AREA,
+    max_area: float = LAYOUT_MAX_REGION_AREA,
+    gap: float = LAYOUT_MERGE_GAP,
+    dedup_iou: float = LAYOUT_DEDUP_IOU,
+) -> list[dict]:
+    """
+    Filter noise, de-duplicate, and merge fragmented candidate regions.
+
+    Composite figures often appear as multiple raster/vector fragments
+    (plot body, axis labels, legend). Overlapping or near-adjacent
+    image/drawing fragments are merged into one region. Tables detected by
+    find_tables are kept intact (already semantic).
+
+    Args:
+        regions: [{"source": "image" | "drawing" | "table", "bbox": [x, y, w, h]}]
+                 with bboxes normalized to [0, 1]
+
+    Returns:
+        Cleaned region list, sorted top-to-bottom then left-to-right.
+        Regions produced by merging fragments get source "merged".
+    """
+    # 1. Drop noise: tiny logos/icons/rules and page-wide background artifacts
+    kept = []
+    for region in regions:
+        _, _, width, height = region["bbox"]
+        area = width * height
+        if area < min_area or area > max_area:
+            continue
+        kept.append({"source": region["source"], "bbox": list(region["bbox"])})
+
+    # 2. De-duplicate near-identical detections, keeping the
+    #    highest-priority source (e.g. a table found by both find_tables
+    #    and cluster_drawings keeps the "table" source)
+    deduped: list[dict] = []
+    for region in sorted(
+        kept,
+        key=lambda r: _LAYOUT_SOURCE_PRIORITY.get(r["source"], 0),
+        reverse=True,
+    ):
+        if any(
+            _bbox_iou(region["bbox"], existing["bbox"]) > dedup_iou
+            for existing in deduped
+        ):
+            continue
+        deduped.append(region)
+
+    # 3. Merge overlapping / near-adjacent image and drawing fragments
+    #    to a fixed point. Tables do not participate in merging.
+    fixed = [r for r in deduped if r["source"] == "table"]
+    mergeable = [r for r in deduped if r["source"] != "table"]
+
+    while True:
+        merged_any = False
+        merged: list[dict] = []
+        for region in mergeable:
+            target = None
+            for existing in merged:
+                if _boxes_overlap_or_near(region["bbox"], existing["bbox"], gap):
+                    target = existing
+                    break
+            if target is None:
+                merged.append(region)
+            else:
+                target["bbox"] = _bbox_union(target["bbox"], region["bbox"])
+                target["source"] = "merged"
+                merged_any = True
+        mergeable = merged
+        if not merged_any:
+            break
+
+    result = fixed + mergeable
+    result.sort(key=lambda r: (r["bbox"][1], r["bbox"][0]))
+    return result
+
+
+def _associate_captions_with_regions(
+    regions: list[dict],
+    captions: list[dict],
+    *,
+    max_distance: float = LAYOUT_CAPTION_MAX_DISTANCE,
+    min_overlap: float = LAYOUT_CAPTION_MIN_OVERLAP,
+) -> list[dict]:
+    """
+    Attach captions to regions by spatial scoring.
+
+    Score components:
+    - vertical proximity (hard cutoff at max_distance)
+    - horizontal x-range overlap (hard cutoff at min_overlap — this is the
+      guard that keeps two-column layouts from cross-attaching)
+    - type prior: figure captions conventionally sit below figures, table
+      captions above tables (a score bonus, not a hard rule)
+
+    Each caption attaches to at most one region and vice versa (best score
+    wins, greedy assignment).
+
+    Args:
+        regions: [{"source": ..., "bbox": [x, y, w, h]}]
+        captions: [{"label": ..., "kind": ..., "text": ..., "bbox": [x, y, w, h]}]
+
+    Returns:
+        New list of region dicts (same order) augmented with caption_label,
+        caption_text, and confidence ("high" | "medium" | "low").
+    """
+    result = []
+    for region in regions:
+        augmented = dict(region)
+        augmented["caption_label"] = None
+        augmented["caption_text"] = None
+        augmented["confidence"] = "low"
+        result.append(augmented)
+
+    if not result or not captions:
+        return result
+
+    # Score every (caption, region) pair that passes the hard cutoffs
+    candidates: list[tuple[float, int, int]] = []
+    for c_idx, caption in enumerate(captions):
+        c_x, c_y, c_w, c_h = caption["bbox"]
+        for r_idx, region in enumerate(result):
+            r_x, r_y, r_w, r_h = region["bbox"]
+
+            overlap = _horizontal_overlap_ratio(caption["bbox"], region["bbox"])
+            if overlap < min_overlap:
+                continue
+
+            below_gap = c_y - (r_y + r_h)   # >= 0 when caption is below region
+            above_gap = r_y - (c_y + c_h)   # >= 0 when caption is above region
+            if below_gap >= 0:
+                vertical_gap, position = below_gap, "below"
+            elif above_gap >= 0:
+                vertical_gap, position = above_gap, "above"
+            else:
+                vertical_gap, position = 0.0, "overlapping"
+
+            if vertical_gap > max_distance:
+                continue
+
+            proximity = 1.0 - (vertical_gap / max_distance)
+            prior = 0.0
+            if caption["kind"] == "figure" and position == "below":
+                prior = 1.0
+            elif caption["kind"] == "table" and position == "above":
+                prior = 1.0
+
+            score = proximity * 0.5 + overlap * 0.3 + prior * 0.2
+            candidates.append((score, c_idx, r_idx))
+
+    # Greedy assignment: best score first, each caption/region used once
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    used_captions: set[int] = set()
+    used_regions: set[int] = set()
+    for score, c_idx, r_idx in candidates:
+        if c_idx in used_captions or r_idx in used_regions:
+            continue
+        used_captions.add(c_idx)
+        used_regions.add(r_idx)
+
+        caption = captions[c_idx]
+        result[r_idx]["caption_label"] = caption["label"]
+        result[r_idx]["caption_text"] = caption["text"]
+
+        # Confidence reflects the margin over competing assignments
+        competing = [s for s, ci, ri in candidates if ci == c_idx and ri != r_idx]
+        if not competing or score - max(competing) >= 0.15:
+            result[r_idx]["confidence"] = "high"
+        else:
+            result[r_idx]["confidence"] = "medium"
+
+    return result
+
+
+def detect_page_regions(pdf_path: str, page_num: int) -> dict:
+    """
+    Detect candidate figure/table regions on a PDF page.
+
+    Provides coordinate grounding for area annotations: instead of guessing
+    normalized coordinates, callers can pick from real detected regions.
+
+    Detection sources:
+    - raster images: page.get_image_info()
+    - vector graphics: page.cluster_drawings() (PyMuPDF >= 1.24.2)
+    - tables: page.find_tables()
+    - captions: text blocks matching "Figure N:" / "Table N:" patterns
+
+    Args:
+        pdf_path: Path to the PDF file
+        page_num: 1-indexed page number
+
+    Returns:
+        On success:
+            {
+                "pageIndex": int,        # 0-indexed
+                "pageLabel": str,
+                "regions": [
+                    {
+                        "region_id": int,
+                        "source": "image" | "drawing" | "table" | "merged",
+                        "bbox": [x, y, width, height],   # normalized [0, 1]
+                        "caption_label": str | None,
+                        "caption_text": str | None,
+                        "confidence": "high" | "medium" | "low",
+                    },
+                    ...
+                ],
+                "warnings": [str, ...],
+            }
+
+        On failure:
+            {"error": str}
+    """
+    try:
+        import fitz
+    except ImportError:
+        raise ImportError(
+            "PDF layout detection requires PyMuPDF. "
+            "Install it with: pip install zotero-mcp-server[pdf]"
+        )
+
+    try:
+        doc = fitz.open(pdf_path)
+    except Exception as e:
+        return {"error": f"Could not open PDF: {e}"}
+
+    try:
+        if not doc.is_pdf:
+            return {"error": "File is not a valid PDF"}
+
+        target_index = page_num - 1
+        total_pages = len(doc)
+        if target_index < 0 or target_index >= total_pages:
+            return {
+                "error": f"Page {page_num} out of range (PDF has {total_pages} pages)",
+            }
+
+        page = doc[target_index]
+        page_width = page.rect.width
+        page_height = page.rect.height
+        if page_width <= 0 or page_height <= 0:
+            return {"error": f"Page {page_num} has invalid dimensions"}
+
+        def normalize_bbox(x0: float, y0: float, x1: float, y1: float) -> list[float]:
+            """Convert page coordinates to clamped normalized [x, y, w, h]."""
+            x = min(max(x0 / page_width, 0.0), 1.0)
+            y = min(max(y0 / page_height, 0.0), 1.0)
+            w = min(max((x1 - x0) / page_width, 0.0), 1.0 - x)
+            h = min(max((y1 - y0) / page_height, 0.0), 1.0 - y)
+            return [x, y, w, h]
+
+        warnings: list[str] = []
+        raw_regions: list[dict] = []
+
+        # --- Raster images ---
+        try:
+            for info in page.get_image_info():
+                x0, y0, x1, y1 = info["bbox"]
+                raw_regions.append(
+                    {"source": "image", "bbox": normalize_bbox(x0, y0, x1, y1)}
+                )
+        except Exception:
+            pass
+
+        # --- Vector graphics (clustered) ---
+        if hasattr(page, "cluster_drawings"):
+            try:
+                for rect in page.cluster_drawings():
+                    raw_regions.append(
+                        {
+                            "source": "drawing",
+                            "bbox": normalize_bbox(rect.x0, rect.y0, rect.x1, rect.y1),
+                        }
+                    )
+            except Exception:
+                pass
+        else:
+            warnings.append(
+                "Vector graphics detection requires pymupdf>=1.24.2; "
+                "showing raster images and tables only."
+            )
+
+        # --- Tables ---
+        try:
+            for table in page.find_tables().tables:
+                x0, y0, x1, y1 = table.bbox
+                raw_regions.append(
+                    {"source": "table", "bbox": normalize_bbox(x0, y0, x1, y1)}
+                )
+        except Exception:
+            pass
+
+        # --- Text blocks (for captions and scanned-page detection) ---
+        text_blocks: list[dict] = []
+        try:
+            for block in page.get_text("blocks"):
+                x0, y0, x1, y1, block_text, _block_no, block_type = block[:7]
+                if block_type == 0 and block_text.strip():
+                    text_blocks.append(
+                        {
+                            "bbox": normalize_bbox(x0, y0, x1, y1),
+                            "text": block_text.strip(),
+                        }
+                    )
+        except Exception:
+            pass
+
+        # Scanned page: a page-covering image with no text layer is a scan,
+        # not an annotatable figure
+        full_page_images = [
+            r
+            for r in raw_regions
+            if r["source"] == "image"
+            and r["bbox"][2] * r["bbox"][3] > LAYOUT_MAX_REGION_AREA
+        ]
+        if full_page_images and not text_blocks:
+            warnings.append(
+                "Page appears to be a full-page scan — region detection and "
+                "captions are unavailable."
+            )
+            return {
+                "pageIndex": target_index,
+                "pageLabel": _page_label_or_default(page, page_num),
+                "regions": [],
+                "warnings": warnings,
+            }
+
+        # --- Captions ---
+        captions: list[dict] = []
+        for block in text_blocks:
+            parsed = _parse_caption_block(block["text"])
+            if parsed:
+                captions.append({**parsed, "bbox": block["bbox"]})
+
+        # --- Pipeline: filter/merge/dedupe, then attach captions ---
+        regions = _merge_candidate_regions(raw_regions)
+        regions = _associate_captions_with_regions(regions, captions)
+
+        for idx, region in enumerate(regions, start=1):
+            region["region_id"] = idx
+            region["bbox"] = [round(value, 4) for value in region["bbox"]]
+
+        return {
+            "pageIndex": target_index,
+            "pageLabel": _page_label_or_default(page, page_num),
+            "regions": regions,
+            "warnings": warnings,
+        }
+
+    finally:
+        doc.close()
+
+
+def _page_label_or_default(page, page_num: int) -> str:
+    """Return the page's printed label, falling back to the 1-indexed number."""
+    try:
+        label = page.get_label()
+        if label:
+            return label
+    except Exception:
+        pass
+    return str(page_num)

--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -94,6 +94,7 @@ from zotero_mcp.tools.annotations import (  # noqa: F401
     delete_note,
     create_annotation,
     create_area_annotation,
+    get_page_layout,
     update_annotation,
     delete_annotation,
 )

--- a/src/zotero_mcp/tools/annotations.py
+++ b/src/zotero_mcp/tools/annotations.py
@@ -1661,6 +1661,172 @@ def create_area_annotation(
         return f"Error creating area annotation: {str(e)}"
 
 
+def _format_page_layout(
+    layout: dict,
+    attachment_key: str,
+    page: int,
+    filename: str,
+) -> str:
+    """Render detect_page_regions output as markdown for the LLM."""
+    regions = layout["regions"]
+    warnings = layout.get("warnings", [])
+    page_label = layout.get("pageLabel", str(page))
+
+    lines = [
+        f"# Page layout: {filename}, page {page} (label: {page_label})",
+        "",
+    ]
+
+    for warning in warnings:
+        lines.append(f"**Warning:** {warning}")
+    if warnings:
+        lines.append("")
+
+    if not regions:
+        lines.append(
+            f"No figure/table regions detected on page {page}. "
+            "The page may be text-only or a scanned image. "
+            "You can still create an area annotation by passing explicit coordinates."
+        )
+        return "\n".join(lines)
+
+    plural = "s" if len(regions) != 1 else ""
+    lines.extend([
+        f"**{len(regions)} region{plural} detected.**",
+        "",
+        "| # | source | x | y | width | height | caption | confidence |",
+        "|---|--------|---|---|-------|--------|---------|------------|",
+    ])
+
+    for region in regions:
+        x, y, width, height = region["bbox"]
+        caption = region.get("caption_text") or "(none)"
+        if len(caption) > 80:
+            caption = caption[:77] + "..."
+        caption = caption.replace("|", "\\|").replace("\n", " ")
+        lines.append(
+            f"| {region['region_id']} | {region['source']} | {x:.4f} | {y:.4f} "
+            f"| {width:.4f} | {height:.4f} | {caption} | {region['confidence']} |"
+        )
+
+    first_x, first_y, first_w, first_h = regions[0]["bbox"]
+    lines.extend([
+        "",
+        "To annotate a region, pass its coordinates to "
+        "zotero_create_area_annotation — e.g. for region 1:",
+        "```",
+        f"zotero_create_area_annotation(attachment_key='{attachment_key}', "
+        f"page={page}, x={first_x:.4f}, y={first_y:.4f}, "
+        f"width={first_w:.4f}, height={first_h:.4f}, comment='...')",
+        "```",
+    ])
+
+    return "\n".join(lines)
+
+
+@mcp.tool(
+    name="zotero_get_page_layout",
+    description=(
+        "Detect candidate figure/table regions on a PDF page and return "
+        "their normalized bounding boxes, so area annotations can be placed "
+        "on detected content instead of guessed positions. ALWAYS call this "
+        "before zotero_create_area_annotation unless exact coordinates are "
+        "already known. Returns each region's bounding box (x, y, width, "
+        "height in [0, 1]), source (image/drawing/table/merged), associated "
+        "caption (e.g. 'Figure 3: ...'), confidence level, and a "
+        "ready-to-paste zotero_create_area_annotation call. "
+        "Note: detection is geometric — boxes cover the graphical core of a "
+        "figure/table; text labels inside figures or unruled table headers "
+        "may fall outside the box. Confidence reflects caption matching, "
+        "not box completeness. "
+        "attachment_key: PDF attachment key — NOT the parent item key (use "
+        "zotero_get_item_children to find attachments). "
+        "page: 1-indexed page number (page 1 is the first page). "
+        "Scope: PDFs only — EPUB attachments are NOT supported. Read-only: "
+        "works in both local and web API modes. "
+        "Example: zotero_get_page_layout(attachment_key='NHZFE5A7', page=7)."
+    )
+)
+def get_page_layout(
+    attachment_key: str,
+    page: int,
+    *,
+    ctx: Context
+) -> str:
+    """
+    Detect figure/table regions on a PDF page for area annotation grounding.
+
+    Args:
+        attachment_key: PDF attachment key (e.g., "NHZFE5A7")
+        page: 1-indexed PDF page number
+        ctx: MCP context
+
+    Returns:
+        Markdown table of detected regions with normalized bounding boxes
+    """
+    from zotero_mcp import pdf_layout
+
+    try:
+        ctx.info(f"Detecting page layout on attachment {attachment_key}, page {page}")
+
+        if not isinstance(page, int) or page < 1:
+            return "Error: page must be a positive 1-indexed page number"
+
+        local_client = _client.get_local_zotero_client()
+        web_client = _client.get_web_zotero_client()
+
+        if web_client:
+            _helpers.apply_library_override(web_client, _client.get_active_library())
+
+        meta_client = web_client or local_client
+        if meta_client is None:
+            return (
+                "Error: No Zotero client configured.\n\n"
+                "Configure either local Zotero (with 'Allow other applications "
+                "on this computer to communicate with Zotero' enabled) or Web "
+                "API credentials:\n" + _WEB_API_ENV_VARS
+            )
+
+        try:
+            attachment = meta_client.item(attachment_key)
+            attachment_data = attachment.get("data", {})
+
+            if attachment_data.get("itemType") != "attachment":
+                return f"Error: Item {attachment_key} is not an attachment"
+
+            content_type = attachment_data.get("contentType", "")
+            if content_type != "application/pdf":
+                return f"Error: Attachment {attachment_key} is not a PDF attachment (type: {content_type})"
+
+            filename = attachment_data.get("filename", f"{attachment_key}.pdf")
+        except Exception as e:
+            return f"Error: No attachment found with key: {attachment_key} ({e})"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path, error_message = _download_attachment_for_processing(
+                attachment_key,
+                filename,
+                tmpdir,
+                local_client=local_client,
+                web_client=web_client,
+                ctx=ctx,
+            )
+            if error_message:
+                return error_message
+
+            ctx.info(f"Detecting regions on page {page}...")
+            layout = pdf_layout.detect_page_regions(file_path, page)
+
+        if "error" in layout:
+            return f"Error: {layout['error']}"
+
+        return _format_page_layout(layout, attachment_key, page, filename)
+
+    except Exception as e:
+        ctx.error(f"Error detecting page layout: {str(e)}")
+        return f"Error detecting page layout: {str(e)}"
+
+
 @mcp.tool(
     name="zotero_update_annotation",
     description=(

--- a/tests/test_page_layout.py
+++ b/tests/test_page_layout.py
@@ -303,6 +303,17 @@ class TestAssociateCaptionsWithRegions:
 # ---------------------------------------------------------------------------
 
 class TestDetectPageRegions:
+    """Integration tests that build synthetic PDFs with real PyMuPDF.
+
+    Skipped when PyMuPDF is not installed (e.g. CI installs the base
+    package without the `pdf` extra). The pure-logic and MCP-tool tests
+    above/below do not need PyMuPDF and always run.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _require_fitz(self):
+        pytest.importorskip("fitz")
+
     def test_detects_raster_image_with_caption(self):
         import fitz
 

--- a/tests/test_page_layout.py
+++ b/tests/test_page_layout.py
@@ -1,0 +1,738 @@
+"""Tests for PDF page layout detection (zotero_get_page_layout).
+
+Covers the pure-logic detection helpers in pdf_layout, the
+detect_page_regions engine, and the MCP tool layer.
+"""
+
+import os
+import tempfile
+
+import pytest
+from conftest import DummyContext
+
+from zotero_mcp import server
+from zotero_mcp.pdf_layout import (
+    _associate_captions_with_regions,
+    _bbox_iou,
+    _merge_candidate_regions,
+    _parse_caption_block,
+    detect_page_regions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic PDF builders (real PyMuPDF)
+# ---------------------------------------------------------------------------
+
+def _new_letter_page(doc):
+    import fitz  # noqa: F401
+
+    return doc.new_page(width=612, height=792)
+
+
+def _gray_image_bytes():
+    import fitz
+
+    pix = fitz.Pixmap(fitz.csRGB, fitz.IRect(0, 0, 100, 80))
+    pix.clear_with(120)
+    return pix.tobytes("png")
+
+
+def _save_pdf(doc, tmpdir, name="test.pdf"):
+    path = os.path.join(tmpdir, name)
+    doc.save(path)
+    doc.close()
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Caption parsing
+# ---------------------------------------------------------------------------
+
+class TestParseCaptionBlock:
+    def test_figure_caption_with_colon(self):
+        result = _parse_caption_block("Figure 3: Mean completion rates across tasks.")
+        assert result is not None
+        assert result["label"] == "Figure 3"
+        assert result["kind"] == "figure"
+        assert "Mean completion rates" in result["text"]
+
+    def test_figure_caption_with_period(self):
+        result = _parse_caption_block("Figure 3. Mean completion rates across tasks.")
+        assert result is not None
+        assert result["label"] == "Figure 3"
+        assert result["kind"] == "figure"
+
+    def test_fig_abbreviation_with_panel_letter(self):
+        result = _parse_caption_block("Fig. 3a: Ablation results.")
+        assert result is not None
+        assert result["label"] == "Fig. 3a"
+        assert result["kind"] == "figure"
+
+    def test_table_caption(self):
+        result = _parse_caption_block("Table 1: Hyperparameters used in training.")
+        assert result is not None
+        assert result["label"] == "Table 1"
+        assert result["kind"] == "table"
+
+    def test_supplementary_table_caption(self):
+        result = _parse_caption_block("Table S1: Additional results.")
+        assert result is not None
+        assert result["label"] == "Table S1"
+        assert result["kind"] == "table"
+
+    def test_extended_data_figure_caption(self):
+        result = _parse_caption_block("Extended Data Fig. 2: Control experiments.")
+        assert result is not None
+        assert result["kind"] == "figure"
+        assert "2" in result["label"]
+
+    def test_in_text_reference_rejected(self):
+        # Does not start the block -> not a caption
+        assert _parse_caption_block("see Figure 3 for details") is None
+
+    def test_sentence_starting_with_figure_rejected(self):
+        # No ./: separator after the number -> in-text sentence, not a caption
+        assert _parse_caption_block("Figure 3 shows the results of our experiments") is None
+
+    def test_plain_text_rejected(self):
+        assert _parse_caption_block("The quick brown fox jumps over the lazy dog.") is None
+
+    def test_empty_text_rejected(self):
+        assert _parse_caption_block("") is None
+
+    def test_caption_is_case_insensitive(self):
+        result = _parse_caption_block("FIGURE 2: Uppercase caption.")
+        assert result is not None
+        assert result["kind"] == "figure"
+
+
+# ---------------------------------------------------------------------------
+# Bounding box IoU
+# ---------------------------------------------------------------------------
+
+class TestBboxIou:
+    def test_identical_boxes(self):
+        box = [0.1, 0.2, 0.5, 0.3]
+        assert _bbox_iou(box, box) == pytest.approx(1.0)
+
+    def test_disjoint_boxes(self):
+        assert _bbox_iou([0.0, 0.0, 0.2, 0.2], [0.5, 0.5, 0.2, 0.2]) == 0.0
+
+    def test_partial_overlap(self):
+        # [0,0,0.4,0.4] and [0.2,0.2,0.4,0.4]: intersection 0.2*0.2=0.04,
+        # union 0.16+0.16-0.04=0.28
+        assert _bbox_iou([0.0, 0.0, 0.4, 0.4], [0.2, 0.2, 0.4, 0.4]) == pytest.approx(
+            0.04 / 0.28
+        )
+
+    def test_contained_box(self):
+        # Small box fully inside large box: intersection = small area
+        assert _bbox_iou([0.0, 0.0, 1.0, 1.0], [0.4, 0.4, 0.2, 0.2]) == pytest.approx(
+            0.04 / 1.0
+        )
+
+
+# ---------------------------------------------------------------------------
+# Region filtering / merging / de-duplication
+# ---------------------------------------------------------------------------
+
+def _region(source, x, y, w, h):
+    return {"source": source, "bbox": [x, y, w, h]}
+
+
+class TestMergeCandidateRegions:
+    def test_drops_tiny_regions(self):
+        # A 0.5%-of-page logo should be filtered out
+        regions = [
+            _region("image", 0.1, 0.1, 0.5, 0.4),   # real figure (20%)
+            _region("image", 0.9, 0.02, 0.05, 0.05),  # tiny logo (0.25%)
+        ]
+        merged = _merge_candidate_regions(regions)
+        assert len(merged) == 1
+        assert merged[0]["bbox"][2] == pytest.approx(0.5)
+
+    def test_drops_full_page_background(self):
+        regions = [
+            _region("drawing", 0.0, 0.0, 1.0, 0.98),  # page-wide background artifact
+            _region("image", 0.1, 0.1, 0.5, 0.4),
+        ]
+        merged = _merge_candidate_regions(regions)
+        assert len(merged) == 1
+        assert merged[0]["source"] == "image"
+
+    def test_merges_overlapping_fragments(self):
+        # Two overlapping fragments of a composite figure -> single merged region
+        regions = [
+            _region("image", 0.1, 0.1, 0.4, 0.3),
+            _region("drawing", 0.3, 0.2, 0.4, 0.3),
+        ]
+        merged = _merge_candidate_regions(regions)
+        assert len(merged) == 1
+        assert merged[0]["source"] == "merged"
+        # Merged bbox spans both
+        x, y, w, h = merged[0]["bbox"]
+        assert x == pytest.approx(0.1)
+        assert y == pytest.approx(0.1)
+        assert x + w == pytest.approx(0.7)
+        assert y + h == pytest.approx(0.5)
+
+    def test_merges_vertically_adjacent_fragments(self):
+        # Gap below 2% of page height -> merged (e.g. plot + axis labels)
+        regions = [
+            _region("drawing", 0.1, 0.10, 0.5, 0.20),
+            _region("drawing", 0.1, 0.31, 0.5, 0.20),  # 1% gap
+        ]
+        merged = _merge_candidate_regions(regions)
+        assert len(merged) == 1
+
+    def test_keeps_distant_regions_separate(self):
+        regions = [
+            _region("image", 0.1, 0.05, 0.5, 0.25),
+            _region("table", 0.1, 0.60, 0.7, 0.25),
+        ]
+        merged = _merge_candidate_regions(regions)
+        assert len(merged) == 2
+
+    def test_dedupes_same_area_keeping_table(self):
+        # find_tables and cluster_drawings often detect the same table;
+        # the table source should win
+        regions = [
+            _region("table", 0.1, 0.1, 0.6, 0.3),
+            _region("drawing", 0.11, 0.11, 0.59, 0.29),  # IoU > 0.8 with the table
+        ]
+        merged = _merge_candidate_regions(regions)
+        assert len(merged) == 1
+        assert merged[0]["source"] == "table"
+
+    def test_empty_input(self):
+        assert _merge_candidate_regions([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Caption <-> region association
+# ---------------------------------------------------------------------------
+
+def _caption(label, kind, text, x, y, w, h):
+    return {"label": label, "kind": kind, "text": text, "bbox": [x, y, w, h]}
+
+
+class TestAssociateCaptionsWithRegions:
+    def test_figure_caption_below_figure(self):
+        regions = [_region("image", 0.1, 0.1, 0.6, 0.3)]
+        captions = [_caption("Figure 3", "figure", "Figure 3: Results.", 0.1, 0.42, 0.6, 0.04)]
+
+        result = _associate_captions_with_regions(regions, captions)
+
+        assert result[0]["caption_label"] == "Figure 3"
+        assert result[0]["caption_text"] == "Figure 3: Results."
+        assert result[0]["confidence"] == "high"
+
+    def test_table_caption_above_table(self):
+        regions = [_region("table", 0.1, 0.5, 0.7, 0.3)]
+        captions = [_caption("Table 1", "table", "Table 1: Hyperparameters.", 0.1, 0.44, 0.7, 0.04)]
+
+        result = _associate_captions_with_regions(regions, captions)
+
+        assert result[0]["caption_label"] == "Table 1"
+        assert result[0]["confidence"] == "high"
+
+    def test_caption_too_far_not_attached(self):
+        regions = [_region("image", 0.1, 0.05, 0.5, 0.15)]
+        # Caption is 40% of page height below the region -> beyond max distance
+        captions = [_caption("Figure 1", "figure", "Figure 1: Far away.", 0.1, 0.6, 0.5, 0.04)]
+
+        result = _associate_captions_with_regions(regions, captions)
+
+        assert result[0]["caption_label"] is None
+        assert result[0]["confidence"] == "low"
+
+    def test_two_column_caption_not_cross_attached(self):
+        # Region in right column, caption in left column at similar height:
+        # no horizontal overlap -> must not attach
+        regions = [_region("image", 0.55, 0.1, 0.4, 0.3)]
+        captions = [_caption("Figure 2", "figure", "Figure 2: Left column.", 0.05, 0.42, 0.4, 0.04)]
+
+        result = _associate_captions_with_regions(regions, captions)
+
+        assert result[0]["caption_label"] is None
+
+    def test_caption_attaches_to_nearest_of_two_stacked_figures(self):
+        # Two stacked figures, caption right below the lower one
+        regions = [
+            _region("image", 0.1, 0.05, 0.6, 0.25),
+            _region("image", 0.1, 0.45, 0.6, 0.25),
+        ]
+        captions = [_caption("Figure 5", "figure", "Figure 5: Lower figure.", 0.1, 0.72, 0.6, 0.04)]
+
+        result = _associate_captions_with_regions(regions, captions)
+
+        upper, lower = result[0], result[1]
+        assert upper["caption_label"] is None
+        assert lower["caption_label"] == "Figure 5"
+
+    def test_each_caption_attaches_to_one_region_only(self):
+        # One caption between two equally-near figures attaches to exactly one
+        regions = [
+            _region("image", 0.1, 0.1, 0.6, 0.2),
+            _region("image", 0.1, 0.4, 0.6, 0.2),
+        ]
+        captions = [_caption("Figure 1", "figure", "Figure 1: Between.", 0.1, 0.32, 0.6, 0.05)]
+
+        result = _associate_captions_with_regions(regions, captions)
+
+        attached = [r for r in result if r["caption_label"] == "Figure 1"]
+        assert len(attached) == 1
+
+    def test_region_without_caption_gets_low_confidence(self):
+        regions = [_region("drawing", 0.1, 0.1, 0.4, 0.2)]
+
+        result = _associate_captions_with_regions(regions, [])
+
+        assert result[0]["caption_label"] is None
+        assert result[0]["caption_text"] is None
+        assert result[0]["confidence"] == "low"
+
+    def test_no_regions(self):
+        captions = [_caption("Figure 1", "figure", "Figure 1: Orphan.", 0.1, 0.5, 0.5, 0.04)]
+        assert _associate_captions_with_regions([], captions) == []
+
+
+# ---------------------------------------------------------------------------
+# detect_page_regions (real PyMuPDF on synthetic PDFs)
+# ---------------------------------------------------------------------------
+
+class TestDetectPageRegions:
+    def test_detects_raster_image_with_caption(self):
+        import fitz
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            doc = fitz.open()
+            page = _new_letter_page(doc)
+            page.insert_image(fitz.Rect(100, 150, 400, 380), stream=_gray_image_bytes())
+            page.insert_text(
+                fitz.Point(100, 400), "Figure 1: Synthetic test figure.", fontsize=10
+            )
+            path = _save_pdf(doc, tmpdir)
+
+            result = detect_page_regions(path, 1)
+
+        assert "error" not in result
+        assert result["pageIndex"] == 0
+        assert len(result["regions"]) == 1
+
+        region = result["regions"][0]
+        assert region["source"] == "image"
+        assert region["caption_label"] == "Figure 1"
+        assert "Synthetic test figure" in region["caption_text"]
+        assert region["confidence"] == "high"
+
+        # bbox covers roughly the inserted rect (normalized to letter page)
+        x, y, w, h = region["bbox"]
+        assert 0.1 < x < 0.25
+        assert 0.15 < y < 0.25
+        assert 0.4 < w < 0.55
+        assert 0.25 < h < 0.35
+
+    def test_detects_vector_drawing(self):
+        import fitz
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            doc = fitz.open()
+            page = _new_letter_page(doc)
+            page.draw_rect(
+                fitz.Rect(100, 450, 300, 560), color=(0, 0, 1), fill=(0.8, 0.8, 0.9)
+            )
+            page.draw_line(
+                fitz.Point(110, 470), fitz.Point(290, 470), color=(1, 0, 0)
+            )
+            path = _save_pdf(doc, tmpdir)
+
+            result = detect_page_regions(path, 1)
+
+        assert "error" not in result
+        assert len(result["regions"]) == 1
+        assert result["regions"][0]["source"] in ("drawing", "merged")
+        assert result["regions"][0]["caption_label"] is None
+        assert result["regions"][0]["confidence"] == "low"
+
+    def test_detects_table_keeping_table_source(self):
+        import fitz
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            doc = fitz.open()
+            page = _new_letter_page(doc)
+            # Lined 2x3 grid with cell text -> detected by both find_tables
+            # and cluster_drawings; the table source must win de-duplication
+            xs, ys = [400, 460, 520], [450, 480, 510, 540]
+            for grid_y in ys:
+                page.draw_line(fitz.Point(xs[0], grid_y), fitz.Point(xs[-1], grid_y))
+            for grid_x in xs:
+                page.draw_line(fitz.Point(grid_x, ys[0]), fitz.Point(grid_x, ys[-1]))
+            for row, grid_y in enumerate(ys[:-1]):
+                for col, grid_x in enumerate(xs[:-1]):
+                    page.insert_text(
+                        fitz.Point(grid_x + 5, grid_y + 20), f"R{row}C{col}", fontsize=8
+                    )
+            page.insert_text(
+                fitz.Point(400, 440), "Table 1: Synthetic table.", fontsize=10
+            )
+            path = _save_pdf(doc, tmpdir)
+
+            result = detect_page_regions(path, 1)
+
+        assert "error" not in result
+        table_regions = [r for r in result["regions"] if r["source"] == "table"]
+        assert len(table_regions) == 1
+        assert table_regions[0]["caption_label"] == "Table 1"
+
+    def test_text_only_page_returns_no_regions(self):
+        import fitz
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            doc = fitz.open()
+            page = _new_letter_page(doc)
+            page.insert_text(
+                fitz.Point(72, 100),
+                "This page contains nothing but plain paragraph text.",
+                fontsize=11,
+            )
+            path = _save_pdf(doc, tmpdir)
+
+            result = detect_page_regions(path, 1)
+
+        assert "error" not in result
+        assert result["regions"] == []
+
+    def test_page_out_of_range_returns_error(self):
+        import fitz
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            doc = fitz.open()
+            _new_letter_page(doc)
+            path = _save_pdf(doc, tmpdir)
+
+            result = detect_page_regions(path, 5)
+
+        assert "error" in result
+        assert "out of range" in result["error"]
+
+    def test_full_page_scan_returns_warning(self):
+        import fitz
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            doc = fitz.open()
+            page = _new_letter_page(doc)
+            # Image covering the entire page, no text layer -> scanned page
+            page.insert_image(
+                fitz.Rect(0, 0, 612, 792),
+                stream=_gray_image_bytes(),
+                keep_proportion=False,
+            )
+            path = _save_pdf(doc, tmpdir)
+
+            result = detect_page_regions(path, 1)
+
+        assert "error" not in result
+        assert result["regions"] == []
+        assert any("scan" in w.lower() for w in result["warnings"])
+
+    def test_missing_cluster_drawings_adds_warning(self, monkeypatch):
+        import fitz
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            doc = fitz.open()
+            page = _new_letter_page(doc)
+            page.insert_image(fitz.Rect(100, 150, 400, 380), stream=_gray_image_bytes())
+            path = _save_pdf(doc, tmpdir)
+
+            # Simulate an older PyMuPDF without Page.cluster_drawings
+            monkeypatch.delattr(fitz.Page, "cluster_drawings")
+
+            result = detect_page_regions(path, 1)
+
+        assert "error" not in result
+        # Raster image still detected
+        assert len(result["regions"]) == 1
+        assert result["regions"][0]["source"] == "image"
+        assert any("pymupdf" in w.lower() for w in result["warnings"])
+
+    def test_regions_have_sequential_ids_and_normalized_bboxes(self):
+        import fitz
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            doc = fitz.open()
+            page = _new_letter_page(doc)
+            page.insert_image(fitz.Rect(100, 100, 350, 280), stream=_gray_image_bytes())
+            page.insert_image(fitz.Rect(100, 500, 350, 680), stream=_gray_image_bytes())
+            path = _save_pdf(doc, tmpdir)
+
+            result = detect_page_regions(path, 1)
+
+        regions = result["regions"]
+        assert [r["region_id"] for r in regions] == [1, 2]
+        for region in regions:
+            x, y, w, h = region["bbox"]
+            assert 0.0 <= x <= 1.0
+            assert 0.0 <= y <= 1.0
+            assert 0.0 < w <= 1.0
+            assert 0.0 < h <= 1.0
+            assert x + w <= 1.0 + 1e-6
+            assert y + h <= 1.0 + 1e-6
+        # Sorted top-to-bottom
+        assert regions[0]["bbox"][1] < regions[1]["bbox"][1]
+
+    def test_rotated_page_bboxes_stay_normalized(self):
+        import fitz
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            doc = fitz.open()
+            page = _new_letter_page(doc)
+            page.insert_image(fitz.Rect(100, 150, 400, 380), stream=_gray_image_bytes())
+            page.set_rotation(90)
+            path = _save_pdf(doc, tmpdir)
+
+            result = detect_page_regions(path, 1)
+
+        assert "error" not in result
+        assert len(result["regions"]) == 1
+        x, y, w, h = result["regions"][0]["bbox"]
+        assert 0.0 <= x <= 1.0
+        assert 0.0 <= y <= 1.0
+        assert 0.0 < w <= 1.0
+        assert 0.0 < h <= 1.0
+        assert x + w <= 1.0 + 1e-6
+        assert y + h <= 1.0 + 1e-6
+
+    def test_cropped_page_bboxes_stay_normalized(self):
+        # Published PDFs often have CropBox != MediaBox; bboxes must be
+        # normalized against the visible (cropped) page area
+        import fitz
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            doc = fitz.open()
+            page = _new_letter_page(doc)
+            page.insert_image(fitz.Rect(100, 150, 400, 380), stream=_gray_image_bytes())
+            page.insert_text(
+                fitz.Point(100, 400), "Figure 1: Cropped page figure.", fontsize=10
+            )
+            page.set_cropbox(fitz.Rect(50, 50, 562, 742))
+            path = _save_pdf(doc, tmpdir)
+
+            result = detect_page_regions(path, 1)
+
+        assert "error" not in result
+        assert len(result["regions"]) == 1
+
+        region = result["regions"][0]
+        x, y, w, h = region["bbox"]
+        assert 0.0 <= x <= 1.0
+        assert 0.0 <= y <= 1.0
+        assert 0.0 < w <= 1.0
+        assert 0.0 < h <= 1.0
+        assert x + w <= 1.0 + 1e-6
+        assert y + h <= 1.0 + 1e-6
+        # Caption association must survive the cropbox shift
+        assert region["caption_label"] == "Figure 1"
+
+    def test_invalid_pdf_returns_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "broken.pdf")
+            with open(path, "wb") as f:
+                f.write(b"not a pdf at all")
+
+            result = detect_page_regions(path, 1)
+
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# MCP tool: zotero_get_page_layout
+# ---------------------------------------------------------------------------
+
+def _pdf_attachment(key="ATTACH01", item_type="attachment", content_type="application/pdf"):
+    return {
+        "key": key,
+        "data": {
+            "itemType": item_type,
+            "contentType": content_type,
+            "filename": "paper.pdf",
+            "title": "paper.pdf",
+            "parentItem": "PARENT01",
+        },
+    }
+
+
+def _layout_result(regions, warnings=None, page_index=6, page_label="7"):
+    return {
+        "pageIndex": page_index,
+        "pageLabel": page_label,
+        "regions": regions,
+        "warnings": warnings or [],
+    }
+
+
+def _layout_region(region_id=1, source="image", bbox=None, caption_label=None,
+                   caption_text=None, confidence="low"):
+    return {
+        "region_id": region_id,
+        "source": source,
+        "bbox": bbox or [0.1, 0.2, 0.5, 0.3],
+        "caption_label": caption_label,
+        "caption_text": caption_text,
+        "confidence": confidence,
+    }
+
+
+class TestGetPageLayoutTool:
+    def _setup_clients(self, monkeypatch, fake_zot, items=None):
+        fake_zot._items = items if items is not None else [_pdf_attachment()]
+        monkeypatch.setattr("zotero_mcp.client.get_web_zotero_client", lambda: fake_zot)
+        monkeypatch.setattr("zotero_mcp.client.get_local_zotero_client", lambda: None)
+        monkeypatch.setattr("zotero_mcp.client.get_active_library", lambda: None)
+
+    def _patch_detection(self, monkeypatch, result):
+        monkeypatch.setattr(
+            "zotero_mcp.pdf_layout.detect_page_regions",
+            lambda _path, _page: result,
+        )
+
+    def test_happy_path_renders_regions_table(self, monkeypatch, fake_zot):
+        self._setup_clients(monkeypatch, fake_zot)
+        self._patch_detection(monkeypatch, _layout_result([
+            _layout_region(
+                region_id=1,
+                source="image",
+                bbox=[0.1012, 0.2034, 0.6011, 0.3498],
+                caption_label="Figure 3",
+                caption_text="Figure 3: Mean completion rates.",
+                confidence="high",
+            ),
+            _layout_region(
+                region_id=2,
+                source="table",
+                bbox=[0.1003, 0.6201, 0.8014, 0.2005],
+                caption_label="Table 1",
+                caption_text="Table 1: Hyperparameters.",
+                confidence="high",
+            ),
+        ]))
+
+        result = server.get_page_layout(
+            attachment_key="ATTACH01", page=7, ctx=DummyContext()
+        )
+
+        assert "Error" not in result
+        assert "2 region" in result
+        # Both regions with their metadata
+        assert "Figure 3" in result
+        assert "Table 1" in result
+        assert "0.1012" in result
+        assert "high" in result
+        # Ready-to-paste call template references the same attachment and page
+        assert "zotero_create_area_annotation" in result
+        assert "attachment_key='ATTACH01'" in result
+        assert "page=7" in result
+
+    def test_no_regions_returns_guidance(self, monkeypatch, fake_zot):
+        self._setup_clients(monkeypatch, fake_zot)
+        self._patch_detection(monkeypatch, _layout_result([]))
+
+        result = server.get_page_layout(
+            attachment_key="ATTACH01", page=3, ctx=DummyContext()
+        )
+
+        assert "No figure/table regions detected" in result
+        assert "explicit coordinates" in result
+
+    def test_warnings_are_included(self, monkeypatch, fake_zot):
+        self._setup_clients(monkeypatch, fake_zot)
+        self._patch_detection(monkeypatch, _layout_result(
+            [],
+            warnings=["Page appears to be a full-page scan — region detection "
+                      "and captions are unavailable."],
+        ))
+
+        result = server.get_page_layout(
+            attachment_key="ATTACH01", page=1, ctx=DummyContext()
+        )
+
+        assert "full-page scan" in result
+
+    def test_detection_error_is_returned(self, monkeypatch, fake_zot):
+        self._setup_clients(monkeypatch, fake_zot)
+        self._patch_detection(monkeypatch, {"error": "Page 99 out of range (PDF has 12 pages)"})
+
+        result = server.get_page_layout(
+            attachment_key="ATTACH01", page=99, ctx=DummyContext()
+        )
+
+        assert "Error" in result
+        assert "out of range" in result
+
+    def test_rejects_non_pdf_attachment(self, monkeypatch, fake_zot):
+        self._setup_clients(
+            monkeypatch, fake_zot, items=[_pdf_attachment(content_type="text/html")]
+        )
+
+        result = server.get_page_layout(
+            attachment_key="ATTACH01", page=1, ctx=DummyContext()
+        )
+
+        assert "not a PDF attachment" in result
+
+    def test_rejects_non_attachment_item(self, monkeypatch, fake_zot):
+        self._setup_clients(
+            monkeypatch, fake_zot, items=[_pdf_attachment(item_type="journalArticle")]
+        )
+
+        result = server.get_page_layout(
+            attachment_key="ATTACH01", page=1, ctx=DummyContext()
+        )
+
+        assert "not an attachment" in result
+
+    def test_rejects_invalid_page_number(self, monkeypatch, fake_zot):
+        self._setup_clients(monkeypatch, fake_zot)
+
+        result = server.get_page_layout(
+            attachment_key="ATTACH01", page=0, ctx=DummyContext()
+        )
+
+        assert "Error" in result
+        assert "page" in result.lower()
+
+    def test_requires_a_zotero_client(self, monkeypatch):
+        monkeypatch.setattr("zotero_mcp.client.get_web_zotero_client", lambda: None)
+        monkeypatch.setattr("zotero_mcp.client.get_local_zotero_client", lambda: None)
+
+        result = server.get_page_layout(
+            attachment_key="ATTACH01", page=1, ctx=DummyContext()
+        )
+
+        assert "Error" in result
+
+    def test_works_with_local_client_only(self, monkeypatch, fake_zot):
+        # Read-only tool must work in local-API mode without web credentials
+        # (unlike create_area_annotation, which needs web write access)
+        fake_zot._items = [_pdf_attachment()]
+        monkeypatch.setattr("zotero_mcp.client.get_web_zotero_client", lambda: None)
+        monkeypatch.setattr("zotero_mcp.client.get_local_zotero_client", lambda: fake_zot)
+        monkeypatch.setattr("zotero_mcp.client.get_active_library", lambda: None)
+        self._patch_detection(monkeypatch, _layout_result([
+            _layout_region(
+                region_id=1,
+                source="image",
+                caption_label="Figure 1",
+                caption_text="Figure 1: Local mode figure.",
+                confidence="high",
+            ),
+        ]))
+
+        result = server.get_page_layout(
+            attachment_key="ATTACH01", page=2, ctx=DummyContext()
+        )
+
+        assert "Error" not in result
+        assert "1 region" in result
+        assert "Figure 1" in result


### PR DESCRIPTION
## Summary

This PR adds a new read-only MCP tool, `zotero_get_page_layout`, that detects candidate figure/table regions on a PDF page and returns their normalized bounding boxes with associated captions.

It closes the main usability gap of `zotero_create_area_annotation` (#190): a model calling that tool cannot see the page layout, so it has to guess `x/y/width/height` coordinates — and the rectangle often lands on the wrong region. With this tool, the model picks from detected coordinates instead of guessing.

## Changes

- add `src/zotero_mcp/pdf_layout.py` — a self-contained detection engine:
  - raster images via `page.get_image_info()`
  - vector graphics via `page.cluster_drawings()` (most scientific charts are vector)
  - tables via `page.find_tables()`
  - captions via text blocks matching `Figure N:` / `Table N:` patterns (anchored regex; rejects in-text references like "see Figure 3")
  - pipeline: noise filtering → fragment merging → IoU de-duplication → caption-region association by spatial scoring (vertical proximity + column overlap + figure/table prior)
- add `zotero_get_page_layout` MCP tool in `tools/annotations.py` — renders detected regions as a markdown table plus a ready-to-paste `zotero_create_area_annotation` call
- export the new tool from `server.py`
- bump `pymupdf>=1.24.2` in the `pdf` extra (`Page.cluster_drawings` was added in 1.24.2); the code also feature-detects it and degrades gracefully on older versions
- add 50 tests covering caption parsing, region merging/de-duplication, caption association (including two-column layouts), synthetic-PDF integration, rotated/cropped pages, scanned-page handling, and the MCP tool layer

## Notes

- read-only: works in both local and web API modes; the existing `zotero_create_area_annotation` flow is unchanged
- this is coordinate grounding for the existing area annotation tool — it does not extract figure images or table data (that is a separate, larger scope; see #219)
- detection is geometric, not semantic: boxes cover the graphical core of a figure/table, so text labels inside figures or unruled table header rows can fall outside the box. The tool description states this limitation explicitly. A follow-up PR can tighten coverage by absorbing caption-bounded text blocks.
- `pdf_utils.py` is untouched — the detection engine lives in its own module

## Verification

```
$ uv run pytest tests/test_page_layout.py -q
50 passed

$ uv run pytest tests/ --ignore=tests/test_fulltext_local_mode.py --ignore=tests/test_fulltext_web_mode.py --ignore=tests/test_semantic_search_quality.py --ignore=tests/test_semantic_stats.py -q
775 passed, 2 skipped, 6 failed (pre-existing on main)
```

Also verified end-to-end against a real two-column academic paper: all 9 figure/table captions on its pages were detected and associated with regions at high confidence, and area annotations created from the returned coordinates landed on the correct figures/tables in Zotero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)