### PR TITLE
feat: add citation_key field to zotero_update_item (#320)

### DIFF
--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1172,6 +1172,7 @@ _UPDATE_ITEM_API_TO_PARAM = {
     "edition": "edition",
     "ISBN": "isbn",
     "bookTitle": "book_title",
+    "citationKey": "citation_key",
 }
 
 
@@ -1192,7 +1193,8 @@ _UPDATE_ITEM_API_TO_PARAM = {
         "item_key: 8-character Zotero item key of the item to update. "
         "Editable fields include: title, creators, date, publisher, place, "
         "publication_title, volume, issue, pages, DOI, ISBN, ISSN, url, "
-        "language, abstract, short_title, edition, book_title, extra, item_type. "
+        "language, abstract, short_title, edition, book_title, extra, "
+        "citation_key, item_type. "
         "To migrate an item across types (e.g., journalArticle → book), pass item_type "
         "with a valid Zotero item-type vocabulary value; overlapping fields are preserved "
         "and type-specific fields that do not map to the target type are dropped. "
@@ -1234,6 +1236,10 @@ def update_item(
     edition: str | None = None,
     isbn: str | None = None,
     book_title: str | None = None,
+    citation_key: Annotated[
+        str | None,
+        Field(description="BetterBibTeX / Zotero native citation key. Writes to data.citationKey. Useful when BBT auto-pinned the key from incomplete metadata and the programmatic refresh path is blocked (see https://github.com/retorquere/zotero-better-bibtex/issues/3522)."),
+    ] = None,
     item_type: str | None = None,
     *,
     ctx: Context
@@ -1250,10 +1256,15 @@ def update_item(
         item_key: 8-character Zotero item key of the item to update.
         title, creators, date, publication_title, abstract, doi, url,
         extra, volume, issue, pages, publisher, place, issn, language,
-        short_title, edition, isbn, book_title: per-field overrides;
-        ``place`` is the publication city (e.g. ``"New York"`` or
-        ``"Cambridge, MA"``) and is valid on book, bookSection, thesis,
-        manuscript, report, and conferencePaper item types.
+        short_title, edition, isbn, book_title, citation_key: per-field
+        overrides; ``place`` is the publication city (e.g. ``"New York"``
+        or ``"Cambridge, MA"``) and is valid on book, bookSection,
+        thesis, manuscript, report, and conferencePaper item types.
+        ``citation_key`` writes Zotero's native ``data.citationKey``
+        (the BetterBibTeX citation key); BBT auto-pins from metadata on
+        creation and provides no programmatic refresh path in 9.x, so
+        direct write here is the only programmatic remediation for
+        malformed pinned keys.
         tags / add_tags / remove_tags: mutually exclusive; ``tags``
         REPLACES the full tag list, ``add_tags`` / ``remove_tags`` are
         incremental. Prefer the incremental forms.
@@ -1354,6 +1365,8 @@ def update_item(
             field_updates["ISBN"] = isbn
         if book_title is not None:
             field_updates["bookTitle"] = book_title
+        if citation_key is not None:
+            field_updates["citationKey"] = citation_key
 
         skipped = []
         for field, value in field_updates.items():

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1376,6 +1376,12 @@ def update_item(
                 if old != value:
                     changes.append(f"- **{param_name}**: '{old}' -> '{value}'")
                 data[field] = value
+            elif field == "citationKey":
+                # citationKey is universally valid; absence on the fetched
+                # item just means BBT has not yet auto-pinned a key, so we
+                # add rather than skip-as-invalid-for-item-type.
+                changes.append(f"- **{param_name}**: (none) -> '{value}'")
+                data[field] = value
             else:
                 skipped.append(param_name)
 

--- a/tests/test_update_item.py
+++ b/tests/test_update_item.py
@@ -15,37 +15,44 @@ def _make_item(key="ABCD1234", version=10, title="Original Title",
                date="2024-01-01", doi="", url="",
                volume="", issue="", pages="", publisher="",
                issn="", language="", short_title="",
-               citation_key="doeOriginalArticle2024",
+               citation_key=None,
                publication_title="Test Journal"):
-    """Build a realistic Zotero item dict for stubbing."""
+    """Build a realistic Zotero item dict for stubbing.
+
+    citation_key defaults to None — the field is omitted from the data dict
+    entirely so add-when-absent paths are exercised by the default fixture.
+    Pass an explicit value to seed a pre-existing citationKey.
+    """
+    data = {
+        "key": key,
+        "version": version,
+        "itemType": "journalArticle",
+        "title": title,
+        "creators": [{"creatorType": "author",
+                      "firstName": "Jane", "lastName": "Doe"}],
+        "date": date,
+        "abstractNote": abstract,
+        "publicationTitle": publication_title,
+        "volume": volume,
+        "issue": issue,
+        "pages": pages,
+        "publisher": publisher,
+        "ISSN": issn,
+        "language": language,
+        "shortTitle": short_title,
+        "tags": [{"tag": t} for t in (tags or [])],
+        "collections": list(collections or []),
+        "DOI": doi,
+        "url": url,
+        "extra": extra,
+        "relations": {},
+    }
+    if citation_key is not None:
+        data["citationKey"] = citation_key
     return {
         "key": key,
         "version": version,
-        "data": {
-            "key": key,
-            "version": version,
-            "itemType": "journalArticle",
-            "title": title,
-            "creators": [{"creatorType": "author",
-                          "firstName": "Jane", "lastName": "Doe"}],
-            "date": date,
-            "abstractNote": abstract,
-            "publicationTitle": publication_title,
-            "volume": volume,
-            "issue": issue,
-            "pages": pages,
-            "publisher": publisher,
-            "ISSN": issn,
-            "language": language,
-            "shortTitle": short_title,
-            "citationKey": citation_key,
-            "tags": [{"tag": t} for t in (tags or [])],
-            "collections": list(collections or []),
-            "DOI": doi,
-            "url": url,
-            "extra": extra,
-            "relations": {},
-        },
+        "data": data,
     }
 
 
@@ -926,12 +933,40 @@ class TestUpdateItemNewFields:
         assert fake.update_calls[0]["data"]["place"] == "Cambridge, MA"
         assert "Cambridge, MA" in result
 
-    def test_update_citation_key(self, monkeypatch):
-        """citation_key writes data.citationKey — the only programmatic
-        remediation path for malformed BBT-auto-pinned keys, since BBT 9.x
-        exposes no refresh mechanism via JSON-RPC. See
-        https://github.com/retorquere/zotero-better-bibtex/issues/3522
-        for the upstream context this works around."""
+    def test_add_citation_key_when_absent(self, monkeypatch):
+        """citation_key adds data.citationKey when the fetched item has none.
+
+        This is the #320 scenario: BBT has not yet auto-pinned a key (or the
+        item predates BBT), so data['citationKey'] is absent. The generic
+        field-write loop's ``if field in data`` check would silently skip
+        this case and emit a misleading 'not valid for item type' warning;
+        the special case in write.py routes the add through.
+        """
+        item = _make_item()  # citation_key=None -> field omitted from data
+        assert "citationKey" not in item["data"]
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="ABCD1234",
+            citation_key="doeCorrectArticle2024",
+            ctx=DummyContext(),
+        )
+
+        assert fake.update_calls[0]["data"]["citationKey"] == \
+            "doeCorrectArticle2024"
+        assert "doeCorrectArticle2024" in result
+        assert "not valid for item type" not in result
+
+    def test_update_citation_key_when_present(self, monkeypatch):
+        """citation_key overwrites an existing data.citationKey.
+
+        Covers the remediation path for malformed BBT-auto-pinned keys —
+        BBT 9.x exposes no JSON-RPC refresh mechanism, so direct write is
+        the only programmatic route. See
+        https://github.com/retorquere/zotero-better-bibtex/issues/3522.
+        """
         item = _make_item(citation_key="doeOldPaperdraftpdf2024")
         fake = FakeZoteroForUpdate(items=[item])
         monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",

--- a/tests/test_update_item.py
+++ b/tests/test_update_item.py
@@ -15,6 +15,7 @@ def _make_item(key="ABCD1234", version=10, title="Original Title",
                date="2024-01-01", doi="", url="",
                volume="", issue="", pages="", publisher="",
                issn="", language="", short_title="",
+               citation_key="doeOriginalArticle2024",
                publication_title="Test Journal"):
     """Build a realistic Zotero item dict for stubbing."""
     return {
@@ -37,6 +38,7 @@ def _make_item(key="ABCD1234", version=10, title="Original Title",
             "ISSN": issn,
             "language": language,
             "shortTitle": short_title,
+            "citationKey": citation_key,
             "tags": [{"tag": t} for t in (tags or [])],
             "collections": list(collections or []),
             "DOI": doi,
@@ -923,6 +925,27 @@ class TestUpdateItemNewFields:
 
         assert fake.update_calls[0]["data"]["place"] == "Cambridge, MA"
         assert "Cambridge, MA" in result
+
+    def test_update_citation_key(self, monkeypatch):
+        """citation_key writes data.citationKey — the only programmatic
+        remediation path for malformed BBT-auto-pinned keys, since BBT 9.x
+        exposes no refresh mechanism via JSON-RPC. See
+        https://github.com/retorquere/zotero-better-bibtex/issues/3522
+        for the upstream context this works around."""
+        item = _make_item(citation_key="doeOldPaperdraftpdf2024")
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="ABCD1234",
+            citation_key="doeCorrectArticle2024",
+            ctx=DummyContext(),
+        )
+
+        assert fake.update_calls[0]["data"]["citationKey"] == \
+            "doeCorrectArticle2024"
+        assert "doeCorrectArticle2024" in result
 
     def test_access_date_skipped_on_book(self, monkeypatch):
         """accessDate is not valid for books — should be in skip warning."""


### PR DESCRIPTION
Closes #320.

## Summary

Exposes Zotero's native `data.citationKey` on `zotero_update_item` via a new `citation_key` parameter, matching the shape of the place / accessDate / ISBN field additions in PR #245 / #281.

## Why

When items are added programmatically (any add path), BetterBibTeX pins the citekey from whatever metadata exists at the moment of add — often incomplete. By the time the workflow has populated full metadata, the citekey is stuck on a malformed value, and BBT 9.x exposes no programmatic refresh:

- BBT JSON-RPC has no mutation methods on citekeys (tracked upstream at retorquere/zotero-better-bibtex#3522)
- Zotero local API at `:23119` returns 501 on item PATCH
- BBT's Extra-field `Citation Key:` override is not honoured in 9.x for items with a set `data.citationKey`

The Zotero cloud API does accept `data.citationKey` in PATCH bodies, so exposing it here gives users the only working programmatic mutation path for malformed pinned keys.

## Change

`src/zotero_mcp/tools/write.py`:

- Add `citation_key: Annotated[str | None, Field(...)] = None` parameter to `update_item` signature (Annotated to surface the BBT context in the field description, matching the `place=` pattern)
- Wire it into `field_updates` as `data.citationKey`
- Register in `_UPDATE_ITEM_API_TO_PARAM`
- Update tool description and docstring

`tests/test_update_item.py`:

- Add `citationKey` to `_make_item` fixture (representative of Zotero 9.x items, which populate it natively)
- Add `test_update_citation_key` covering the round-trip

## Tests

- 56/56 pass in `tests/test_update_item.py` (including the new test)
- Full suite: 809 pass, 2 pre-existing failures in `tests/test_place_field_reads.py` confirmed on upstream `main` (BBT-integration assertion mismatch, unrelated to this change)

## Diff size

+41/-5 across 2 files. Comparable to:
- #240 (accessDate exposure, in PR #245)
- #238 (place field, in PR #245)
- #281 (place field expansion, +94/-1)