### PR TITLE
fix(security): credential-hygiene + DoS hardening batch (#326, findings 2-6)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,10 @@ COPY . /app
 RUN pip install --no-cache-dir build hatchling \
     && pip install --no-cache-dir .
 
+# Run as a non-root user (defense-in-depth for multi-tenant hosts)
+RUN useradd --create-home --shell /usr/sbin/nologin app \
+    && chown -R app:app /app
+USER app
+
 # Start the MCP server
 ENTRYPOINT ["zotero-mcp", "serve", "--transport", "stdio"]

--- a/src/zotero_mcp/cli.py
+++ b/src/zotero_mcp/cli.py
@@ -132,6 +132,12 @@ def _save_zotero_db_path_to_config(config_path: Path, db_path: str) -> None:
         # Write back to file
         with open(config_path, 'w') as f:
             json.dump(full_config, f, indent=2)
+        # The config can hold credentials (API/embedding keys) — keep it
+        # owner-only. Best-effort; no-op on platforms without POSIX perms.
+        try:
+            os.chmod(config_path, 0o600)
+        except OSError:
+            pass
 
         print(f"Saved Zotero database path to config: {config_path}")
 

--- a/src/zotero_mcp/pdfannots_helper.py
+++ b/src/zotero_mcp/pdfannots_helper.py
@@ -107,11 +107,15 @@ def extract_annotations_from_pdf(
     ]
 
     try:
-        # Run the command and capture JSON output
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        # Run the command and capture JSON output. Bound the runtime so a
+        # hostile/oversized PDF can't wedge the worker indefinitely.
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=120)
         annotations = json.loads(result.stdout)
         print(f"Extracted {len(annotations)} annotations from PDF")
         return annotations
+    except subprocess.TimeoutExpired:
+        print("Error: pdfannots2json timed out (PDF too large or unresponsive)")
+        return []
     except subprocess.CalledProcessError as e:
         print(f"Error extracting annotations: {e}")
         print(f"stderr: {e.stderr}")

--- a/src/zotero_mcp/setup_helper.py
+++ b/src/zotero_mcp/setup_helper.py
@@ -25,6 +25,20 @@ def _obfuscate_sensitive(value: str | None, keep_chars: int = 4) -> str:
     return value[:keep_chars] + "*" * (len(value) - keep_chars)
 
 
+def _restrict_file_permissions(path) -> None:
+    """Best-effort ``chmod 600`` on a config file that may hold credentials.
+
+    Config files written here can contain ZOTERO_API_KEY and OpenAI/Gemini
+    keys; default umask often leaves them world-readable, which matters on
+    shared hosts / synced ~/.config. No-op on platforms without POSIX
+    permissions (Windows).
+    """
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
 def find_executable():
     """Find the full path to the zotero-mcp executable."""
     # Try to find the executable in the PATH
@@ -353,6 +367,7 @@ def save_semantic_search_config(config: dict, semantic_config_path: Path) -> boo
         # Write config
         with open(semantic_config_path, 'w') as f:
             json.dump(full_semantic_config, f, indent=2)
+        _restrict_file_permissions(semantic_config_path)
 
         print(f"Semantic search configuration saved to: {semantic_config_path}")
         return True
@@ -446,6 +461,7 @@ def update_claude_config(config_path, zotero_mcp_path, local=True, api_key=None,
     try:
         with open(config_path, 'w') as f:
             json.dump(config, f, indent=2)
+        _restrict_file_permissions(config_path)
         print(f"\nSuccessfully wrote config to: {config_path}")
     except Exception as e:
         print(f"Error writing config file: {str(e)}")
@@ -492,6 +508,7 @@ def _write_standalone_config(local: bool, api_key: str, library_id: str, library
 
     with open(cfg_path, 'w') as f:
         json.dump(full, f, indent=2)
+    _restrict_file_permissions(cfg_path)
 
     return cfg_path
 
@@ -501,7 +518,10 @@ def main(cli_args=None):
     parser = argparse.ArgumentParser(description="Configure zotero-mcp for Claude Desktop")
     parser.add_argument("--no-local", action="store_true", help="Configure for Zotero Web API instead of local API")
     parser.add_argument("--no-claude", action="store_true", help="Don't setup Claude Desktop config: instead store settings in config file.")
-    parser.add_argument("--api-key", help="Zotero API key (only needed with --no-local)")
+    parser.add_argument("--api-key",
+                        help="Zotero API key (only needed with --no-local). Insecure on "
+                             "multi-user systems — leaks via 'ps'/shell history; omit to be "
+                             "prompted securely or set the ZOTERO_API_KEY env var.")
     parser.add_argument("--library-id", help="Zotero library ID (only needed with --no-local)")
     parser.add_argument("--library-type", choices=["user", "group"], default="user",
                         help="Zotero library type (only needed with --no-local)")
@@ -510,6 +530,9 @@ def main(cli_args=None):
                         help="Skip semantic search configuration")
     parser.add_argument("--semantic-config-only", action="store_true",
                         help="Only configure semantic search, skip Zotero setup")
+    parser.add_argument("--show-secrets", action="store_true",
+                        help="Print secrets (e.g. the Zotero API key) in plaintext in the "
+                             "setup summary. Off by default; values are masked.")
 
     # If this is being called from CLI with existing args
     if cli_args is not None and hasattr(cli_args, 'no_local'):
@@ -571,6 +594,18 @@ def main(cli_args=None):
     library_id = args.library_id
     library_type = args.library_type
 
+    # Web mode needs an API key. Prefer the env var, then prompt securely —
+    # avoid forcing it onto the command line (where it leaks via ps/history).
+    if not use_local and not api_key:
+        api_key = os.environ.get("ZOTERO_API_KEY")
+        if not api_key:
+            try:
+                api_key = getpass.getpass(
+                    "Enter your Zotero API key (hidden, input not echoed): "
+                ).strip()
+            except (EOFError, KeyboardInterrupt):
+                api_key = None
+
     # Configure semantic search if not skipped
     if not args.skip_semantic_search:
         # if there is already a semantic search configuration in the config file:
@@ -611,13 +646,26 @@ def main(cli_args=None):
             )
             print("\nSetup complete (standalone/web mode)!")
             print(f"Config saved to: {cfg_path}")
-            # Emit one-line client_env for easy copy/paste
+            # Emit one-line client_env for easy copy/paste. Mask the API key
+            # by default — single-line JSON is exactly what gets pasted into
+            # bug reports / shared terminals; only print it in full on request.
             try:
                 with open(cfg_path) as f:
                     full = json.load(f)
-                env_line = json.dumps(full.get("client_env", {}), separators=(',', ':'))
+                client_env = full.get("client_env", {})
+                show_secrets = getattr(args, "show_secrets", False)
+                if show_secrets:
+                    display_env = client_env
+                else:
+                    display_env = dict(client_env)
+                    if display_env.get("ZOTERO_API_KEY"):
+                        display_env["ZOTERO_API_KEY"] = _obfuscate_sensitive(
+                            display_env["ZOTERO_API_KEY"]
+                        )
                 print("Client environment (single-line JSON):")
-                print(env_line)
+                print(json.dumps(display_env, separators=(',', ':')))
+                if not show_secrets and client_env.get("ZOTERO_API_KEY"):
+                    print("  (API key masked — re-run with --show-secrets to print it in full)")
             except Exception:
                 pass
             if semantic_config_changed:

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,0 +1,56 @@
+"""Tests for the security-hardening fixes from issue #326.
+
+Covers the credential-file permission helper (#3) and the pdfannots2json
+subprocess timeout handling (#5). The SSRF guard (#1) is covered in
+test_pdf_cascade.py. The plaintext-key gating (#2), --api-key getpass
+fallback (#4), and Dockerfile USER (#6) are exercised manually.
+"""
+
+import os
+import stat
+import subprocess
+import tempfile
+
+import pytest
+
+
+def test_restrict_file_permissions_sets_owner_only():
+    """_restrict_file_permissions tightens a world-readable file to 0o600."""
+    if os.name != "posix":
+        pytest.skip("POSIX file permissions only")
+    from zotero_mcp.setup_helper import _restrict_file_permissions
+
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    try:
+        os.chmod(path, 0o644)
+        _restrict_file_permissions(path)
+        assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+    finally:
+        os.unlink(path)
+
+
+def test_restrict_file_permissions_swallows_errors():
+    """Missing file must not raise (best-effort hardening)."""
+    from zotero_mcp.setup_helper import _restrict_file_permissions
+
+    # Should not raise even though the path does not exist.
+    _restrict_file_permissions("/nonexistent/path/to/config.json")
+
+
+def test_pdfannots_timeout_returns_empty(monkeypatch):
+    """A pdfannots2json timeout is handled gracefully (returns [])."""
+    import zotero_mcp.pdfannots_helper as ph
+
+    monkeypatch.setattr(ph, "ensure_pdfannots_installed", lambda: True)
+    monkeypatch.setattr(ph, "get_pdfannots_executable", lambda: "/bin/true")
+
+    def _raise_timeout(*args, **kwargs):
+        # Confirm the call is bounded by a timeout.
+        assert kwargs.get("timeout"), "subprocess.run must pass a timeout"
+        raise subprocess.TimeoutExpired(cmd="pdfannots2json", timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(ph.subprocess, "run", _raise_timeout)
+
+    result = ph.extract_annotations_from_pdf("/nonexistent.pdf", output_dir=".")
+    assert result == []


### PR DESCRIPTION
Addresses **findings 2–6** of the security review in #326 (thanks @elfrost). Finding 1 (SSRF) landed separately in #327.

| # | Sev | Fix |
|---|-----|-----|
| 2 | med | `setup --no-claude` printed the full `ZOTERO_API_KEY` as single-line JSON (despite masking it 25 lines earlier). Now masked by default; `--show-secrets` to opt in. |
| 3 | low | Config files holding API/embedding keys were written world-readable under default umask. `chmod 0o600` after each write (`_restrict_file_permissions`; best-effort, no-op on non-POSIX). |
| 4 | low | `--api-key` leaked via `argv` (`ps`/shell history). Prefer `ZOTERO_API_KEY` env var, else `getpass` prompt — mirrors the existing OpenAI/Gemini handling. Flag still works, documented as insecure. |
| 5 | low | `pdfannots2json` subprocess had no timeout — a hostile/oversized PDF could wedge the worker. Added `timeout=120` + `TimeoutExpired` handling. |
| 6 | low | Dockerfile ran as root. Added a non-root `app` user before `ENTRYPOINT`. |

## Tests
New `tests/test_security_hardening.py`: file-permission helper sets `0o600` / swallows errors, and the pdfannots timeout returns `[]` (asserting `subprocess.run` is called with a `timeout`). Full suite: 886 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)