### PR TITLE
feat(docker): publish multi-flavor GHCR images and document container runtime/persistence

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,8 @@
 name: Build and publish Docker images
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches:
@@ -27,17 +30,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -51,7 +54,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ steps.image.outputs.name }}
           tags: |
@@ -85,7 +88,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and (conditionally) publish
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,101 @@
+name: Build and publish Docker images
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - flavor: core
+            extras: ""
+          - flavor: all
+            extras: all
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image name
+        id: image
+        run: |
+          IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY,,}"
+          echo "name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=short,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build flavor tag set
+        id: tags
+        shell: bash
+        run: |
+          flavor="${{ matrix.flavor }}"
+          {
+            echo "value<<EOF"
+            while IFS= read -r tag; do
+              [ -z "$tag" ] && continue
+              echo "${tag}-${flavor}"
+            done <<< "${{ steps.meta.outputs.tags }}"
+
+            if [ "$flavor" = "all" ]; then
+              while IFS= read -r tag; do
+                [ -z "$tag" ] && continue
+                echo "$tag"
+              done <<< "${{ steps.meta.outputs.tags }}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and (conditionally) publish
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.tags.outputs.value }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.variant=${{ matrix.flavor }}
+          build-args: |
+            INSTALL_EXTRAS=${{ matrix.extras }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
 name: Build and publish to PyPI
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 on:
   push:
     tags:
@@ -18,8 +21,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install package and test dependencies
@@ -34,8 +37,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - name: Build package

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,23 @@ FROM python:3.10-slim
 # Set working directory
 WORKDIR /app
 
+# Select dependency flavor at build time.
+# Valid values: "" (core), "all", "semantic", "pdf", "scite".
+ARG INSTALL_EXTRAS=""
+
 # Copy the project files
 COPY . /app
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Install build dependencies and install the package
 RUN pip install --no-cache-dir build hatchling \
-    && pip install --no-cache-dir .
+    && if [ -n "$INSTALL_EXTRAS" ]; then pip install --no-cache-dir ".[${INSTALL_EXTRAS}]"; else pip install --no-cache-dir .; fi \
+    && chmod 755 /usr/local/bin/entrypoint.sh
 
 # Run as a non-root user (defense-in-depth for multi-tenant hosts)
 RUN useradd --create-home --shell /usr/sbin/nologin app \
     && chown -R app:app /app
 USER app
 
-# Start the MCP server
-ENTRYPOINT ["zotero-mcp", "serve", "--transport", "stdio"]
+# Default to MCP server mode; can switch to CLI via ZOTERO_APP=cli.
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -369,6 +369,13 @@ The image supports both MCP server and standalone CLI modes.
 - **Server mode (default)**: runs `zotero-mcp serve --transport stdio`
 - **CLI mode**: set `ZOTERO_APP=cli` and pass normal `zotero-cli` arguments
 
+### Docker env vars and persistence
+
+- Container runtime vars: `ZOTERO_APP` (`server` or `cli`) and `ZOTERO_TRANSPORT` (default: `stdio`)
+- All standard Zotero MCP vars are supported in containers (`ZOTERO_LOCAL`, `ZOTERO_API_KEY`, `ZOTERO_LIBRARY_ID`, embedding provider keys, etc.)
+- ChromaDB persistence path in the container is `/home/app/.config/zotero-mcp/chroma_db/`
+- Persist config + ChromaDB by mounting `/home/app/.config/zotero-mcp`
+
 Examples:
 
 ```bash
@@ -380,6 +387,9 @@ docker run --rm ghcr.io/<owner>/zotero-mcp:latest serve --transport streamable-h
 
 # Standalone CLI mode
 docker run --rm -e ZOTERO_APP=cli ghcr.io/<owner>/zotero-mcp:latest search "machine learning"
+
+# Persist config + ChromaDB across runs
+docker run --rm -v zotero-mcp-data:/home/app/.config/zotero-mcp --env-file .env ghcr.io/<owner>/zotero-mcp:latest
 ```
 
 ## ⌨️ CLI Mode (`zotero-cli`)

--- a/README.md
+++ b/README.md
@@ -346,6 +346,42 @@ zotero-mcp db-status                       # Show database status and info
 zotero-mcp version                         # Show current version
 ```
 
+## 🐳 Docker Images (GHCR)
+
+This repository publishes multi-arch container images to GitHub Container Registry:
+
+- `ghcr.io/<owner>/zotero-mcp:<tag>-core` - lightweight install (no optional extras)
+- `ghcr.io/<owner>/zotero-mcp:<tag>-all` - full install with `[semantic,pdf,scite]`
+- Unsuffixed tags (for example `:latest`, `:vX.Y.Z`) point to the `all` flavor
+
+Detailed publishing and runtime notes are in `docs/docker-images.md`.
+
+Tag strategy:
+
+- Release tags: `vX.Y.Z`, `vX.Y`, `vX` (plus `-core` and `-all` variants)
+- Main branch: `latest` (plus `latest-core` and `latest-all`)
+- Immutable SHA tags: `sha-<shortsha>-core`, `sha-<shortsha>-all` (and unsuffixed SHA for `all`)
+
+### Runtime modes in the container
+
+The image supports both MCP server and standalone CLI modes.
+
+- **Server mode (default)**: runs `zotero-mcp serve --transport stdio`
+- **CLI mode**: set `ZOTERO_APP=cli` and pass normal `zotero-cli` arguments
+
+Examples:
+
+```bash
+# Default MCP server mode (stdio)
+docker run --rm ghcr.io/<owner>/zotero-mcp:latest
+
+# MCP server mode with explicit transport
+docker run --rm ghcr.io/<owner>/zotero-mcp:latest serve --transport streamable-http --host 0.0.0.0 --port 8000
+
+# Standalone CLI mode
+docker run --rm -e ZOTERO_APP=cli ghcr.io/<owner>/zotero-mcp:latest search "machine learning"
+```
+
 ## ⌨️ CLI Mode (`zotero-cli`)
 
 `zotero-cli` is a standalone terminal interface to your Zotero library. It uses the same tools as the MCP server but without needing an AI assistant — useful for quick lookups, shell scripts, and automation.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+app_mode="${ZOTERO_APP:-server}"
+
+if [ "$app_mode" = "cli" ]; then
+    if [ "$#" -eq 0 ]; then
+        set -- --help
+    fi
+    exec zotero-cli "$@"
+fi
+
+if [ "$#" -eq 0 ]; then
+    set -- serve --transport "${ZOTERO_TRANSPORT:-stdio}"
+fi
+
+exec zotero-mcp "$@"

--- a/docs/docker-images.md
+++ b/docs/docker-images.md
@@ -1,0 +1,51 @@
+# Docker Images and GHCR Publishing
+
+This project publishes Docker images to GitHub Container Registry (GHCR) via `.github/workflows/docker.yml`.
+
+## Flavors
+
+- `core`: base install with no optional extras
+- `all`: full install with `[semantic,pdf,scite]`
+
+Flavors are selected at build time through the Docker build arg `INSTALL_EXTRAS`:
+
+- `INSTALL_EXTRAS=""` -> core
+- `INSTALL_EXTRAS="all"` -> all
+
+## Tags
+
+The workflow publishes these tags:
+
+- Flavor tags: `*-core`, `*-all`
+- Release tags (from `v*` git tags): `vX.Y.Z`, `vX.Y`, `vX` (plus both flavor suffixes)
+- Main branch tags: `latest` (plus `latest-core`, `latest-all`)
+- Immutable tags: `sha-<shortsha>` (plus flavor suffixes)
+
+Unsuffixed tags map to the `all` flavor.
+
+## Runtime modes
+
+The container entrypoint supports both MCP server and CLI usage.
+
+- Default (`ZOTERO_APP=server`):
+  - Runs `zotero-mcp serve --transport stdio` when no arguments are provided
+  - Any explicit args are passed to `zotero-mcp`
+- CLI mode (`ZOTERO_APP=cli`):
+  - Runs `zotero-cli` with provided arguments
+  - Defaults to `zotero-cli --help` if no args are passed
+
+## Local build examples
+
+```bash
+# Core flavor
+docker build -t zotero-mcp:core --build-arg INSTALL_EXTRAS="" .
+
+# Full flavor
+docker build -t zotero-mcp:all --build-arg INSTALL_EXTRAS=all .
+
+# Run default MCP server mode
+docker run --rm zotero-mcp:all
+
+# Run CLI mode
+docker run --rm -e ZOTERO_APP=cli zotero-mcp:all search "transformer models"
+```

--- a/docs/docker-images.md
+++ b/docs/docker-images.md
@@ -34,6 +34,47 @@ The container entrypoint supports both MCP server and CLI usage.
   - Runs `zotero-cli` with provided arguments
   - Defaults to `zotero-cli --help` if no args are passed
 
+## Environment variables for containers
+
+Container-specific runtime variables:
+
+- `ZOTERO_APP`: `server` (default) or `cli`
+- `ZOTERO_TRANSPORT`: MCP transport used when `ZOTERO_APP=server` and no explicit args are passed (`stdio` default)
+
+Common Zotero MCP variables (same as non-container installs):
+
+- `ZOTERO_LOCAL=true`: use local Zotero API mode
+- `ZOTERO_API_KEY`, `ZOTERO_LIBRARY_ID`, `ZOTERO_LIBRARY_TYPE`: web/hybrid access
+- `ZOTERO_WEBDAV_URL`, `ZOTERO_WEBDAV_USERNAME`, `ZOTERO_WEBDAV_PASSWORD`: remote attachment download support
+- `ZOTERO_EMBEDDING_MODEL`: `default`, `openai`, `gemini`, or supported HF model
+- `OPENAI_API_KEY`, `OPENAI_EMBEDDING_MODEL`, `OPENAI_BASE_URL`
+- `GEMINI_API_KEY`, `GEMINI_EMBEDDING_MODEL`, `GEMINI_BASE_URL`
+- `ZOTERO_DB_PATH`: override path to `zotero.sqlite`
+
+Recommended pattern:
+
+```bash
+docker run --rm --env-file .env ghcr.io/<owner>/zotero-mcp:latest
+```
+
+## Persistence (config + ChromaDB)
+
+By default, the container stores config and semantic index under:
+
+- `/home/app/.config/zotero-mcp/config.json`
+- `/home/app/.config/zotero-mcp/chroma_db/`
+
+To persist configuration and ChromaDB across container restarts, mount that directory:
+
+```bash
+docker run --rm \
+  -v zotero-mcp-data:/home/app/.config/zotero-mcp \
+  --env-file .env \
+  ghcr.io/<owner>/zotero-mcp:latest
+```
+
+If you run semantic indexing (`zotero-mcp update-db` or `zotero-cli db update`) without this mount, ChromaDB is ephemeral and will be rebuilt in a new container.
+
 ## Local build examples
 
 ```bash
@@ -48,4 +89,7 @@ docker run --rm zotero-mcp:all
 
 # Run CLI mode
 docker run --rm -e ZOTERO_APP=cli zotero-mcp:all search "transformer models"
+
+# Run with persistent config + ChromaDB
+docker run --rm -v zotero-mcp-data:/home/app/.config/zotero-mcp zotero-mcp:all
 ```


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build and publish multi-arch Docker images to GHCR for `core` and `all` flavors.
- Add container entrypoint support for both MCP server mode and standalone CLI mode.
- Expand Docker docs (including README) with container env var guidance and ChromaDB persistence instructions.

## What changed

### Docker image/runtime
- Updated `Dockerfile` to support build-time flavor selection via `INSTALL_EXTRAS`.
- Added `docker/entrypoint.sh`:
  - default server behavior: `zotero-mcp serve --transport stdio` (or `ZOTERO_TRANSPORT` override)
  - CLI mode via `ZOTERO_APP=cli` using `zotero-cli`

### CI/CD publishing
- Added `.github/workflows/docker.yml`:
  - triggers on PR, `main`, and `v*` tags
  - builds `core` and `all` flavor images
  - publishes to `ghcr.io/<owner>/<repo>`
  - tag strategy includes semver, sha, `latest`, and flavor-suffixed tags (`-core`, `-all`)
  - unsuffixed tags map to `all`

### Documentation
- Updated `README.md` Docker section with:
  - container runtime env vars (`ZOTERO_APP`, `ZOTERO_TRANSPORT`)
  - note that standard Zotero MCP env vars are supported in containers
  - ChromaDB/config persistence mount path (`/home/app/.config/zotero-mcp`)
  - persistent volume usage examples
- Added/expanded `docs/docker-images.md` with:
  - flavor/tag behavior
  - env var reference for container usage
  - ChromaDB persistence behavior and examples

## Why
This introduces a clear and supported Docker distribution story for different dependency footprints (`core` vs `all`), enables both MCP-server and CLI container workflows, and prevents accidental loss of semantic index data by documenting persistent ChromaDB storage.