### PR TITLE
fix(cli): repair 'add file' — drop phantom parent_key, expose --title/--item-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ zotero-cli ann search "highlight text"
 # Add items
 zotero-cli add doi 10.1038/s41586-021-03819-2
 zotero-cli add url https://arxiv.org/abs/2301.00001
-zotero-cli add file /path/to/paper.pdf
+zotero-cli add file --filepath /path/to/paper.pdf --title "Override Title"
 
 # Collections and tags
 zotero-cli coll list                          # list collections (short alias)

--- a/src/zotero_mcp/cli_standalone.py
+++ b/src/zotero_mcp/cli_standalone.py
@@ -236,7 +236,8 @@ def cmd_add(args):
         ))
     elif args.subcommand == "file":
         print(write_mod.add_from_file(
-            file_path=args.filepath, parent_key=getattr(args, "parent_key", None),
+            file_path=args.filepath, title=getattr(args, "title", None),
+            item_type=getattr(args, "item_type", "document"),
             collections=collections, tags=tags, ctx=ctx,
         ))
     else:
@@ -625,9 +626,11 @@ def build_parser() -> argparse.ArgumentParser:
     aurl.add_argument("--collections")
     aurl.add_argument("--tags")
     aurl.add_argument("--attach-mode", choices=["auto", "linked_url", "import_file"], default="auto")
-    afil = add_sub.add_parser("file", help="Add item from local file")
+    afil = add_sub.add_parser("file", help="Add item from local file (.pdf/.epub)")
     afil.add_argument("--filepath", required=True)
-    afil.add_argument("--parent-key")
+    afil.add_argument("--title", help="Override title if metadata extraction misses")
+    afil.add_argument("--item-type", default="document",
+                      help="Zotero item type for the new item (default: document)")
     afil.add_argument("--collections")
     afil.add_argument("--tags")
 

--- a/tests/test_cli_standalone.py
+++ b/tests/test_cli_standalone.py
@@ -1,13 +1,15 @@
 """Tests for the standalone CLI module (zotero-cli entry point)."""
 
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
+import zotero_mcp.tools.write as write_tools
 from zotero_mcp.cli_standalone import (
     CLIContext,
     build_parser,
+    cmd_add,
     cmd_edit,
     cmd_notes,
     cmd_search,
@@ -127,6 +129,29 @@ class TestParser:
         args = self.parser.parse_args(["coll", "search", "my collection"])
         assert args.command in ("collections", "coll")
         assert args.subcommand == "search"
+
+    def test_add_file_flags(self):
+        args = self.parser.parse_args([
+            "add", "file", "--filepath", "/tmp/x.pdf",
+            "--title", "Override", "--item-type", "book",
+        ])
+        assert args.subcommand == "file"
+        assert args.filepath == "/tmp/x.pdf"
+        assert args.title == "Override"
+        assert args.item_type == "book"
+
+    def test_add_file_defaults(self):
+        args = self.parser.parse_args(["add", "file", "--filepath", "/tmp/x.pdf"])
+        assert args.title is None
+        assert args.item_type == "document"
+
+    def test_add_file_parent_key_removed(self):
+        # --parent-key never mapped to a real add_from_file parameter and made
+        # every `add file` invocation raise TypeError; it must stay removed.
+        with pytest.raises(SystemExit):
+            self.parser.parse_args([
+                "add", "file", "--filepath", "/tmp/x.pdf", "--parent-key", "ABC12345",
+            ])
 
 
 # ---------------------------------------------------------------------------
@@ -340,3 +365,77 @@ class TestCmdEdit:
 
         call_kwargs = mock_write.update_item.call_args.kwargs
         assert call_kwargs["add_tags"] == ["tag1", "tag2", "tag3"]
+
+
+# ---------------------------------------------------------------------------
+# cmd_add
+# ---------------------------------------------------------------------------
+
+class TestCmdAdd:
+    """cmd_add must call the write tools with kwargs their real signatures accept.
+
+    Plain MagicMocks hide kwarg mismatches (they accept anything), which is how
+    `add file` shipped passing a nonexistent parent_key= and raised TypeError on
+    every invocation. Autospec the real functions so signature drift fails here.
+    """
+
+    def _run(self, args):
+        mock_write = MagicMock()
+        for fn in ("add_by_doi", "add_by_url", "add_from_file"):
+            setattr(mock_write, fn,
+                    create_autospec(getattr(write_tools, fn), return_value="ok"))
+        with patch("zotero_mcp.cli_standalone.setup_zotero_environment"):
+            with patch("zotero_mcp.cli_standalone._import_tools",
+                       return_value=(MagicMock(), MagicMock(), MagicMock(),
+                                     mock_write, MagicMock())):
+                cmd_add(args)
+        return mock_write
+
+    def test_add_file_matches_real_signature(self, capsys):
+        # Regression: would raise TypeError while parent_key= was passed.
+        args = MagicMock(subcommand="file", filepath="/tmp/paper.pdf",
+                         title=None, item_type="document",
+                         collections=None, tags=None, verbose=False)
+        mock_write = self._run(args)
+
+        mock_write.add_from_file.assert_called_once()
+        call_kwargs = mock_write.add_from_file.call_args.kwargs
+        assert call_kwargs["file_path"] == "/tmp/paper.pdf"
+        assert call_kwargs["title"] is None
+        assert call_kwargs["item_type"] == "document"
+        assert "ok" in capsys.readouterr().out
+
+    def test_add_file_forwards_title_and_item_type(self):
+        args = MagicMock(subcommand="file", filepath="/tmp/book.epub",
+                         title="My Book", item_type="book",
+                         collections="ABCD1234,EFGH5678", tags="a,b",
+                         verbose=False)
+        mock_write = self._run(args)
+
+        call_kwargs = mock_write.add_from_file.call_args.kwargs
+        assert call_kwargs["title"] == "My Book"
+        assert call_kwargs["item_type"] == "book"
+        assert call_kwargs["collections"] == ["ABCD1234", "EFGH5678"]
+        assert call_kwargs["tags"] == ["a", "b"]
+
+    def test_add_doi_matches_real_signature(self):
+        args = MagicMock(subcommand="doi", doi="10.1234/test",
+                         attach_mode="auto", collections="ABCD1234",
+                         tags=None, verbose=False)
+        mock_write = self._run(args)
+
+        mock_write.add_by_doi.assert_called_once()
+        call_kwargs = mock_write.add_by_doi.call_args.kwargs
+        assert call_kwargs["doi"] == "10.1234/test"
+        assert call_kwargs["collections"] == ["ABCD1234"]
+
+    def test_add_url_matches_real_signature(self):
+        args = MagicMock(subcommand="url", url="https://arxiv.org/abs/2301.00001",
+                         attach_mode="auto", collections=None, tags=None,
+                         verbose=False)
+        mock_write = self._run(args)
+
+        mock_write.add_by_url.assert_called_once()
+        assert mock_write.add_by_url.call_args.kwargs["url"] == (
+            "https://arxiv.org/abs/2301.00001"
+        )


### PR DESCRIPTION
Fixes #335

## Problem

Every `zotero-cli add file` invocation crashed:

```
$ uv run zotero-cli add file --filepath /tmp/paper.pdf
Error: add_from_file() got an unexpected keyword argument 'parent_key'
```

`cmd_add` passed `parent_key=` to `add_from_file`, which has never had that parameter (verified back to 34cb0a7, the commit that introduced the CLI). There is no real parameter to wire it to — `add_from_file` creates a standalone item and has no attach-to-parent mode — so the flag is dropped rather than wired.

## Changes

- `cmd_add`: pass `add_from_file`'s real optional parameters `title` / `item_type` instead of the phantom `parent_key`.
- Parser: remove `--parent-key`; add `--title` and `--item-type` (default `document`). Removing the flag can't break anyone — every invocation that used it crashed.
- README: the `add file` example showed a positional path the parser never accepted; corrected to `--filepath`.
- Tests: new `TestCmdAdd` class that wraps the real `add_by_doi` / `add_by_url` / `add_from_file` in `create_autospec`, so kwargs are validated against the real signatures. (The existing CLI tests use plain `MagicMock`s, which accept any kwargs — that's how this shipped broken.) Plus parser tests pinning the new flags and the removal of `--parent-key`.

## Verification

- Repro before fix: `TypeError` as above. After: the call reaches `add_from_file`'s own validation (`Error: File not found: …`).
- `tests/test_cli_standalone.py`: all 41 pass; the new tests fail against the old handler.
- Full suite on this branch: 901 passed; the 5 failures (`test_lifespan.py` ×3, `test_place_field_reads.py` ×2) also fail on clean `main` — pre-existing, unrelated.

First of a 4-PR series (with #336/#337/#338 implementations following on top of this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
