### PR TITLE
fix(chroma): register custom embedding functions with ChromaDB registry

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -15,6 +15,7 @@ try:
     import chromadb
     from chromadb import Documents, EmbeddingFunction, Embeddings
     from chromadb.config import Settings
+    from chromadb.utils.embedding_functions import register_embedding_function
 except ImportError as e:
     raise ImportError(
         "chromadb is required for semantic search. "
@@ -26,8 +27,17 @@ from zotero_mcp.utils import suppress_stdout
 logger = logging.getLogger(__name__)
 
 
+@register_embedding_function
 class OpenAIEmbeddingFunction(EmbeddingFunction):
-    """Custom OpenAI embedding function for ChromaDB."""
+    """Custom OpenAI embedding function for ChromaDB.
+
+    Registered under the name "openai" so ChromaDB rebuilds it (rather than its
+    own incompatible built-in of the same name) when reloading a persisted
+    collection's config. ChromaDB >=1.x reconstructs the embedding function by
+    name from the stored config during upsert; without registration the name
+    collides with the built-in, whose build_from_config rejects our
+    {model_name, base_url} config.
+    """
 
     max_input_tokens = 8000  # text-embedding-3-* limit is 8191
 
@@ -91,8 +101,13 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
         return text
 
 
+@register_embedding_function
 class GeminiEmbeddingFunction(EmbeddingFunction):
-    """Custom Gemini embedding function for ChromaDB using google-genai."""
+    """Custom Gemini embedding function for ChromaDB using google-genai.
+
+    Registered under the name "gemini" so ChromaDB can rebuild it from a
+    persisted collection's config (see OpenAIEmbeddingFunction for details).
+    """
 
     # gemini-embedding-2-* models ignore the task_type config field (the API
     # silently drops it). Google's recommended alternative is to embed the
@@ -240,8 +255,14 @@ class GeminiEmbeddingFunction(EmbeddingFunction):
         return text
 
 
+@register_embedding_function
 class HuggingFaceEmbeddingFunction(EmbeddingFunction):
-    """Custom HuggingFace embedding function for ChromaDB using sentence-transformers."""
+    """Custom HuggingFace embedding function for ChromaDB using sentence-transformers.
+
+    Registered under the name "huggingface" so ChromaDB rebuilds it (rather than
+    its own incompatible built-in of the same name) when reloading a persisted
+    collection's config (see OpenAIEmbeddingFunction for details).
+    """
 
     def __init__(self, model_name: str = "Qwen/Qwen3-Embedding-0.6B"):
         self.model_name = model_name

--- a/tests/test_embedding_function_registration.py
+++ b/tests/test_embedding_function_registration.py
@@ -1,0 +1,73 @@
+"""Regression test: custom embedding functions must be registered with ChromaDB.
+
+ChromaDB >=1.x reconstructs a collection's embedding function *by name* from the
+persisted config when it reopens a collection (e.g. the ``collection.configuration``
+property used inside the upsert path). It looks the name up in
+``chromadb.utils.embedding_functions.known_embedding_functions`` and calls that
+class's ``build_from_config``.
+
+Our custom embedding functions report names that either collide with ChromaDB's
+own built-ins (``"openai"``, ``"huggingface"``) or are absent from the registry
+(``"gemini"``). If they are not registered, ChromaDB resolves ``"openai"`` to its
+*built-in* OpenAIEmbeddingFunction, whose ``build_from_config`` expects an
+``api_key_env_var`` key and asserts on our ``{model_name, base_url}`` config:
+
+    Could not build embedding function openai from config
+    {'base_url': None, 'model_name': 'text-embedding-3-small'}:
+    This code should not be reached
+
+which surfaced as "19 errors" on every ``update-db`` against an existing index.
+
+Fix: decorate the custom classes with ``@register_embedding_function`` so the
+registry maps their names to *our* classes (and our compatible build_from_config).
+"""
+
+import pytest
+
+# chromadb is an optional extra (``[semantic]``); skip where it isn't installed.
+chromadb = pytest.importorskip("chromadb")  # noqa: F841
+
+from chromadb.utils.embedding_functions import (  # noqa: E402
+    known_embedding_functions,
+)
+
+from zotero_mcp import chroma_client  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "name, cls_attr",
+    [
+        ("openai", "OpenAIEmbeddingFunction"),
+        ("gemini", "GeminiEmbeddingFunction"),
+        ("huggingface", "HuggingFaceEmbeddingFunction"),
+    ],
+)
+def test_custom_embedding_functions_are_registered(name, cls_attr):
+    """Importing chroma_client must register our EFs under their names.
+
+    Without this, ``known_embedding_functions["openai"]`` resolves to ChromaDB's
+    incompatible built-in and breaks reload/upsert of an existing collection.
+    """
+    assert name in known_embedding_functions, (
+        f"{name!r} not registered; ChromaDB cannot rebuild the embedding "
+        "function from a persisted collection's config."
+    )
+    assert known_embedding_functions[name] is getattr(chroma_client, cls_attr)
+
+
+def test_openai_build_from_config_handles_persisted_config(monkeypatch):
+    """The exact operation that failed for existing indexes must now succeed.
+
+    ChromaDB stores our OpenAI EF config as ``{"model_name": ..., "base_url": ...}``
+    (see ``OpenAIEmbeddingFunction.get_config``). Rebuilding from that config via
+    the registry previously hit ChromaDB's built-in and raised
+    "This code should not be reached".
+    """
+    pytest.importorskip("openai")  # __init__ constructs an openai.OpenAI client
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key-no-network")
+
+    persisted = {"model_name": "text-embedding-3-small", "base_url": None}
+    ef = known_embedding_functions["openai"].build_from_config(persisted)
+
+    assert isinstance(ef, chroma_client.OpenAIEmbeddingFunction)
+    assert ef.get_config() == persisted


### PR DESCRIPTION
## Problem

`update-db` fails at the ChromaDB upsert step for any **existing** index, with every item erroring:

```
Could not build embedding function openai from config {'base_url': None, 'model_name': 'text-embedding-3-small'}: This code should not be reached
```

(also reported via `WARNING: Batch upsert failed ...` / `Retry failed for <KEY>: ... This code should not be reached in upsert`).

## Root cause

ChromaDB ≥1.x reconstructs a collection's embedding function **by name** from the persisted config when it reopens an existing collection — e.g. the `collection.configuration` property used inside the upsert path (`CollectionCommon._embed`). It looks the name up in `chromadb.utils.embedding_functions.known_embedding_functions` and calls that class's `build_from_config`.

The custom embedding functions in `chroma_client.py` were never registered, so their reported names either **collided** with ChromaDB's built-ins (`"openai"`, `"huggingface"`) or were **absent** (`"gemini"`). On reopen, `"openai"` resolved to ChromaDB's *own* `OpenAIEmbeddingFunction`, whose `build_from_config` expects an `api_key_env_var` key and asserts on our `{model_name, base_url}` config (`assert False, "This code should not be reached"`).

It only surfaces with newer ChromaDB, which rebuilds the embedding function from persisted config on reopen rather than using the in-memory instance passed to `get_or_create_collection`.

## Fix

Decorate the three custom embedding functions with `@register_embedding_function` so the registry maps their **existing** names to our classes (and our compatible `build_from_config`).

Keeping the existing names makes this **backward-compatible**: already-persisted collections resolve to the custom class with no `--force-rebuild` required.

## Tests

Adds `tests/test_embedding_function_registration.py`:
- registry maps `"openai"`/`"gemini"`/`"huggingface"` to the custom classes;
- the OpenAI EF rebuilds from the persisted `{model_name, base_url}` config (the exact operation that failed).

Verified the tests **fail without** the fix and **pass with** it; existing chroma-dependent tests still pass. Also reproduced the original error against real ChromaDB (1.5.9) and confirmed registration resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)