### PR TITLE
feat: add zotero_batch_update_extra for batch Extra-field key edits (#232)

### DIFF
--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -99,6 +99,7 @@ from zotero_mcp.tools.annotations import (  # noqa: F401
     delete_annotation,
 )
 from zotero_mcp.tools.write import (  # noqa: F401
+    batch_update_extra,
     batch_update_tags,
     create_collection,
     delete_collection,

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -235,6 +235,216 @@ def batch_update_tags(
         return f"Error in batch tag update: {str(e)}"
 
 
+def _apply_extra_edits(
+    extra: str,
+    set_keys: dict[str, str],
+    remove_keys: list[str],
+    replace: bool,
+) -> tuple[str, bool]:
+    """Apply `Key: value` line edits to an Extra field value.
+
+    Extra is treated as newline-separated lines; lines of the form
+    "Key: value" are matched by the text before the first colon,
+    case-insensitively. Free-form lines (no colon) are never touched.
+
+    Returns:
+        (new_extra, changed)
+    """
+    def line_key(line: str) -> str | None:
+        head, sep, _ = line.partition(":")
+        return head.strip().lower() if sep else None
+
+    original = extra or ""
+
+    if replace:
+        new_extra = "\n".join(f"{k}: {v}" for k, v in set_keys.items())
+        return new_extra, new_extra != original
+
+    lines = original.splitlines()
+
+    if remove_keys:
+        remove = {k.strip().lower() for k in remove_keys if k.strip()}
+        lines = [ln for ln in lines if line_key(ln) not in remove]
+
+    for key, value in (set_keys or {}).items():
+        target = key.strip().lower()
+        new_line = f"{key}: {value}"
+        out = []
+        replaced = False
+        for ln in lines:
+            if line_key(ln) == target:
+                # Replace the first matching line in place; drop duplicates.
+                if not replaced:
+                    out.append(new_line)
+                    replaced = True
+            else:
+                out.append(ln)
+        if not replaced:
+            out.append(new_line)
+        lines = out
+
+    new_extra = "\n".join(lines)
+    return new_extra, new_extra != original
+
+
+@mcp.tool(
+    name="zotero_batch_update_extra",
+    description=(
+        "Upsert and/or remove `Key: value` lines in the Extra field across "
+        "multiple items in one call — the batch counterpart of "
+        "zotero_update_item for Extra-field metadata (Better BibTeX "
+        "citation keys, tex.* fields, CSL variables). "
+        "item_keys: list of item keys to edit (or a JSON-encoded list "
+        "string). set_keys: mapping of key→value lines to upsert (or a "
+        "JSON object string); an existing line with the same key is "
+        "replaced in place, otherwise the line is appended. "
+        "remove_keys: list of key names whose lines are deleted. "
+        "replace: when true, rebuild Extra from set_keys only, dropping "
+        "every other line (incompatible with remove_keys). "
+        "Keys are matched by their `key:` prefix, case-insensitively; "
+        "free-form lines without a colon are preserved. Items needing no "
+        "change, attachments/notes/annotations, and unknown keys are "
+        "skipped (counted in the summary). "
+        "Requires a writable library (web API key or hybrid mode) — fails "
+        "in local-only mode. "
+        "Example: zotero_batch_update_extra(item_keys=['ABCD1234', "
+        "'EFGH5678'], set_keys={'tex.otscore': '2'}, "
+        "remove_keys=['tex.draft'])."
+    )
+)
+@with_zotero_api_lock
+def batch_update_extra(
+    item_keys: list[str] | str | None = None,
+    set_keys: dict[str, str] | str | None = None,
+    remove_keys: list[str] | str | None = None,
+    replace: bool | str = False,
+    *,
+    ctx: Context
+) -> str:
+    """
+    Batch update Extra-field key lines across multiple items.
+
+    Args:
+        item_keys: Item keys to edit (list or JSON-encoded list string)
+        set_keys: Mapping of key→value lines to upsert (dict or JSON object string)
+        remove_keys: Key names whose lines are deleted (list or JSON string)
+        replace: When true, rebuild Extra from set_keys only
+        ctx: MCP context
+
+    Returns:
+        Summary of the batch update
+    """
+    try:
+        try:
+            item_keys = _helpers._normalize_str_list_input(item_keys, "item_keys")
+            remove_keys = _helpers._normalize_str_list_input(remove_keys, "remove_keys")
+        except ValueError as validation_error:
+            return f"Error: {validation_error}"
+
+        if not item_keys:
+            return "Error: Must provide item_keys to update"
+
+        if isinstance(set_keys, str):
+            try:
+                set_keys = json.loads(set_keys)
+            except json.JSONDecodeError:
+                return "Error: set_keys must be a mapping of key→value strings"
+        if set_keys is None:
+            set_keys = {}
+        if not isinstance(set_keys, dict):
+            return "Error: set_keys must be a mapping of key→value strings"
+        set_keys = {
+            str(k).strip(): str(v).strip()
+            for k, v in set_keys.items()
+            if str(k).strip()
+        }
+
+        if isinstance(replace, str):
+            replace = replace.strip().lower() in ("true", "1", "yes")
+        replace = bool(replace)
+
+        if not set_keys and not remove_keys and not replace:
+            return "Error: Must specify set_keys, remove_keys, or replace"
+        if replace and remove_keys:
+            return "Error: replace=True is incompatible with remove_keys"
+
+        ctx.info(f"Batch updating Extra field for {len(item_keys)} item(s)")
+        zot = _client.get_zotero_client()
+
+        try:
+            _, write_zot = _helpers._get_write_client(ctx)
+        except ValueError as e:
+            return str(e)
+
+        updated_count = 0
+        skipped_count = 0
+
+        for item_key in item_keys:
+            try:
+                item = zot.item(item_key)
+            except Exception as e:
+                ctx.error(f"Failed to fetch item {item_key}: {str(e)}")
+                skipped_count += 1
+                continue
+            if not item:
+                skipped_count += 1
+                continue
+
+            if item["data"].get("itemType") in ("attachment", "note", "annotation"):
+                skipped_count += 1
+                continue
+
+            extra = item["data"].get("extra", "") or ""
+            new_extra, changed = _apply_extra_edits(
+                extra, set_keys, remove_keys, replace
+            )
+            if not changed:
+                skipped_count += 1
+                continue
+
+            try:
+                # If writing via web API, re-fetch the item from web to get
+                # the correct version number for the update
+                if write_zot is not zot:
+                    web_item = write_zot.item(item_key)
+                    web_item["data"]["extra"] = new_extra
+                    result = write_zot.update_item(web_item)
+                else:
+                    item["data"]["extra"] = new_extra
+                    result = write_zot.update_item(item)
+
+                if _helpers._handle_write_response(result, ctx):
+                    updated_count += 1
+                else:
+                    ctx.error(f"Update may have failed for item {item_key}: {result}")
+                    skipped_count += 1
+            except Exception as e:
+                ctx.error(f"Failed to update item {item_key}: {str(e)}")
+                skipped_count += 1
+
+        response = ["# Batch Extra Update Results", ""]
+        response.append(f"Items processed: {len(item_keys)}")
+        response.append(f"Items updated: {updated_count}")
+        response.append(f"Items skipped: {skipped_count}")
+
+        if set_keys:
+            response.append("\n## Keys Set")
+            for key, value in set_keys.items():
+                response.append(f"- `{key}: {value}`")
+        if remove_keys:
+            response.append("\n## Keys Removed")
+            for key in remove_keys:
+                response.append(f"- `{key}`")
+        if replace:
+            response.append("\nExtra field fully replaced from set_keys.")
+
+        return "\n".join(response)
+
+    except Exception as e:
+        ctx.error(f"Error in batch extra update: {str(e)}")
+        return f"Error in batch extra update: {str(e)}"
+
+
 @mcp.tool(
     name="zotero_create_collection",
     description=(

--- a/tests/test_batch_update_extra.py
+++ b/tests/test_batch_update_extra.py
@@ -1,0 +1,258 @@
+"""Tests for zotero_batch_update_extra (issue #232).
+
+Batch upsert / removal of `Key: value` lines in the Extra field across
+multiple items, parallel to zotero_batch_update_tags.
+"""
+
+from zotero_mcp import server
+from zotero_mcp.tools.write import _apply_extra_edits
+
+
+class DummyContext:
+    def info(self, *_args, **_kwargs):
+        return None
+
+    def error(self, *_args, **_kwargs):
+        return None
+
+    def warning(self, *_args, **_kwargs):
+        return None
+
+
+class FakeZoteroForExtra:
+    """Fake client serving items by key and recording updates."""
+
+    def __init__(self, items):
+        self._items = {it["key"]: it for it in items}
+        self.updated = []
+
+    def item(self, item_key):
+        it = self._items.get(item_key)
+        if it is None:
+            raise KeyError(item_key)
+        return it
+
+    def update_item(self, item):
+        self.updated.append(item)
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Pure line-editing helper
+# ---------------------------------------------------------------------------
+
+
+def test_apply_extra_edits_upserts_into_empty_extra():
+    new_extra, changed = _apply_extra_edits(
+        "", set_keys={"tex.otscore": "2"}, remove_keys=[], replace=False
+    )
+    assert new_extra == "tex.otscore: 2"
+    assert changed is True
+
+
+def test_apply_extra_edits_replaces_existing_key_case_insensitive():
+    extra = "Citation Key: smith2020\ntex.otscore: 1\nfree-form note line"
+    new_extra, changed = _apply_extra_edits(
+        extra, set_keys={"TEX.OTSCORE": "2"}, remove_keys=[], replace=False
+    )
+    assert new_extra == "Citation Key: smith2020\nTEX.OTSCORE: 2\nfree-form note line"
+    assert changed is True
+
+
+def test_apply_extra_edits_appends_new_key_at_end():
+    extra = "Citation Key: smith2020"
+    new_extra, changed = _apply_extra_edits(
+        extra,
+        set_keys={"tex.provenance": "coursework:waldstreicher-80010"},
+        remove_keys=[],
+        replace=False,
+    )
+    assert new_extra == (
+        "Citation Key: smith2020\n"
+        "tex.provenance: coursework:waldstreicher-80010"
+    )
+    assert changed is True
+
+
+def test_apply_extra_edits_removes_matching_lines():
+    extra = "tex.otscore: 2\nCitation Key: smith2020\nTex.OtScore: 3"
+    new_extra, changed = _apply_extra_edits(
+        extra, set_keys={}, remove_keys=["tex.otscore"], replace=False
+    )
+    assert new_extra == "Citation Key: smith2020"
+    assert changed is True
+
+
+def test_apply_extra_edits_no_change_when_nothing_matches():
+    extra = "Citation Key: smith2020"
+    new_extra, changed = _apply_extra_edits(
+        extra, set_keys={}, remove_keys=["tex.otscore"], replace=False
+    )
+    assert new_extra == extra
+    assert changed is False
+
+
+def test_apply_extra_edits_no_change_when_value_already_set():
+    extra = "tex.otscore: 2"
+    new_extra, changed = _apply_extra_edits(
+        extra, set_keys={"tex.otscore": "2"}, remove_keys=[], replace=False
+    )
+    assert new_extra == extra
+    assert changed is False
+
+
+def test_apply_extra_edits_replace_rebuilds_from_set_keys():
+    extra = "Citation Key: smith2020\nfree-form note line"
+    new_extra, changed = _apply_extra_edits(
+        extra, set_keys={"tex.otscore": "2"}, remove_keys=[], replace=True
+    )
+    assert new_extra == "tex.otscore: 2"
+    assert changed is True
+
+
+def test_apply_extra_edits_preserves_freeform_lines():
+    extra = "this is not a key-value line\ntex.otscore: 1"
+    new_extra, changed = _apply_extra_edits(
+        extra, set_keys={"tex.otscore": "2"}, remove_keys=[], replace=False
+    )
+    assert new_extra == "this is not a key-value line\ntex.otscore: 2"
+    assert changed is True
+
+
+# ---------------------------------------------------------------------------
+# Tool-level behavior
+# ---------------------------------------------------------------------------
+
+
+def _make_items():
+    return [
+        {
+            "key": "ITEM0001",
+            "data": {
+                "itemType": "journalArticle",
+                "extra": "Citation Key: smith2020",
+            },
+        },
+        {
+            "key": "ITEM0002",
+            "data": {"itemType": "preprint", "extra": ""},
+        },
+        {
+            "key": "ATTACH01",
+            "data": {"itemType": "attachment", "extra": ""},
+        },
+    ]
+
+
+def _setup(monkeypatch, items):
+    fake = FakeZoteroForExtra(items)
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: False)
+    return fake
+
+
+def test_batch_update_extra_updates_multiple_items(monkeypatch):
+    fake = _setup(monkeypatch, _make_items())
+
+    result = server.batch_update_extra(
+        item_keys=["ITEM0001", "ITEM0002"],
+        set_keys={"tex.otscore": "2"},
+        ctx=DummyContext(),
+    )
+
+    assert len(fake.updated) == 2
+    for it in fake.updated:
+        assert "tex.otscore: 2" in it["data"]["extra"]
+    # ITEM0001 keeps its existing line
+    assert "Citation Key: smith2020" in fake.updated[0]["data"]["extra"]
+    assert "Items updated: 2" in result
+
+
+def test_batch_update_extra_removes_keys(monkeypatch):
+    items = _make_items()
+    items[0]["data"]["extra"] = "Citation Key: smith2020\ntex.otscore: 2"
+    fake = _setup(monkeypatch, items)
+
+    result = server.batch_update_extra(
+        item_keys=["ITEM0001"],
+        remove_keys=["tex.otscore"],
+        ctx=DummyContext(),
+    )
+
+    assert len(fake.updated) == 1
+    assert fake.updated[0]["data"]["extra"] == "Citation Key: smith2020"
+    assert "Items updated: 1" in result
+
+
+def test_batch_update_extra_skips_attachments(monkeypatch):
+    fake = _setup(monkeypatch, _make_items())
+
+    result = server.batch_update_extra(
+        item_keys=["ITEM0001", "ATTACH01"],
+        set_keys={"tex.otscore": "2"},
+        ctx=DummyContext(),
+    )
+
+    assert len(fake.updated) == 1
+    assert "Items skipped: 1" in result
+
+
+def test_batch_update_extra_accepts_json_string_set_keys(monkeypatch):
+    fake = _setup(monkeypatch, _make_items())
+
+    server.batch_update_extra(
+        item_keys='["ITEM0002"]',
+        set_keys='{"tex.otscore": "2"}',
+        ctx=DummyContext(),
+    )
+
+    assert len(fake.updated) == 1
+    assert fake.updated[0]["data"]["extra"] == "tex.otscore: 2"
+
+
+def test_batch_update_extra_requires_item_keys(monkeypatch):
+    _setup(monkeypatch, _make_items())
+
+    result = server.batch_update_extra(
+        item_keys=[], set_keys={"tex.otscore": "2"}, ctx=DummyContext()
+    )
+
+    assert result.startswith("Error")
+
+
+def test_batch_update_extra_requires_an_action(monkeypatch):
+    _setup(monkeypatch, _make_items())
+
+    result = server.batch_update_extra(
+        item_keys=["ITEM0001"], ctx=DummyContext()
+    )
+
+    assert result.startswith("Error")
+
+
+def test_batch_update_extra_replace_incompatible_with_remove_keys(monkeypatch):
+    _setup(monkeypatch, _make_items())
+
+    result = server.batch_update_extra(
+        item_keys=["ITEM0001"],
+        set_keys={"tex.otscore": "2"},
+        remove_keys=["tex.provenance"],
+        replace=True,
+        ctx=DummyContext(),
+    )
+
+    assert result.startswith("Error")
+
+
+def test_batch_update_extra_continues_after_missing_item(monkeypatch):
+    fake = _setup(monkeypatch, _make_items())
+
+    result = server.batch_update_extra(
+        item_keys=["NOSUCHKEY", "ITEM0002"],
+        set_keys={"tex.otscore": "2"},
+        ctx=DummyContext(),
+    )
+
+    assert len(fake.updated) == 1
+    assert "Items updated: 1" in result
+    assert "Items skipped: 1" in result

--- a/tests/test_description_tokens.py
+++ b/tests/test_description_tokens.py
@@ -40,6 +40,7 @@ TOOL_BUDGETS = {
     "zotero_get_tags":                 ( 85, 195),
     # tools/write.py
     "zotero_batch_update_tags":        (155, 350),
+    "zotero_batch_update_extra":       (165, 370),
     # tools/search.py
     "zotero_search_items":             (175, 400),
     "zotero_search_by_tag":            (115, 265),


### PR DESCRIPTION
## Summary

Closes #232. Workflows that store structured metadata as Extra-field lines (Better BibTeX citation keys, `tex.*` fields, CSL variables) had no batch mutation path — applying a schema like `tex.otscore: 2` to a 40-item reading list meant 40 serial `zotero_update_item` calls (and 120+ for multi-key passes), which is infeasible within rate limits at library scale. `zotero_batch_update_tags` already exists for tags; this adds the analogous tool for the Extra field.

## API

```python
zotero_batch_update_extra(
    item_keys=["ABCD1234", "EFGH5678", ...],   # explicit selection (or JSON-encoded list string)
    set_keys={"tex.otscore": "2"},              # upsert `key: value` lines
    remove_keys=["tex.draft"],                  # delete lines by key name
    replace=False,                              # True → rebuild Extra from set_keys only
)
```

Line semantics (pinned by unit tests):
- lines are matched by their `key:` prefix, **case-insensitively**; an existing line with the same key is replaced in place (duplicates dropped), new keys are appended at the end
- free-form lines without a colon are never touched
- `remove_keys` deletes every line whose key matches
- items needing no change, attachments/notes/annotations, and unresolvable keys are skipped and counted in the summary

## Changes

- `_apply_extra_edits()` — the line-editing logic as a pure function, separately unit-tested
- `batch_update_extra` tool — follows `zotero_batch_update_tags` conventions throughout: `@with_zotero_api_lock`, hybrid-mode write client via `_get_write_client` (web re-fetch for correct version numbers), per-item error isolation (one failure doesn't abort the batch), markdown summary with processed/updated/skipped counts
- registered the tool's description in `test_description_tokens.py` TOOL_BUDGETS (246 tokens, budget 165–370) per the repo's rubric-tracking convention

## Tests

16 new tests in `tests/test_batch_update_extra.py`:
- 8 unit tests pinning `_apply_extra_edits` semantics (upsert into empty / in-place case-insensitive replace / append / remove / no-op detection / replace-mode rebuild / free-form preservation)
- 8 tool-level tests (multi-item update, removal, attachment skip, JSON-string inputs, the three validation errors, continue-after-missing-key)

```
uv run pytest tests/test_batch_update_extra.py tests/test_description_tokens.py -q
37 passed
```

Full suite: 916 passed; the 5 pre-existing failures (`test_lifespan`, `test_place_field_reads`) fail identically on `main` and are unrelated.

## Notes / design decisions

- The issue sketches `replace: bool` but doesn't define what the replacement content is. Interpreted here as: `replace=True` rebuilds Extra **from `set_keys` only** (so `replace=True` with empty `set_keys` clears the field); incompatible with `remove_keys`. Happy to adjust if you prefer a different shape.
- No `limit` parameter (unlike the tags tool): selection is by explicit `item_keys`, so the caller already controls batch size; a cap would silently truncate an explicit list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)