### PR TITLE
feat(feeds):Show publication date for RSS feed items

### DIFF
--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -602,6 +602,7 @@ class LocalZoteroReader:
                    title_val.value as title,
                    abstract_val.value as abstract,
                    date_val.value as date,
+                   doi_val.value as DOI,
                    url_val.value as url,
                    GROUP_CONCAT(
                        CASE
@@ -621,6 +622,9 @@ class LocalZoteroReader:
             LEFT JOIN fields date_f ON date_f.fieldName = 'date'
             LEFT JOIN itemData date_data ON i.itemID = date_data.itemID AND date_data.fieldID = date_f.fieldID
             LEFT JOIN itemDataValues date_val ON date_data.valueID = date_val.valueID
+            LEFT JOIN fields doi_f ON doi_f.fieldName = 'DOI'
+            LEFT JOIN itemData doi_data ON i.itemID = doi_data.itemID AND doi_data.fieldID = doi_f.fieldID
+            LEFT JOIN itemDataValues doi_val ON doi_data.valueID = doi_val.valueID
             LEFT JOIN fields url_f ON url_f.fieldName = 'url'
             LEFT JOIN itemData url_data ON i.itemID = url_data.itemID AND url_data.fieldID = url_f.fieldID
             LEFT JOIN itemDataValues url_val ON url_data.valueID = url_val.valueID

--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -601,6 +601,7 @@ class LocalZoteroReader:
                    fi.readTime, fi.translatedTime,
                    title_val.value as title,
                    abstract_val.value as abstract,
+                   date_val.value as date,
                    url_val.value as url,
                    GROUP_CONCAT(
                        CASE
@@ -617,6 +618,9 @@ class LocalZoteroReader:
             LEFT JOIN itemDataValues title_val ON title_data.valueID = title_val.valueID
             LEFT JOIN itemData abstract_data ON i.itemID = abstract_data.itemID AND abstract_data.fieldID = 2
             LEFT JOIN itemDataValues abstract_val ON abstract_data.valueID = abstract_val.valueID
+            LEFT JOIN fields date_f ON date_f.fieldName = 'date'
+            LEFT JOIN itemData date_data ON i.itemID = date_data.itemID AND date_data.fieldID = date_f.fieldID
+            LEFT JOIN itemDataValues date_val ON date_data.valueID = date_val.valueID
             LEFT JOIN fields url_f ON url_f.fieldName = 'url'
             LEFT JOIN itemData url_data ON i.itemID = url_data.itemID AND url_data.fieldID = url_f.fieldID
             LEFT JOIN itemDataValues url_val ON url_data.valueID = url_val.valueID

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -948,7 +948,7 @@ def list_libraries(*, ctx: Context) -> str:
                 libraries = reader.get_libraries()
 
                 # User library
-                user_libs = [l for l in libraries if l["type"] == "user"]
+                user_libs = [library for library in libraries if library["type"] == "user"]
                 if user_libs:
                     output.append("## User Library")
                     for lib in user_libs:
@@ -959,7 +959,7 @@ def list_libraries(*, ctx: Context) -> str:
                     output.append("")
 
                 # Group libraries
-                group_libs = [l for l in libraries if l["type"] == "group"]
+                group_libs = [library for library in libraries if library["type"] == "group"]
                 if group_libs:
                     output.append("## Group Libraries")
                     for lib in group_libs:
@@ -971,7 +971,7 @@ def list_libraries(*, ctx: Context) -> str:
                     output.append("")
 
                 # Feeds
-                feed_libs = [l for l in libraries if l["type"] == "feed"]
+                feed_libs = [library for library in libraries if library["type"] == "feed"]
                 if feed_libs:
                     output.append("## RSS Feeds")
                     for lib in feed_libs:
@@ -1123,14 +1123,14 @@ def validate_library_switch(library_id: str, library_type: str) -> str | None:
             try:
                 libraries = reader.get_libraries()
                 if library_type == "group":
-                    valid_ids = {str(l["groupID"]) for l in libraries if l["type"] == "group"}
+                    valid_ids = {str(library["groupID"]) for library in libraries if library["type"] == "group"}
                     if library_id not in valid_ids:
                         return (
                             f"Group '{library_id}' not found. "
                             f"Available groups: {', '.join(sorted(valid_ids))}"
                         )
                 elif library_type == "feed":
-                    valid_ids = {str(l["libraryID"]) for l in libraries if l["type"] == "feed"}
+                    valid_ids = {str(library["libraryID"]) for library in libraries if library["type"] == "feed"}
                     if library_id not in valid_ids:
                         return (
                             f"Feed with libraryID '{library_id}' not found. "
@@ -1277,6 +1277,8 @@ def get_feed_items(
                     output.append(f"- **Authors:** {item['creators']}")
                 if item.get("url"):
                     output.append(f"- **URL:** {item['url']}")
+                if item.get("date"):
+                    output.append(f"- **Date:** {item['date']}")
                 output.append(f"- **Added:** {item.get('dateAdded', 'unknown')}")
                 if item.get("abstract"):
                     abstract = _utils.clean_html(item["abstract"])

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -1279,6 +1279,8 @@ def get_feed_items(
                     output.append(f"- **URL:** {item['url']}")
                 if item.get("date"):
                     output.append(f"- **Date:** {item['date']}")
+                if item.get("DOI"):
+                    output.append(f"- **DOI:** {item['DOI']}")
                 output.append(f"- **Added:** {item.get('dateAdded', 'unknown')}")
                 if item.get("abstract"):
                     abstract = _utils.clean_html(item["abstract"])

--- a/tests/test_feed_retrieval.py
+++ b/tests/test_feed_retrieval.py
@@ -1,0 +1,44 @@
+class DummyContext:
+    def info(self, *_args, **_kwargs):
+        return None
+
+    def error(self, *_args, **_kwargs):
+        return None
+
+
+class FakeFeedReader:
+    def get_feeds(self):
+        return [{
+            "libraryID": 10,
+            "name": "Example Feed",
+            "url": "https://example.test/feed.xml",
+        }]
+
+    def get_feed_items(self, library_id, limit=20):
+        assert library_id == 10
+        assert limit == 20
+        return [{
+            "title": "Feed Item Title",
+            "readTime": None,
+            "creators": "Lovelace, Ada",
+            "url": "https://example.test/item",
+            "date": "2024-05-15",
+            "dateAdded": "2026-06-01 10:00:00",
+            "abstract": None,
+        }]
+
+    def close(self):
+        return None
+
+
+def test_get_feed_items_output_includes_publication_date(monkeypatch):
+    monkeypatch.setenv("ZOTERO_LOCAL", "true")
+
+    import zotero_mcp.local_db
+    from zotero_mcp.tools import retrieval
+
+    monkeypatch.setattr(zotero_mcp.local_db, "LocalZoteroReader", FakeFeedReader)
+    result = retrieval.get_feed_items(library_id=10, limit=20, ctx=DummyContext())
+
+    assert "- **Date:** 2024-05-15" in result
+    assert "- **Added:** 2026-06-01 10:00:00" in result

--- a/tests/test_feed_retrieval.py
+++ b/tests/test_feed_retrieval.py
@@ -23,6 +23,7 @@ class FakeFeedReader:
             "creators": "Lovelace, Ada",
             "url": "https://example.test/item",
             "date": "2024-05-15",
+            "DOI": "10.1234/example.doi",
             "dateAdded": "2026-06-01 10:00:00",
             "abstract": None,
         }]
@@ -41,4 +42,5 @@ def test_get_feed_items_output_includes_publication_date(monkeypatch):
     result = retrieval.get_feed_items(library_id=10, limit=20, ctx=DummyContext())
 
     assert "- **Date:** 2024-05-15" in result
+    assert "- **DOI:** 10.1234/example.doi" in result
     assert "- **Added:** 2026-06-01 10:00:00" in result

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -243,6 +243,7 @@ def _create_feed_db(db_path: Path) -> None:
             (2, "abstractNote"),
             (13, "date"),
             (15, "url"),
+            (26, "DOI"),
         ],
     )
     conn.execute(
@@ -269,6 +270,7 @@ def _create_feed_db(db_path: Path) -> None:
             (1002, "Feed item abstract"),
             (1003, "2024-05-15"),
             (1004, "https://example.test/item"),
+            (1005, "10.1234/example.doi"),
         ],
     )
     conn.executemany(
@@ -278,6 +280,7 @@ def _create_feed_db(db_path: Path) -> None:
             (2, 1002),
             (13, 1003),
             (15, 1004),
+            (26, 1005),
         ],
     )
     conn.execute(
@@ -299,3 +302,16 @@ def test_get_feed_items_includes_publication_date(tmp_path):
         reader.close()
 
     assert items[0]["date"] == "2024-05-15"
+
+
+def test_get_feed_items_includes_doi(tmp_path):
+    db_path = tmp_path / "zotero.sqlite"
+    _create_feed_db(db_path)
+
+    reader = LocalZoteroReader(db_path=str(db_path))
+    try:
+        items = reader.get_feed_items(10, limit=20)
+    finally:
+        reader.close()
+
+    assert items[0]["DOI"] == "10.1234/example.doi"

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 
-import pytest
-
-from zotero_mcp.local_db import ZoteroItem, LocalZoteroReader
+from zotero_mcp.local_db import LocalZoteroReader, ZoteroItem
 
 
 class FakeLocalZoteroReader(LocalZoteroReader):
@@ -181,3 +179,123 @@ class TestGetAttachmentPaths:
         ])
         result = reader.get_attachment_paths("PARENT")
         assert [a["key"] for a in result] == ["A", "B"]
+
+
+def _create_feed_db(db_path: Path) -> None:
+    import sqlite3
+
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE feeds (
+            libraryID INTEGER PRIMARY KEY,
+            name TEXT,
+            url TEXT,
+            lastCheck TEXT,
+            lastUpdate TEXT,
+            lastCheckError TEXT,
+            refreshInterval INTEGER
+        );
+        CREATE TABLE feedItems (
+            itemID INTEGER PRIMARY KEY,
+            readTime TEXT,
+            translatedTime TEXT
+        );
+        CREATE TABLE items (
+            itemID INTEGER PRIMARY KEY,
+            key TEXT,
+            itemTypeID INTEGER,
+            libraryID INTEGER,
+            dateAdded TEXT
+        );
+        CREATE TABLE itemTypes (
+            itemTypeID INTEGER PRIMARY KEY,
+            typeName TEXT
+        );
+        CREATE TABLE fields (
+            fieldID INTEGER PRIMARY KEY,
+            fieldName TEXT
+        );
+        CREATE TABLE itemData (
+            itemID INTEGER,
+            fieldID INTEGER,
+            valueID INTEGER
+        );
+        CREATE TABLE itemDataValues (
+            valueID INTEGER PRIMARY KEY,
+            value TEXT
+        );
+        CREATE TABLE itemCreators (
+            itemID INTEGER,
+            creatorID INTEGER
+        );
+        CREATE TABLE creators (
+            creatorID INTEGER PRIMARY KEY,
+            firstName TEXT,
+            lastName TEXT
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO fields (fieldID, fieldName) VALUES (?, ?)",
+        [
+            (1, "title"),
+            (2, "abstractNote"),
+            (13, "date"),
+            (15, "url"),
+        ],
+    )
+    conn.execute(
+        """
+        INSERT INTO feeds (
+            libraryID, name, url, lastCheck, lastUpdate, lastCheckError, refreshInterval
+        ) VALUES (10, 'Example Feed', 'https://example.test/feed.xml', NULL, NULL, NULL, 60)
+        """
+    )
+    conn.execute("INSERT INTO itemTypes (itemTypeID, typeName) VALUES (7, 'journalArticle')")
+    conn.execute(
+        """
+        INSERT INTO items (itemID, key, itemTypeID, libraryID, dateAdded)
+        VALUES (100, 'FEEDKEY1', 7, 10, '2026-06-01 10:00:00')
+        """
+    )
+    conn.execute(
+        "INSERT INTO feedItems (itemID, readTime, translatedTime) VALUES (100, NULL, NULL)"
+    )
+    conn.executemany(
+        "INSERT INTO itemDataValues (valueID, value) VALUES (?, ?)",
+        [
+            (1001, "Feed Item Title"),
+            (1002, "Feed item abstract"),
+            (1003, "2024-05-15"),
+            (1004, "https://example.test/item"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO itemData (itemID, fieldID, valueID) VALUES (100, ?, ?)",
+        [
+            (1, 1001),
+            (2, 1002),
+            (13, 1003),
+            (15, 1004),
+        ],
+    )
+    conn.execute(
+        "INSERT INTO creators (creatorID, firstName, lastName) VALUES (1, 'Ada', 'Lovelace')"
+    )
+    conn.execute("INSERT INTO itemCreators (itemID, creatorID) VALUES (100, 1)")
+    conn.commit()
+    conn.close()
+
+
+def test_get_feed_items_includes_publication_date(tmp_path):
+    db_path = tmp_path / "zotero.sqlite"
+    _create_feed_db(db_path)
+
+    reader = LocalZoteroReader(db_path=str(db_path))
+    try:
+        items = reader.get_feed_items(10, limit=20)
+    finally:
+        reader.close()
+
+    assert items[0]["date"] == "2024-05-15"


### PR DESCRIPTION
## Summary

This PR adds the Zotero item `date` field to RSS feed item output.

I use Zotero RSS feeds together with an agent workflow for daily literature collection, analysis, and management. In the current implementation, feed items only expose `Added`, which
comes from `items.dateAdded`. However, `dateAdded` reflects when the item was added to the local Zotero feed library, not necessarily when the paper/article was published.

Different RSS sources handle feed updates differently, so `dateAdded` is not always a reliable signal for identifying literature published on a specific day. Exposing the item `date`
field makes it possible to filter and analyze feed items by their publication date.

## Changes

- Read the feed item's `date` field from the local Zotero SQLite database.
- Display `Date` in `zotero_get_feed_items` output when available.
- Keep the existing `Added` output unchanged.
- Add tests covering:
  - local DB feed item queries returning `date`
  - RSS feed item markdown output showing both `Date` and `Added`

## Notes

RSS feed support remains local-mode only because Zotero feeds are stored in the local SQLite database and are not exposed by the Zotero Web API.

This PR intentionally keeps the existing sort order by `dateAdded DESC`. It only adds the publication date to the returned/output fields.

## Testing

```bash
uv run --extra dev ruff check src/zotero_mcp/local_db.py src/zotero_mcp/tools/retrieval.py tests/test_local_db.py tests/test_feed_retrieval.py
uv run --extra dev pytest tests/test_local_db.py tests/test_feed_retrieval.py