### PR TITLE
fix(webdav): route add_by_doi & arXiv PDF uploads through WebDAV PUT

### DIFF
--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -421,7 +421,13 @@ def _normalize_arxiv_id(raw):
 # ---------------------------------------------------------------------------
 
 def _download_and_attach_pdf(write_zot, item_key, pdf_url, doi, ctx):
-    """Download a PDF from a URL and attach it to a Zotero item."""
+    """Download a PDF from a URL and attach it to a Zotero item.
+
+    Returns the WebDAV-status suffix string on success (``""`` when WebDAV
+    is not configured, otherwise something like ``" (uploaded to WebDAV
+    as <key>.zip)"`` or a warning if the PUT failed). Returns ``None``
+    on failure so callers can branch with ``if suffix is not None``.
+    """
     try:
         pdf_resp = requests.get(pdf_url, timeout=30, stream=True)
         pdf_resp.raise_for_status()
@@ -429,7 +435,7 @@ def _download_and_attach_pdf(write_zot, item_key, pdf_url, doi, ctx):
         content_type = pdf_resp.headers.get("Content-Type", "")
         if "pdf" not in content_type and "octet-stream" not in content_type:
             ctx.info(f"URL did not return a PDF (Content-Type: {content_type})")
-            return False
+            return None
 
         with tempfile.TemporaryDirectory() as tmpdir:
             filename = f"{doi.replace('/', '_')}.pdf"
@@ -440,16 +446,66 @@ def _download_and_attach_pdf(write_zot, item_key, pdf_url, doi, ctx):
 
             if os.path.getsize(filepath) < 1000:
                 ctx.info("Downloaded file too small, likely not a real PDF")
-                return False
+                return None
 
-            write_zot.attachment_both(
+            attach_result = write_zot.attachment_both(
                 [(filename, filepath)],
                 parentid=item_key,
             )
-        return True
+            # Must run inside the with-block — temp file disappears on exit.
+            return _maybe_upload_to_webdav(attach_result, filepath, ctx)
     except Exception as e:
         ctx.info(f"PDF download/attach failed: {e}")
-        return False
+        return None
+
+
+def _maybe_upload_to_webdav(attach_result, file_path, ctx):
+    """Suffix to append to a user-facing 'file attached' message.
+
+    PR #279 added WebDAV-aware upload to ``zotero_add_from_file``. The same
+    treatment is needed everywhere else ``attachment_both`` is called: the
+    Web API's file upload lands bytes in Zotero Storage, which a desktop
+    client with File Syncing set to WebDAV never consults.
+
+    Returns ``""`` when WebDAV is not configured, when the attachment key
+    cannot be extracted, or after a successful PUT with logging via ``ctx``
+    (callers that don't surface the suffix can ignore the return value).
+    On a successful PUT returns ``" (uploaded to WebDAV as <key>.zip)"``;
+    on PUT failure returns ``" (WARNING: WebDAV upload failed — <err>; ...)"``
+    so callers can keep the user-visible signal without re-implementing the
+    branch.
+    """
+    from zotero_mcp import webdav as _webdav
+
+    if not _webdav.is_webdav_configured():
+        return ""
+
+    attachment_key = None
+    if isinstance(attach_result, dict):
+        for status in ("success", "unchanged"):
+            for entry in attach_result.get(status, []) or []:
+                if isinstance(entry, dict) and entry.get("key"):
+                    attachment_key = entry["key"]
+                    break
+            if attachment_key:
+                break
+
+    if not attachment_key:
+        return ""
+
+    try:
+        _webdav.upload_attachment_to_webdav(
+            attachment_key=attachment_key,
+            file_path=file_path,
+        )
+        ctx.info(f"WebDAV PUT: {attachment_key}.zip uploaded")
+        return f" (uploaded to WebDAV as {attachment_key}.zip)"
+    except Exception as e:
+        ctx.info(f"WebDAV PUT failed for {attachment_key}: {e}")
+        return (
+            f" (WARNING: WebDAV upload failed — {e}; "
+            f"attachment {attachment_key} exists but has no file bytes on WebDAV)"
+        )
 
 
 def _attach_pdf_linked_url(write_zot, pdf_url, parent_key, ctx):
@@ -619,8 +675,11 @@ def _try_attach_oa_pdf(write_zot, item_key, doi, ctx, crossref_metadata=None,
                     if _attach_pdf_linked_url(write_zot, pdf_url, item_key, ctx):
                         return f"PDF linked (source: {source_name})"
                 else:  # "auto" or "import_file" — try download only
-                    if _download_and_attach_pdf(write_zot, item_key, pdf_url, doi, ctx):
-                        return f"PDF attached (source: {source_name})"
+                    webdav_suffix = _download_and_attach_pdf(
+                        write_zot, item_key, pdf_url, doi, ctx
+                    )
+                    if webdav_suffix is not None:
+                        return f"PDF attached (source: {source_name}){webdav_suffix}"
 
                 ctx.info(f"{source_name} URL didn't yield a valid PDF, trying next source")
         except Exception as e:

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -23,22 +23,6 @@ from zotero_mcp.tools import _helpers
 CROSSREF_TYPE_MAP = _helpers.CROSSREF_TYPE_MAP
 
 
-def _extract_attachment_key(attach_result) -> str | None:
-    """Pull the new attachment item's 8-char key out of pyzotero's response.
-
-    ``Zupload.upload`` returns ``{"success": [...], "failure": [...], "unchanged": [...]}``
-    where each list element is the original payload dict with a ``key``
-    field populated on the items that landed.
-    """
-    if not isinstance(attach_result, dict):
-        return None
-    for status in ("success", "unchanged"):
-        for item in attach_result.get(status, []) or []:
-            if isinstance(item, dict) and item.get("key"):
-                return item["key"]
-    return None
-
-
 @mcp.tool(
     name="zotero_batch_update_tags",
     description=(
@@ -915,11 +899,15 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
                     with open(filepath, "wb") as f:
                         for chunk in pdf_resp.iter_content(chunk_size=8192):
                             f.write(chunk)
-                    write_zot.attachment_both(
+                    attach_result = write_zot.attachment_both(
                         [(filename, filepath)],
                         parentid=item_key,
                     )
-                pdf_status = "PDF attached"
+                    # Must run inside the with-block — temp file disappears on exit.
+                    webdav_suffix = _helpers._maybe_upload_to_webdav(
+                        attach_result, filepath, ctx
+                    )
+                pdf_status = "PDF attached" + webdav_suffix
             except Exception as e:
                 ctx.info(f"arXiv PDF attachment failed (non-fatal): {e}")
                 pdf_status = f"no PDF attached ({e})"
@@ -2079,33 +2067,10 @@ def add_from_file(
                 [(display_name, file_path)],
                 parentid=parent_key,
             )
-            attach_info = f"File attached: {display_name}"
-
-            # For WebDAV-storage users, pyzotero's web-API upload path is a
-            # no-op (Zotero's /file endpoint targets Zotero Storage / S3).
-            # If WebDAV creds are configured, push the bytes directly via
-            # WebDAV PUT so the attachment is actually retrievable.
-            from zotero_mcp import webdav as _webdav
-
-            if _webdav.is_webdav_configured():
-                attachment_key = _extract_attachment_key(attach_result)
-                if attachment_key:
-                    try:
-                        _webdav.upload_attachment_to_webdav(
-                            attachment_key=attachment_key,
-                            file_path=file_path,
-                        )
-                        attach_info = (
-                            f"File attached: {display_name} "
-                            f"(uploaded to WebDAV as {attachment_key}.zip)"
-                        )
-                    except Exception as webdav_err:
-                        attach_info = (
-                            f"File attached: {display_name} "
-                            f"(WARNING: WebDAV upload failed — {webdav_err}; "
-                            f"attachment {attachment_key} exists but has no file bytes "
-                            f"on WebDAV)"
-                        )
+            attach_info = (
+                f"File attached: {display_name}"
+                + _helpers._maybe_upload_to_webdav(attach_result, file_path, ctx)
+            )
         except Exception as e:
             attach_info = f"Item created but file attachment failed: {e}"
 


### PR DESCRIPTION
Fixes #313.

## Summary

PR #279 added `webdav.upload_attachment_to_webdav()` and called it from `zotero_add_from_file` so users with `ZOTERO_WEBDAV_*` configured get their PDFs PUT to their own server rather than uploaded to Zotero Storage. The same treatment was missing from the two other call sites that ultimately reach `Zotero.attachment_both()`:

- `_helpers._download_and_attach_pdf` — called from `_try_attach_oa_pdf` and reached by `zotero_add_by_doi`'s Unpaywall + arXiv-via-Crossref + Semantic Scholar + PMC cascade.
- `write._add_by_arxiv` — reached by `zotero_add_by_url` for arXiv abstracts when `attach_mode="auto"`.

On a WebDAV-configured library both paths landed bytes in Zotero Storage; the desktop client — which only consults the configured WebDAV backend — then showed "file could not be found" despite the API saying the attachment was attached.

## Empirical reproduction + fix

Verified end-to-end against a Synology DSM WebDAV (Apache) and Zotero desktop 7.x with the issue's reproduction recipe.

| Path | Pre-patch | Post-patch |
|---|---|---|
| `zotero_add_from_file` | ✓ (already handled by #279) | ✓ |
| `zotero_add_by_doi` (Unpaywall) | ✗ WebDAV `HEAD <key>.zip` → 404 | ✓ → 200 |
| User-facing success message | `PDF attached (source: Unpaywall)` | `PDF attached (source: Unpaywall) (uploaded to WebDAV as <key>.zip)` |
| Zotero desktop "View PDF" | "file could not be found" | opens the PDF |

`add_by_url`/arXiv was patched by code-reading inference; not empirically retested because `export.arxiv.org` was timing out during the session. Happy to re-verify if you want before merging — the patch shape is identical to the DOI path.

## Refactor / cleanup

- Extracted `_helpers._maybe_upload_to_webdav(attach_result, file_path, ctx)` as the single source of truth for the WebDAV PUT pattern. Returns a suffix the caller appends to its user-facing message (empty when WebDAV isn't configured, warning suffix on PUT failure).
- `_download_and_attach_pdf` now returns the WebDAV suffix on success or `None` on failure, letting `_try_attach_oa_pdf` surface the WebDAV status without an extra branch.
- `zotero_add_from_file` refactored to call the same helper — collapses the ~30-line inline WebDAV branch added in #279 into a single line, behavior preserved (including the failure-suffix wording).
- Deleted `write._extract_attachment_key` — its only caller was the inline block we just removed; the new helper inlines the equivalent extraction.

## Tests

No new tests added — `tests/test_webdav.py` covers `upload_attachment_to_webdav` correctness (zip/prop structure, PUT order, URL escaping, error handling). The two new call sites apply the same well-tested helper at the same point in their flow. Happy to add regression tests modelled on `TestArxivAttachMode` if you'd like — let me know what coverage shape you want.

## Related

- #279 — `zotero_add_from_file` WebDAV upload (the precedent + the helper this PR reuses).
- #275 — `_add_by_arxiv` `attach_mode` plumbing (orthogonal — about callers opting out of binary download, not about routing the download).
- #249 — WebDAV download fallback (complementary).
