### PR TITLE
fix: bump pyzotero floor to >=1.8.0 + repair PDF-attach tests broken by #314

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "pyzotero>=1.6.0",
+    "pyzotero>=1.8.0",
     "mcp>=1.2.0",
     "python-dotenv>=1.0.0",
     "markitdown[pdf]",

--- a/tests/test_pdf_cascade.py
+++ b/tests/test_pdf_cascade.py
@@ -232,7 +232,7 @@ class TestDownloadAndAttachPdf:
         monkeypatch.setattr(requests, "get", fake_get)
         result = _download_and_attach_pdf(zot, "ITEM1", "https://x.com/f.pdf",
                                           "10.1234/test", dummy_ctx)
-        assert result is False
+        assert result is None
         assert len(zot.attachments) == 0
 
     def test_download_too_small(self, monkeypatch, dummy_ctx):
@@ -249,7 +249,7 @@ class TestDownloadAndAttachPdf:
         monkeypatch.setattr(requests, "get", fake_get)
         result = _download_and_attach_pdf(zot, "ITEM1", "https://x.com/f.pdf",
                                           "10.1234/test", dummy_ctx)
-        assert result is False
+        assert result is None
         assert len(zot.attachments) == 0
 
 

--- a/tests/test_v021_fixes.py
+++ b/tests/test_v021_fixes.py
@@ -369,8 +369,9 @@ class TestLinkedUrlRemoval:
         mock_arxiv.return_value = None
         mock_ss.return_value = None
         mock_pmc.return_value = None
-        # Download fails
-        mock_download.return_value = False
+        # Download fails — _download_and_attach_pdf returns None on failure
+        # (suffix-string on success) since the WebDAV-routing change in #314.
+        mock_download.return_value = None
 
         write_zot = self._make_write_zot()
         ctx = DummyContext()


### PR DESCRIPTION
## Why

Two follow-ups after the recent merge batch:

### 1. `pyzotero>=1.8.0` (was `>=1.6.0`)
`client.py` passes a `client=` kwarg to `zotero.Zotero(...)` (the #160 HTTP/1.1 local-API fix). That parameter was **added in pyzotero 1.8.0** — verified by parsing the constructor across 1.6.17 → 1.12.0. The old `>=1.6.0` floor lets a fresh install resolve 1.6.x, which lacks the param and crashes **every tool call** with `TypeError: Zotero.__init__() got an unexpected keyword argument 'client'`. Likely the root cause behind several "502 / unexpected keyword" reports.

### 2. Repair tests broken by #314
#314 changed `_download_and_attach_pdf` to return a WebDAV suffix string / `None` instead of `True`/`False`, and updated the production callers — but three older tests still asserted/mocked the old bool contract and now fail on `main`:
- `test_pdf_cascade.py::TestDownloadAndAttachPdf::test_download_content_type_check`
- `test_pdf_cascade.py::TestDownloadAndAttachPdf::test_download_too_small`
- `test_v021_fixes.py::TestLinkedUrlRemoval::test_auto_mode_reports_url_when_download_fails`

Updated them to the new `None`-on-failure contract.

## Test
`pytest` → **878 passed, 3 skipped** (skips are async lifespan tests needing `pytest-asyncio`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)