### PR TITLE
docs: fix broken JSON indentation in Claude Desktop manual config

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,25 +213,32 @@ After installation, either:
 2. **Manual configuration**:
    Add to your `claude_desktop_config.json`:
    ```json
-  {
-      "mcpServers": {
-          "zotero": {
-              "command": "zotero-mcp",
-              "env": {
-                  "ZOTERO_LOCAL": "true",
-                  "ZOTERO_API_KEY": "YOUR_API_KEY",
-                  "ZOTERO_LIBRARY_ID": "YOUR_LIBRARY_ID"
-              }
-          }
-      }
-  }
+   {
+     "mcpServers": {
+       "zotero": {
+         "command": "zotero-mcp",
+         "env": {
+           "ZOTERO_LOCAL": "true",
+           "ZOTERO_API_KEY": "YOUR_API_KEY",
+           "ZOTERO_LIBRARY_ID": "YOUR_LIBRARY_ID"
+         }
+       }
+     }
+   }
    ```
 
-The API key and the library ID are only needed if you want to use the MCP server in write mode (the local API, while fast, is read-only. The MCP server uses the web API for write operations).
+   For **local read-only use**, `ZOTERO_LOCAL: "true"` is all you need — drop the
+   `ZOTERO_API_KEY` and `ZOTERO_LIBRARY_ID` lines entirely. Add them only to enable
+   **write mode**: the local API is fast but read-only, so the server uses the Zotero
+   web API for write operations.
 
-Generate API keys [from here](https://www.zotero.org/settings/security#applications).
+   - Generate an API key from <https://www.zotero.org/settings/security#applications>.
+   - `ZOTERO_LIBRARY_ID` is your numeric **userID**, shown on that same page (for a
+     group library, use the group's ID and also set `ZOTERO_LIBRARY_TYPE: "group"`).
 
-The library ID is the "User ID" listed on the above screen.
+   > **Tip:** if Claude Desktop reports it can't find the `zotero-mcp` command, use the
+   > absolute path instead (run `zotero-mcp setup-info` or `which zotero-mcp` to find it) —
+   > GUI apps don't always inherit your shell `PATH`.
 
 #### Usage
 


### PR DESCRIPTION
The manual `claude_desktop_config.json` example rendered with ragged indentation (outer braces at 2 spaces, body at 6) — introduced in #308. This normalizes the JSON and clarifies the surrounding guidance:

- `ZOTERO_API_KEY` / `ZOTERO_LIBRARY_ID` are optional (write-mode only); local read-only needs just `ZOTERO_LOCAL`.
- `ZOTERO_LIBRARY_ID` is the numeric userID (with a note to set `ZOTERO_LIBRARY_TYPE: "group"` for group libraries).
- Added a PATH tip for when Claude Desktop can't find the `zotero-mcp` command.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)