### PR TITLE
deps: bump chromadb floor to >=1.0.0 (register_embedding_function)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ dependencies = [
 
 [project.optional-dependencies]
 semantic = [
-    "chromadb>=0.4.0",
+    # >=1.0.0 for chromadb.utils.embedding_functions.register_embedding_function,
+    # used to register the custom OpenAI/Gemini/HF embedding functions (#315).
+    "chromadb>=1.0.0",
     "sentence-transformers>=2.2.0",
     "openai>=1.0.0",
     "google-genai>=0.7.0",


### PR DESCRIPTION
The merged #315 relies on `chromadb.utils.embedding_functions.register_embedding_function` to register the custom OpenAI/Gemini/HuggingFace embedding functions. That symbol was **introduced in chromadb 1.0.0** (verified absent at 0.6.3, present at 1.0.0). The `[semantic]` extra still pinned `>=0.4.0`, so a fresh install resolving an old chromadb would `ImportError` at import time in `chroma_client.py`.

Bumps the floor to `chromadb>=1.0.0`. `[semantic]`-only; no effect on the base install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)