### PR TITLE
fix(write): strip pyzotero-rejected lastRead field on attachment updates

### DIFF
--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -159,6 +159,28 @@ def is_collection_trashed(zot, collection_key: str) -> bool | None:
     return bool(coll.get("data", {}).get("deleted"))
 
 
+# Fields the Zotero reader/server sets on items but pyzotero's check_items()
+# whitelist (pyzotero/_client.py: check_items) does not include. Any fetched
+# item that carries one of these will be rejected client-side with
+# "Invalid keys present in item N: <field>" when passed back to update_item().
+# The canonical fetch→mutate→update flow then breaks on attachments that have
+# been opened in the Zotero PDF reader (which writes lastRead).
+_UNWRITABLE_ITEM_FIELDS = frozenset({"lastRead"})
+
+
+def _strip_unwritable_fields(item: dict) -> dict:
+    """Remove fields that pyzotero's check_items() rejects from a fetched item.
+
+    Mutates ``item["data"]`` in place and returns the same dict so the caller
+    can chain. Safe to call on any item type — fields not present are ignored.
+    """
+    data = item.get("data")
+    if isinstance(data, dict):
+        for field in _UNWRITABLE_ITEM_FIELDS:
+            data.pop(field, None)
+    return item
+
+
 def _handle_write_response(response, ctx=None):
     """Check if a pyzotero write operation succeeded."""
     if hasattr(response, "status_code"):

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1281,14 +1281,8 @@ def update_item(
         ctx.info(f"Updating item {item_key}")
 
         # Fetch current item from write client for correct version
-        item = write_zot.item(item_key)
+        item = _helpers._strip_unwritable_fields(write_zot.item(item_key))
         data = item.get("data", {})
-        # `lastRead` is set by Zotero's PDF reader (timestamp of last open) and
-        # is not in the writable schema; pyzotero's check_items() then bounces
-        # the PATCH with "Invalid keys present in item 1: lastRead", so any
-        # attempt to update an attachment that was ever opened in the reader
-        # fails. Strip it before re-submitting.
-        data.pop("lastRead", None)
         changes = []
 
         # Handle item_type migration first so subsequent field updates are
@@ -1794,6 +1788,7 @@ def merge_duplicates(
             keeper_data = keeper.get("data", {})
             existing_tags = [t.get("tag", "") for t in keeper_data.get("tags", [])]
             keeper_data["tags"] = [{"tag": t} for t in sorted(set(existing_tags) | all_tags)]
+            _helpers._strip_unwritable_fields(keeper)
             resp = write_zot.update_item(keeper)
             if not _helpers._handle_write_response(resp, ctx):
                 return "Error: Failed to merge tags into keeper."
@@ -1828,6 +1823,7 @@ def merge_duplicates(
                             skipped_dupes.append(child_key)
                             continue  # Skip — keeper already has this attachment
                     fresh_child.get("data", {})["parentItem"] = keeper_key
+                    _helpers._strip_unwritable_fields(fresh_child)
                     resp = write_zot.update_item(fresh_child)
                     if _helpers._handle_write_response(resp, ctx):
                         moved.append(child_key)
@@ -2236,6 +2232,7 @@ def add_item_relation(
         data["relations"] = relations
 
         # Update the primary item
+        _helpers._strip_unwritable_fields(item)
         resp = write_zot.update_item(item)
         if not _helpers._handle_write_response(resp, ctx):
             return f"Failed to add relation to item '{item_key}'."
@@ -2260,6 +2257,7 @@ def add_item_relation(
             if not _relation_exists(reverse_relations[relation_type], library_id, item_key):
                 reverse_relations[relation_type].append(item_uri)
                 related_data["relations"] = reverse_relations
+                _helpers._strip_unwritable_fields(related_item)
                 write_zot.update_item(related_item)
         except Exception as e:
             ctx.warn(f"Could not add reverse relation: {e}")
@@ -2349,6 +2347,7 @@ def remove_item_relation(
         data["relations"] = relations
 
         # Update the item
+        _helpers._strip_unwritable_fields(item)
         resp = write_zot.update_item(item)
         if not _helpers._handle_write_response(resp, ctx):
             return f"Failed to remove relation from item '{item_key}'."
@@ -2373,6 +2372,7 @@ def remove_item_relation(
                         else:
                             reverse_relations[relation_type] = reverse_list
                         related_data["relations"] = reverse_relations
+                        _helpers._strip_unwritable_fields(related_item)
                         write_zot.update_item(related_item)
             except Exception as e:
                 ctx.warn(f"Could not remove reverse relation: {e}")

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1283,6 +1283,12 @@ def update_item(
         # Fetch current item from write client for correct version
         item = write_zot.item(item_key)
         data = item.get("data", {})
+        # `lastRead` is set by Zotero's PDF reader (timestamp of last open) and
+        # is not in the writable schema; pyzotero's check_items() then bounces
+        # the PATCH with "Invalid keys present in item 1: lastRead", so any
+        # attempt to update an attachment that was ever opened in the reader
+        # fails. Strip it before re-submitting.
+        data.pop("lastRead", None)
         changes = []
 
         # Handle item_type migration first so subsequent field updates are

--- a/tests/test_shared_helpers.py
+++ b/tests/test_shared_helpers.py
@@ -303,3 +303,44 @@ class TestCrossrefTypeMap:
 
     def test_unknown_type_fallback(self):
         assert server.CROSSREF_TYPE_MAP.get("unknown-type", "document") == "document"
+
+
+# ---------------------------------------------------------------------------
+# _strip_unwritable_fields — pyzotero check_items whitelist omission workaround
+# ---------------------------------------------------------------------------
+
+class TestStripUnwritableFields:
+    """pyzotero's check_items() rejects keys outside a hardcoded whitelist that
+    omits `lastRead` (set by Zotero's PDF reader). Without stripping, any
+    fetch→mutate→update on an opened attachment raises
+    InvalidItemFieldsError before the request leaves the client."""
+
+    def test_strips_last_read_from_attachment(self):
+        from zotero_mcp.tools import _helpers
+        item = {
+            "key": "ATT1",
+            "version": 3,
+            "data": {
+                "key": "ATT1",
+                "itemType": "attachment",
+                "linkMode": "imported_file",
+                "filename": "paper.pdf",
+                "lastRead": 1780565972,
+                "tags": [],
+            },
+        }
+        returned = _helpers._strip_unwritable_fields(item)
+        assert returned is item
+        assert "lastRead" not in item["data"]
+        assert item["data"]["filename"] == "paper.pdf"
+
+    def test_noop_when_field_absent(self):
+        from zotero_mcp.tools import _helpers
+        item = {"data": {"itemType": "journalArticle", "title": "x"}}
+        _helpers._strip_unwritable_fields(item)
+        assert item["data"] == {"itemType": "journalArticle", "title": "x"}
+
+    def test_safe_when_data_missing(self):
+        from zotero_mcp.tools import _helpers
+        # Should not raise on a malformed item with no data dict.
+        _helpers._strip_unwritable_fields({"key": "ABC"})

--- a/tests/test_update_item.py
+++ b/tests/test_update_item.py
@@ -605,6 +605,44 @@ class TestUpdateItemErrors:
 
         assert "fail" in result.lower() or "error" in result.lower()
 
+    def test_attachment_lastread_field_stripped(self, monkeypatch):
+        """Attachment items carry a `lastRead` field that pyzotero's
+        check_items() rejects ("Invalid keys present in item 1: lastRead").
+        update_item must strip it before re-submitting."""
+        attachment = {
+            "key": "ATTACH12",
+            "version": 7,
+            "data": {
+                "key": "ATTACH12",
+                "version": 7,
+                "itemType": "attachment",
+                "linkMode": "imported_file",
+                "title": "Old PDF Title",
+                "filename": "paper.pdf",
+                "contentType": "application/pdf",
+                "lastRead": 1780565972,
+                "md5": "abc123",
+                "mtime": 1780565511000,
+                "tags": [],
+                "relations": {},
+            },
+        }
+        fake = FakeZoteroForUpdate(items=[attachment])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="ATTACH12",
+            title="New PDF Title",
+            ctx=DummyContext(),
+        )
+
+        assert len(fake.update_calls) == 1
+        submitted = fake.update_calls[0]["data"]
+        assert "lastRead" not in submitted
+        assert submitted["title"] == "New PDF Title"
+        assert "New PDF Title" in result
+
 
 # ---------------------------------------------------------------------------
 # Additional field updates


### PR DESCRIPTION
## Summary

- Fixes `zotero_update_item` (#317) failing on PDF attachments that have been opened in Zotero's reader.
- Extends the fix to every other tool that does fetch→mutate→`update_item` on an arbitrary item type: `zotero_merge_duplicates`, `zotero_add_item_relation`, `zotero_remove_item_relation`.
- Adds `_helpers._strip_unwritable_fields()` and a `_UNWRITABLE_ITEM_FIELDS` constant so the workaround lives in one place and can grow if pyzotero's allowed-keys whitelist drifts further.

Closes #<issue-number>.

## Why

pyzotero's `check_items()` validates the outgoing item dict against a whitelist built from `/itemFields` plus a hardcoded set of bookkeeping/attachment-only fields (`mtime`, `md5`, `filename`, `contentType`, `linkMode`, `inPublications`, ...). `lastRead` — a unix timestamp Zotero's PDF reader stamps on attachment items every time they're opened — is in neither set, so `update_item` raises `InvalidItemFieldsError` before the request leaves the client:

```
Error updating item: Invalid keys present in item 1: lastRead
```

This breaks the canonical pyzotero edit pattern (`fetch → mutate → update_item`) on any attachment a user has ever opened in the reader. The MCP exhibited the bug in `zotero_update_item` first; an audit found four other tools that exhibit it on attachment-typed inputs.

I'll file the upstream pyzotero whitelist fix separately. This PR is the defence-in-depth so the MCP keeps working in the meantime, and so the MCP is resilient if the upstream whitelist regresses again.

## Affected callsites

| Tool | Site in `write.py` (post-PR) | Why vulnerable |
|---|---|---|
| `zotero_update_item` | L1284 | User-facing, accepts any item key. **Originally reported.** |
| `zotero_merge_duplicates` keeper consolidation | L1791 | Keeper could (rarely) be an attachment. |
| `zotero_merge_duplicates` child re-parenting | L1826 | Children explicitly include unique attachment PDFs. |
| `zotero_add_item_relation` | L2235, L2260 | Forward + reverse PATCH; relations are settable on attachments. |
| `zotero_remove_item_relation` | L2350, L2375 | Forward + reverse PATCH; same. |

Not touched because they don't take attachment input:
- `zotero_batch_update_tags` (filters attachments at `write.py:147`).
- `zotero_update_note` / `zotero_update_annotation` (target other item types).

## Test plan

- [x] New `test_attachment_lastread_field_stripped` in `tests/test_update_item.py` verifies the user-facing tool strips `lastRead` from an opened attachment and still applies the requested update.
- [x] New `TestStripUnwritableFields` class in `tests/test_shared_helpers.py` covers the helper directly: strips when present, no-op when absent, safe when `data` is missing.
- [x] Existing suites green: `tests/test_update_item.py`, `tests/test_shared_helpers.py`, `tests/test_duplicates.py`, `tests/test_item_related.py` (143 passed total).
- [x] Manual: open a PDF attachment in Zotero desktop, then update its title via `zotero_update_item` — succeeds where it previously failed with `InvalidItemFieldsError`.
