### PR TITLE
fix(scite): correct POST /papers body shape and case-insensitive DOI lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `scite_check_retractions` and Scite enrichment now reach the `/papers` endpoint correctly. `get_papers_batch` POSTed a `{"dois": [...]}` object, but the endpoint requires a bare JSON array and returns HTTP 400 ("Input should be a valid list") for the object form — which broke retraction checks entirely and silently dropped editorial notices from `scite_enrich_search`.
+- Scite lookups are now case-insensitive. Scite lowercases DOI keys in its `/papers` and `/tallies` responses, so retractions and tallies on DOIs containing uppercase characters (e.g. `10.1016/S0140-6736(97)11096-0`) were missed, producing a false "all clear".
+
 ## [0.5.0] - 2026-06-08
 
 ### Added

--- a/src/zotero_mcp/scite_client.py
+++ b/src/zotero_mcp/scite_client.py
@@ -105,7 +105,7 @@ def get_papers_batch(dois: list[str]) -> dict[str, dict]:
     try:
         resp = requests.post(
             f"{_BASE}/papers",
-            json={"dois": dois[:500]},
+            json=dois[:500],
             headers=_HEADERS,
             timeout=_TIMEOUT,
         )

--- a/src/zotero_mcp/tools/scite.py
+++ b/src/zotero_mcp/tools/scite.py
@@ -86,17 +86,19 @@ def enrich_items(items: list[dict]) -> dict[str, dict[str, str]]:
         return {}
 
     dois = list(doi_map.keys())
-    tallies = _scite.get_tallies_batch(dois)
-    papers = _scite.get_papers_batch(dois)
+    # Scite lowercases DOI keys in its responses; index by lowercase so
+    # original-case DOIs (DOIs are case-insensitive) still match.
+    tallies = {k.lower(): v for k, v in _scite.get_tallies_batch(dois).items()}
+    papers = {k.lower(): v for k, v in _scite.get_papers_batch(dois).items()}
 
     result: dict[str, dict[str, str]] = {}
     for doi in dois:
         fields: dict[str, str] = {}
-        tally = tallies.get(doi)
+        tally = tallies.get(doi.lower())
         if tally:
             fields["Scite"] = _format_tally_line(tally)
 
-        paper = papers.get(doi)
+        paper = papers.get(doi.lower())
         if paper:
             notices = paper.get("editorialNotices", [])
             if notices:
@@ -374,10 +376,14 @@ def check_retractions(
         if not papers:
             return "Could not reach Scite API — try again later."
 
+        # Scite lowercases DOI keys in its responses; index by lowercase so
+        # original-case DOIs (DOIs are case-insensitive) still match.
+        papers = {k.lower(): v for k, v in papers.items()}
+
         # Find items with notices
         flagged: list[tuple[dict, list[dict]]] = []
         for doi, item in doi_items.items():
-            paper = papers.get(doi, {})
+            paper = papers.get(doi.lower(), {})
             notices = paper.get("editorialNotices", [])
             if notices:
                 flagged.append((item, notices))

--- a/tests/test_scite.py
+++ b/tests/test_scite.py
@@ -1,0 +1,120 @@
+"""Tests for the Scite integration (scite_client + tools/scite).
+
+Covers two API-contract bugs:
+
+1. ``get_papers_batch`` must POST a bare JSON array to ``/papers``. The
+   object form ``{"dois": [...]}`` returns HTTP 400 ("Input should be a
+   valid list"), which silently breaks paper-metadata enrichment and
+   ``scite_check_retractions`` entirely.
+
+2. Scite lowercases DOI keys in its responses (both ``/papers`` and
+   ``/tallies``), while the tools look results up by the original-case DOI
+   from ``_normalize_doi`` (which preserves case). A retraction on an
+   uppercase DOI (e.g. Wakefield 1998, ``10.1016/S0140-6736(97)11096-0``)
+   was therefore missed, producing a false "all clear".
+"""
+
+from zotero_mcp import scite_client
+from zotero_mcp.tools import scite as scite_tools
+
+# A real DOI with uppercase characters whose Scite record carries editorial
+# notices (the retracted Wakefield 1998 MMR paper).
+UPPER_DOI = "10.1016/S0140-6736(97)11096-0"
+LOWER_DOI = UPPER_DOI.lower()
+
+
+class _FakeResp:
+    """Minimal ``requests.Response`` stub."""
+
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — POST /papers requires a bare JSON array body
+# ---------------------------------------------------------------------------
+
+
+def test_get_papers_batch_posts_bare_doi_array(monkeypatch):
+    """The request body must be a bare list, not ``{"dois": [...]}``."""
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["json"] = json
+        return _FakeResp(200, {"papers": {"10.1162/tacl_a_00638": {"title": "X"}}})
+
+    monkeypatch.setattr(scite_client.requests, "post", fake_post)
+
+    result = scite_client.get_papers_batch(["10.1162/tacl_a_00638"])
+
+    assert captured["json"] == ["10.1162/tacl_a_00638"]
+    assert result == {"10.1162/tacl_a_00638": {"title": "X"}}
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — case-insensitive DOI lookup against Scite's lowercased keys
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_items_matches_lowercased_scite_keys(monkeypatch):
+    """enrich_items must match an uppercase-DOI item to Scite's lowercase keys."""
+    monkeypatch.setattr(
+        scite_tools._scite,
+        "get_tallies_batch",
+        lambda dois: {
+            LOWER_DOI: {
+                "supporting": 1,
+                "contradicting": 2,
+                "mentioning": 3,
+                "citingPublications": 6,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        scite_tools._scite,
+        "get_papers_batch",
+        lambda dois: {
+            LOWER_DOI: {
+                "editorialNotices": [
+                    {"type": "retraction", "sourceDoi": "10.1016/x"}
+                ]
+            }
+        },
+    )
+
+    items = [{"data": {"DOI": UPPER_DOI, "title": "Wakefield 1998"}}]
+    result = scite_tools.enrich_items(items)
+
+    # Result is keyed by the original-case DOI (what enrich_search looks up).
+    assert UPPER_DOI in result
+    assert "Scite" in result[UPPER_DOI]
+    assert "Editorial Notices" in result[UPPER_DOI]
+
+
+def test_check_retractions_flags_uppercase_doi(monkeypatch, dummy_ctx, fake_zot):
+    """check_retractions must flag a retracted paper whose DOI is uppercase."""
+    fake_zot._items = [
+        {"key": "ITEM0001", "data": {"DOI": UPPER_DOI, "title": "Wakefield 1998"}}
+    ]
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake_zot)
+    monkeypatch.setattr(
+        scite_tools._scite,
+        "get_papers_batch",
+        lambda dois: {
+            LOWER_DOI: {
+                "editorialNotices": [
+                    {"type": "retraction", "sourceDoi": "10.1016/x"}
+                ]
+            }
+        },
+    )
+
+    result = scite_tools.check_retractions(ctx=dummy_ctx)
+
+    assert "Editorial Notice Alerts" in result
+    assert "Retraction" in result
+    assert "All clear" not in result


### PR DESCRIPTION
## Summary

Two independent bugs in the Scite integration (`scite_client.py` + `tools/scite.py`), both verified against the live Scite API on 2026-06-09 (found on 0.4.1, reproduced on `main` @ 0.5.0).

## Bug 1 — `POST /papers` requires a bare JSON array body

`get_papers_batch` posts `json={"dois": dois[:500]}`, but `https://api.scite.ai/papers` expects a **bare JSON array**, not an object. The object form returns HTTP 400 (`"Input should be a valid list"`), so `get_papers_batch` always returns `{}`. Impact:

- **`scite_check_retractions` is broken entirely** — `papers` is always empty, so the tool returns "Could not reach Scite API — try again later." and never checks anything.
- **`scite_enrich_search` silently drops editorial notices** — the batch enrichment path can't fetch paper metadata, so retraction/correction alerts never appear (tallies still work, since they use the already-correct `get_tallies_batch`).

The sibling `get_tallies_batch` already does it correctly (`json=dois[:500]`).

**Repro:**

```bash
# object form → HTTP 400
curl -s -X POST -H "Content-Type: application/json" \
  -d '{"dois":["10.1162/tacl_a_00638"]}' https://api.scite.ai/papers
# {"detail":[{"type":"list_type","loc":["body"],"msg":"Input should be a valid list", ...}]}

# bare array → HTTP 200
curl -s -X POST -H "Content-Type: application/json" \
  -d '["10.1162/tacl_a_00638"]' https://api.scite.ai/papers
# {"papers": {"10.1162/tacl_a_00638": {...}}}
```

**Fix:** `json={"dois": dois[:500]}` → `json=dois[:500]`. The response shape (`{"papers": {...}}`) is unchanged, so the existing `.get("papers", {})` parse still works.

## Bug 2 — case-insensitive DOI lookup

Scite **lowercases DOI keys** in its responses (both `POST /papers` and `POST /tallies`). But `check_retractions` and `enrich_items` look results up by the original-case DOI (from `_normalize_doi`, which preserves case), so any DOI containing uppercase characters misses — a **silent false "all clear"** for retraction checks, and missing tallies/notices for enrichment.

**Repro** (real retracted paper — Wakefield 1998 MMR, which Scite flags with editorial notices including "Retracted"):

```bash
curl -s -X POST -H "Content-Type: application/json" \
  -d '["10.1016/S0140-6736(97)11096-0"]' https://api.scite.ai/papers \
  | python3 -c "import sys,json; d=json.load(sys.stdin)['papers']; print('response keys:', list(d)); k=next(iter(d)); print('notice count:', len(d[k].get('editorialNotices',[])))"
# response keys: ['10.1016/s0140-6736(97)11096-0']   <- lowercased by Scite
# notice count: 30
```

Sent `10.1016/S0140-6736(97)11096-0` (uppercase `S`), got back the key `10.1016/s0140-6736(97)11096-0`. Before the fix, `papers.get("10.1016/S0140-6736(97)11096-0")` → `None` → not flagged. After, it's flagged correctly.

**Fix:** index the response dicts by lowercase once and look up with `doi.lower()` — applied to both the `tallies` and `papers` lookups in `enrich_items`, and the `papers` lookup in `check_retractions`.

## Tests

Adds `tests/test_scite.py` — 3 tests, no network (the `requests.post` call and the `_scite` batch calls are monkeypatched):

- `test_get_papers_batch_posts_bare_doi_array` — asserts the request body is a bare list, not `{"dois": [...]}`.
- `test_enrich_items_matches_lowercased_scite_keys` — an uppercase-DOI item matches Scite's lowercase response keys.
- `test_check_retractions_flags_uppercase_doi` — a retracted uppercase-DOI paper is flagged, not reported "all clear".

All three fail on `main` and pass with this change; the rest of the suite is unaffected.

## Changelog

Added a `### Fixed` entry under `[Unreleased]`.
