### PR TITLE
fix(security): SSRF guard on the open-access PDF download path (#326)

### DIFF
--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -3,8 +3,11 @@
 import json
 import os
 import re
+import socket
 import tempfile
+from ipaddress import ip_address
 from pathlib import Path
+from urllib.parse import urljoin, urlparse
 
 import requests
 
@@ -442,8 +445,83 @@ def _normalize_arxiv_id(raw):
 # PDF / open-access helpers
 # ---------------------------------------------------------------------------
 
+_MAX_PDF_REDIRECTS = 5
+_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+
+
+def _url_resolves_to_public_host(url: str) -> bool:
+    """Return ``True`` only if ``url`` is http(s) and its host resolves
+    entirely to globally-routable IP addresses.
+
+    SSRF guard for the open-access PDF download path: the candidate URL comes
+    from third-party metadata APIs (Unpaywall / Semantic Scholar) and is
+    therefore attacker-influenceable (a hostile paper record, or prompt
+    injection steering ``zotero_add_by_doi``). We reject non-http(s) schemes
+    and any host that resolves to a private, loopback, link-local, reserved,
+    or otherwise non-global address — including the 169.254.169.254
+    cloud-metadata endpoint, which matters for HTTP/SSE-transport deployments.
+
+    Note: a determined DNS-rebinding attacker could still flip the record
+    between this check and the socket connect. Re-validating every redirect
+    hop (see ``_guarded_pdf_get``) and rejecting on the first non-global
+    result narrows that window to a non-practical vector for this tool's
+    threat model; full pinning would require a custom connection adapter.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return False
+    try:
+        infos = socket.getaddrinfo(parsed.hostname, parsed.port or None)
+    except (socket.gaierror, UnicodeError, ValueError):
+        return False
+    if not infos:
+        return False
+    for info in infos:
+        sockaddr = info[4]
+        try:
+            ip = ip_address(sockaddr[0])
+        except ValueError:
+            return False
+        if not ip.is_global or ip.is_reserved or ip.is_multicast:
+            return False
+    return True
+
+
+def _guarded_pdf_get(pdf_url, ctx):
+    """GET ``pdf_url`` with SSRF protection.
+
+    Validates that the host resolves to public IPs, follows redirects
+    manually (re-validating each hop), and returns the final ``requests``
+    response, or ``None`` if any URL in the chain is rejected or there are
+    too many redirects.
+    """
+    current = pdf_url
+    for _ in range(_MAX_PDF_REDIRECTS + 1):
+        if not _url_resolves_to_public_host(current):
+            ctx.info(f"PDF URL rejected by SSRF guard: {current}")
+            return None
+        resp = requests.get(current, timeout=30, stream=True, allow_redirects=False)
+        if resp.status_code in _REDIRECT_STATUSES:
+            location = resp.headers.get("Location")
+            try:
+                resp.close()
+            except Exception:
+                pass
+            if not location:
+                return None
+            current = urljoin(current, location)
+            continue
+        return resp
+    ctx.info("Too many redirects while fetching PDF")
+    return None
+
+
 def _download_and_attach_pdf(write_zot, item_key, pdf_url, doi, ctx):
     """Download a PDF from a URL and attach it to a Zotero item.
+
+    The URL is fetched through ``_guarded_pdf_get`` (SSRF guard + manual
+    redirect re-validation), since it originates from third-party metadata
+    APIs rather than the user.
 
     Returns the WebDAV-status suffix string on success (``""`` when WebDAV
     is not configured, otherwise something like ``" (uploaded to WebDAV
@@ -451,7 +529,9 @@ def _download_and_attach_pdf(write_zot, item_key, pdf_url, doi, ctx):
     on failure so callers can branch with ``if suffix is not None``.
     """
     try:
-        pdf_resp = requests.get(pdf_url, timeout=30, stream=True)
+        pdf_resp = _guarded_pdf_get(pdf_url, ctx)
+        if pdf_resp is None:
+            return None
         pdf_resp.raise_for_status()
 
         content_type = pdf_resp.headers.get("Content-Type", "")

--- a/tests/test_pdf_cascade.py
+++ b/tests/test_pdf_cascade.py
@@ -53,6 +53,13 @@ class _AttachZotero(FakeZotero):
         self.attachments.append({"files": files, "parentid": parentid})
 
 
+def _allow_ssrf_guard(monkeypatch):
+    """Bypass the SSRF host check so a test can exercise download logic
+    (content-type / size) without depending on real DNS resolution."""
+    from zotero_mcp.tools import _helpers
+    monkeypatch.setattr(_helpers, "_url_resolves_to_public_host", lambda url: True)
+
+
 # ---------------------------------------------------------------------------
 # _try_unpaywall
 # ---------------------------------------------------------------------------
@@ -222,6 +229,7 @@ class TestDownloadAndAttachPdf:
     def test_download_content_type_check(self, monkeypatch, dummy_ctx):
         """Response with text/html content-type -> file NOT attached."""
         zot = _AttachZotero()
+        _allow_ssrf_guard(monkeypatch)
 
         def fake_get(url, **kwargs):
             return _FakeHTTPResponse(
@@ -238,6 +246,7 @@ class TestDownloadAndAttachPdf:
     def test_download_too_small(self, monkeypatch, dummy_ctx):
         """Response < 1000 bytes -> file NOT attached."""
         zot = _AttachZotero()
+        _allow_ssrf_guard(monkeypatch)
         tiny_content = b"%PDF-1.4 tiny"  # well under 1000 bytes
 
         def fake_get(url, **kwargs):
@@ -249,6 +258,69 @@ class TestDownloadAndAttachPdf:
         monkeypatch.setattr(requests, "get", fake_get)
         result = _download_and_attach_pdf(zot, "ITEM1", "https://x.com/f.pdf",
                                           "10.1234/test", dummy_ctx)
+        assert result is None
+        assert len(zot.attachments) == 0
+
+    # -- SSRF guard ---------------------------------------------------------
+
+    def test_download_rejects_loopback(self, monkeypatch, dummy_ctx):
+        """A URL resolving to loopback is rejected before any HTTP request."""
+        zot = _AttachZotero()
+        called = []
+        monkeypatch.setattr(requests, "get",
+                            lambda *a, **k: called.append(1))
+        result = _download_and_attach_pdf(
+            zot, "ITEM1", "http://127.0.0.1:23119/api/users/0", "10.1/x", dummy_ctx)
+        assert result is None
+        assert called == []          # guard short-circuits before requests.get
+        assert len(zot.attachments) == 0
+
+    def test_download_rejects_cloud_metadata(self, monkeypatch, dummy_ctx):
+        """The 169.254.169.254 cloud-metadata endpoint is rejected."""
+        zot = _AttachZotero()
+        called = []
+        monkeypatch.setattr(requests, "get", lambda *a, **k: called.append(1))
+        result = _download_and_attach_pdf(
+            zot, "ITEM1", "http://169.254.169.254/latest/meta-data/", "10.1/x", dummy_ctx)
+        assert result is None
+        assert called == []
+
+    def test_download_rejects_private_range(self, monkeypatch, dummy_ctx):
+        """An RFC1918 host is rejected."""
+        zot = _AttachZotero()
+        called = []
+        monkeypatch.setattr(requests, "get", lambda *a, **k: called.append(1))
+        result = _download_and_attach_pdf(
+            zot, "ITEM1", "http://10.0.0.5/secret.pdf", "10.1/x", dummy_ctx)
+        assert result is None
+        assert called == []
+
+    def test_download_rejects_non_http_scheme(self, monkeypatch, dummy_ctx):
+        """Non-http(s) schemes (file://, gopher://) are rejected."""
+        zot = _AttachZotero()
+        called = []
+        monkeypatch.setattr(requests, "get", lambda *a, **k: called.append(1))
+        for url in ("file:///etc/passwd", "gopher://127.0.0.1/x"):
+            assert _download_and_attach_pdf(zot, "ITEM1", url, "10.1/x", dummy_ctx) is None
+        assert called == []
+
+    def test_download_rejects_redirect_to_private(self, monkeypatch, dummy_ctx):
+        """A public URL that 302-redirects to a private host is rejected."""
+        from zotero_mcp.tools import _helpers
+
+        # First hop (public) passes the resolver; the redirect target is a
+        # literal loopback IP, which the guard rejects on re-validation.
+        monkeypatch.setattr(_helpers, "_url_resolves_to_public_host",
+                            lambda url: "evil.example" in url)
+
+        def fake_get(url, **kwargs):
+            return _FakeHTTPResponse(
+                302, headers={"Location": "http://127.0.0.1:23119/api"})
+
+        monkeypatch.setattr(requests, "get", fake_get)
+        result = _download_and_attach_pdf(
+            zot := _AttachZotero(), "ITEM1", "https://evil.example/p.pdf",
+            "10.1/x", dummy_ctx)
         assert result is None
         assert len(zot.attachments) == 0
 


### PR DESCRIPTION
Addresses **finding 1 (medium)** of the security review in #326 (thanks @elfrost).

## Problem
`zotero_add_by_doi` with the default `attach_mode='auto'` resolves an open-access PDF URL from third-party metadata APIs (Unpaywall, Semantic Scholar) and passed it straight to `requests.get(pdf_url, ...)` in `_download_and_attach_pdf` — no scheme/host check, default redirect following. The URL is attacker-influenceable (hostile paper record, or prompt injection steering the agent to add a specific DOI), so it could target internal services: `169.254.169.254` cloud-metadata / RFC1918 on HTTP/SSE deployments, and a localhost probe oracle on the default stdio install.

## Fix
- `_url_resolves_to_public_host(url)` — http(s) only; resolves **every** returned address and rejects if any is non-global / loopback / link-local / reserved / multicast (covers the metadata endpoint and RFC1918/ULA).
- `_guarded_pdf_get(url, ctx)` — disables automatic redirects and **re-validates every redirect hop**, closing the public→private redirect bypass.
- All OA sources funnel through this single sink; arXiv/PMC/scite use hardcoded hosts and were already safe.

Residual: a DNS-rebinding attacker could flip the record between check and connect; per-hop re-validation narrows this to a non-practical vector for the tool's threat model (noted in a code comment). Full pinning would need a custom connection adapter — out of scope here.

## Tests
New: rejects loopback, cloud-metadata, RFC1918, non-http schemes, and a public→private redirect (asserting `requests.get` is never reached for the pre-resolve rejects). Existing content-type/size tests retained. Full suite: 883 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)