### PR TITLE
feat(collections): resolve names/paths/keys in all add paths + manage_collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,12 @@ zotero-cli add doi 10.1038/s41586-021-03819-2
 zotero-cli add url https://arxiv.org/abs/2301.00001
 zotero-cli add file --filepath /path/to/paper.pdf --title "Override Title"
 
+# --collections accepts keys, names, or parent/child paths — resolved and
+# validated before the item is created (a typo fails the add, with suggestions,
+# instead of leaving an unfiled item)
+zotero-cli add doi 10.1038/s41586-021-03819-2 --collections "Reading List"
+zotero-cli collections manage --item-keys ABC123 --add-to "_project/topic"
+
 # Collections and tags
 zotero-cli coll list                          # list collections (short alias)
 zotero-cli coll search "PhD Research"
@@ -491,9 +497,11 @@ zotero_remove_item_relation(
 - `zotero_add_by_doi`: Add a paper by DOI with automatic metadata and open-access PDF attachment
 - `zotero_add_by_url`: Add a paper by URL (arXiv, DOI URLs, and general webpages)
 - `zotero_add_from_file`: Import a local PDF or EPUB file with automatic DOI extraction
+
+All add tools take a `collections` parameter accepting collection keys, names, or `parent/child` paths — resolved and validated before the item is created, so unknown or ambiguous specs fail with suggestions instead of producing an unfiled item.
 - `zotero_create_collection`: Create a new collection (folder/project) in your library
 - `zotero_search_collections`: Search for collections by name to find their keys
-- `zotero_manage_collections`: Add or remove items from collections
+- `zotero_manage_collections`: Add or remove items from collections (accepts keys, names, or `parent/child` paths)
 - `zotero_update_item`: Update metadata for an existing item (title, tags, abstract, date, etc.)
 - `zotero_find_duplicates`: Find duplicate items by title and/or DOI
 - `zotero_merge_duplicates`: Merge duplicate items with dry-run preview; consolidates all child items

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ zotero-cli ann search "highlight text"
 # Add items
 zotero-cli add doi 10.1038/s41586-021-03819-2
 zotero-cli add url https://arxiv.org/abs/2301.00001
-zotero-cli add file /path/to/paper.pdf
+zotero-cli add file --filepath /path/to/paper.pdf --title "Override Title"
 
 # Collections and tags
 zotero-cli coll list                          # list collections (short alias)

--- a/src/zotero_mcp/cli_standalone.py
+++ b/src/zotero_mcp/cli_standalone.py
@@ -236,7 +236,8 @@ def cmd_add(args):
         ))
     elif args.subcommand == "file":
         print(write_mod.add_from_file(
-            file_path=args.filepath, parent_key=getattr(args, "parent_key", None),
+            file_path=args.filepath, title=getattr(args, "title", None),
+            item_type=getattr(args, "item_type", "document"),
             collections=collections, tags=tags, ctx=ctx,
         ))
     else:
@@ -625,9 +626,11 @@ def build_parser() -> argparse.ArgumentParser:
     aurl.add_argument("--collections")
     aurl.add_argument("--tags")
     aurl.add_argument("--attach-mode", choices=["auto", "linked_url", "import_file"], default="auto")
-    afil = add_sub.add_parser("file", help="Add item from local file")
+    afil = add_sub.add_parser("file", help="Add item from local file (.pdf/.epub)")
     afil.add_argument("--filepath", required=True)
-    afil.add_argument("--parent-key")
+    afil.add_argument("--title", help="Override title if metadata extraction misses")
+    afil.add_argument("--item-type", default="document",
+                      help="Zotero item type for the new item (default: document)")
     afil.add_argument("--collections")
     afil.add_argument("--tags")
 

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -343,6 +343,198 @@ def _resolve_collection_names(zot, names, ctx=None):
     return results
 
 
+_COLLECTION_KEY_RE = re.compile(r"^[A-Z0-9]{8}$")
+
+
+def build_collection_paths(collections) -> dict[str, list[str]]:
+    """Map collection key → full path segments ``[root, ..., name]``.
+
+    Built from ``data.parentCollection`` links. A parent that isn't in the
+    fetched set (e.g. trashed) or a parent cycle degrades to a shorter path
+    rather than failing.
+    """
+    by_key = {c["key"]: c for c in collections if c.get("key")}
+    paths: dict[str, list[str]] = {}
+
+    def _segments(key: str, seen: set[str]) -> list[str]:
+        if key in paths:
+            return paths[key]
+        coll = by_key[key]
+        name = coll.get("data", {}).get("name") or key
+        parent = coll.get("data", {}).get("parentCollection")
+        if parent in by_key and parent not in seen:
+            seen.add(key)
+            segs = _segments(parent, seen) + [name]
+        else:
+            segs = [name]
+        paths[key] = segs
+        return segs
+
+    for key in by_key:
+        _segments(key, {key})
+    return paths
+
+
+def resolve_collection_specs(
+    zot,
+    specs,
+    *,
+    create_missing: bool = False,
+    write_zot=None,
+    ctx=None,
+) -> list[str]:
+    """Resolve collection *specs* — keys, names, or '/'-paths — to live keys.
+
+    Resolution order per spec:
+
+    1. **Key**: 8-char uppercase-alphanumeric AND currently a live collection
+       key → used as-is. Existence is checked, not just shape, so trashed or
+       bogus keys fail loudly here instead of producing an invisibly-filed or
+       unfiled item after creation (#233/#235).
+    2. **Name/path**: the spec is split on '/' and matched case-insensitively
+       against the *trailing* path segments of every collection, so a bare
+       name matches anywhere in the tree and 'parent/name' disambiguates
+       same-named leaves.
+
+    An ambiguous spec raises ValueError listing every candidate. An unknown
+    spec raises ValueError with near-miss suggestions — unless
+    ``create_missing`` is True, in which case the collection (including any
+    missing intermediate path segments) is created via ``write_zot``.
+
+    Returns resolved keys in input order, deduplicated.
+    """
+    cleaned = [str(s).strip() for s in (specs or []) if str(s).strip()]
+    if not cleaned:
+        return []
+
+    paths = build_collection_paths(_paginate(zot.collections))
+
+    resolved: list[str] = []
+    for spec in cleaned:
+        if _COLLECTION_KEY_RE.match(spec) and spec in paths:
+            resolved.append(spec)
+            continue
+
+        wanted = [seg.strip().lower() for seg in spec.split("/") if seg.strip()]
+        if not wanted:
+            raise ValueError(f"Collection spec '{spec}' is empty.")
+
+        matches = [
+            key for key, segs in paths.items()
+            if len(segs) >= len(wanted)
+            and [s.lower() for s in segs[-len(wanted):]] == wanted
+        ]
+
+        if len(matches) > 1:
+            candidates = "; ".join(
+                f"'{'/'.join(paths[k])}' ({k})"
+                for k in sorted(matches, key=lambda k: paths[k])
+            )
+            raise ValueError(
+                f"Collection spec '{spec}' is ambiguous — it matches: "
+                f"{candidates}. Disambiguate with a longer path or the "
+                "8-character collection key."
+            )
+        if matches:
+            resolved.append(matches[0])
+            continue
+
+        if create_missing:
+            if write_zot is None:
+                raise ValueError(
+                    f"Collection '{spec}' not found and no writable client "
+                    "is available to create it."
+                )
+            resolved.append(
+                _create_collection_path(write_zot, paths, spec, ctx=ctx)
+            )
+            continue
+
+        raise ValueError(_collection_not_found_message(zot, spec, paths))
+
+    seen: set[str] = set()
+    return [k for k in resolved if not (k in seen or seen.add(k))]
+
+
+def _create_collection_path(write_zot, paths, spec, ctx=None) -> str:
+    """Create the collections needed to satisfy *spec*; return the leaf key.
+
+    The longest prefix of the path that already resolves (unique trailing-
+    segment match) anchors the chain; remaining segments are created beneath
+    it, or at the library root when nothing resolves. Mutates *paths* with
+    the created entries so later specs in the same call see them.
+    """
+    names = [seg.strip() for seg in spec.split("/") if seg.strip()]
+
+    parent_key = None
+    start = 0
+    for i in range(len(names) - 1, 0, -1):
+        prefix = [s.lower() for s in names[:i]]
+        matches = [
+            key for key, segs in paths.items()
+            if len(segs) >= len(prefix)
+            and [s.lower() for s in segs[-len(prefix):]] == prefix
+        ]
+        if len(matches) > 1:
+            candidates = "; ".join(f"'{'/'.join(paths[k])}' ({k})" for k in matches)
+            raise ValueError(
+                f"Cannot create '{spec}': parent path "
+                f"'{'/'.join(names[:i])}' is ambiguous — it matches: "
+                f"{candidates}."
+            )
+        if matches:
+            parent_key = matches[0]
+            start = i
+            break
+
+    for name in names[start:]:
+        payload = {"name": name, "parentCollection": parent_key or False}
+        result = write_zot.create_collections([payload])
+        if not (isinstance(result, dict) and result.get("success")):
+            raise ValueError(f"Failed to create collection '{name}': {result}")
+        new_key = next(iter(result["success"].values()))
+        paths[new_key] = (paths[parent_key] if parent_key else []) + [name]
+        if ctx is not None:
+            ctx.info(f"Created collection '{'/'.join(paths[new_key])}' ({new_key})")
+        parent_key = new_key
+    return parent_key
+
+
+def _collection_not_found_message(zot, spec, paths) -> str:
+    """Build the error message for an unresolvable collection spec."""
+    if _COLLECTION_KEY_RE.match(spec):
+        try:
+            trashed = {c.get("key") for c in fetch_trashed_collections(zot)}
+        except Exception:
+            trashed = set()
+        if spec in trashed:
+            return (
+                f"Collection '{spec}' is in the Zotero Trash. Restore it in "
+                "Zotero (or use another collection) before filing items into it."
+            )
+    msg = (
+        f"Collection '{spec}' not found in the active library "
+        "(tried key, name, and path matching)."
+    )
+    words = [w for w in spec.lower().replace("/", " ").split() if w]
+    suggestions = [
+        key for key, segs in paths.items()
+        if all(w in "/".join(segs).lower() for w in words)
+    ]
+    if suggestions:
+        shown = ", ".join(
+            f"'{'/'.join(paths[k])}' ({k})"
+            for k in sorted(suggestions, key=lambda k: paths[k])[:5]
+        )
+        msg += f" Close matches: {shown}."
+    else:
+        msg += (
+            " Use zotero_search_collections (or `zotero-cli collections "
+            "search`) to list available collections."
+        )
+    return msg
+
+
 def _normalize_doi(raw):
     """Normalize a DOI string from various input formats."""
     if not raw:

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -23,6 +23,42 @@ from zotero_mcp.tools import _helpers
 CROSSREF_TYPE_MAP = _helpers.CROSSREF_TYPE_MAP
 
 
+def _resolve_collections_arg(
+    read_zot,
+    collections,
+    ctx,
+    *,
+    create_missing: bool = False,
+    write_zot=None,
+) -> list[str]:
+    """Normalize the caller's ``collections`` argument and resolve every spec
+    (key, name, or '/'-path) to a live collection key.
+
+    Raises ValueError with a user-facing message on unknown or ambiguous
+    specs — callers should fail the add *before* creating an item, so a typo
+    can't produce an unfiled or invisibly-filed item.
+    """
+    specs = _helpers._normalize_str_list_input(collections, "collections")
+    if not specs:
+        return []
+    return _helpers.resolve_collection_specs(
+        read_zot, specs,
+        create_missing=create_missing, write_zot=write_zot, ctx=ctx,
+    )
+
+
+def _collections_status(coll_keys: list[str], missing: list[str]) -> str:
+    """Render the post-create collection-membership state for tool output."""
+    if not coll_keys:
+        return "My Library (no collection)"
+    if missing:
+        return (
+            f"Filed in {sorted(set(coll_keys) - set(missing))}; "
+            f"FAILED to file in {missing}"
+        )
+    return f"Filed in {coll_keys}"
+
+
 @mcp.tool(
     name="zotero_batch_update_tags",
     description=(
@@ -416,7 +452,9 @@ def search_collections(
     description=(
         "Add or remove one or more items from collections. "
         "item_keys must be an ARRAY of item keys, e.g. [\"KEY1\", \"KEY2\"] — not a single string. "
-        "add_to and remove_from also accept arrays of collection keys. "
+        "add_to and remove_from accept arrays of collection keys, names, or "
+        "'/'-separated paths (resolved and validated automatically; unknown, "
+        "trashed, or ambiguous specs fail before anything is changed). "
         "Use zotero_search_items to find item keys and zotero_search_collections to find collection keys."
     )
 )
@@ -435,37 +473,28 @@ def manage_collections(
 
     try:
         keys = _helpers._normalize_str_list_input(item_keys, "item_keys")
-        add_colls = _helpers._normalize_str_list_input(add_to, "add_to")
-        remove_colls = _helpers._normalize_str_list_input(remove_from, "remove_from")
+        add_specs = _helpers._normalize_str_list_input(add_to, "add_to")
+        remove_specs = _helpers._normalize_str_list_input(remove_from, "remove_from")
 
         if not keys:
             return "Error: No item keys provided."
-        if not add_colls and not remove_colls:
+        if not add_specs and not remove_specs:
             return "Error: Must specify add_to and/or remove_from."
 
-        # Validate collection keys before doing any work — Zotero will happily
-        # accept add/remove against a trashed collection, leaving items
-        # parented under an invisible bucket so the caller sees "success" but
-        # nothing renders in the desktop client (#233).
-        validation_errors: list[str] = []
-        for coll_key in list(add_colls) + list(remove_colls):
-            trashed = _helpers.is_collection_trashed(write_zot, coll_key)
-            if trashed is None:
-                validation_errors.append(
-                    f"Collection '{coll_key}' was not found in the active "
-                    f"library. Use zotero_search_collections (with "
-                    f"include_trashed=True if needed) to find a valid key."
-                )
-            elif trashed:
-                validation_errors.append(
-                    f"Collection '{coll_key}' is in the Trash. Restore it "
-                    f"in Zotero (or create a new collection) before adding "
-                    f"or removing items — the underlying API will accept "
-                    f"the call but the change won't be visible in the "
-                    f"normal collection tree."
-                )
-        if validation_errors:
-            return "Error:\n" + "\n".join(validation_errors)
+        # Resolve specs (keys, names, or '/'-paths) to live collection keys
+        # before doing any work. Resolution also validates existence — Zotero
+        # will happily accept add/remove against a trashed collection, leaving
+        # items parented under an invisible bucket so the caller sees
+        # "success" but nothing renders in the desktop client (#233).
+        try:
+            add_colls = _helpers.resolve_collection_specs(
+                read_zot, add_specs, ctx=ctx
+            )
+            remove_colls = _helpers.resolve_collection_specs(
+                read_zot, remove_specs, ctx=ctx
+            )
+        except ValueError as e:
+            return f"Error: {e}"
 
         results = []
 
@@ -518,9 +547,11 @@ def manage_collections(
         "zotero_add_from_file. "
         "doi: the DOI string (with or without the '10.' prefix, with or "
         "without a leading 'https://doi.org/'). "
-        "collections: optional list of 8-character collection keys (or "
-        "collection names — resolved automatically) to file the item "
-        "under. "
+        "collections: optional list of collection keys, names, or "
+        "'/'-separated paths (e.g. '_project/topic') — resolved and "
+        "validated before the item is created; unknown or ambiguous "
+        "specs fail the call with suggestions instead of producing an "
+        "unfiled item. "
         "tags: optional list of tag strings to attach. "
         "attach_mode: 'auto' (default) downloads a PDF if CrossRef links "
         "one and storage is available; 'none' skips PDF download; "
@@ -552,6 +583,13 @@ def add_by_doi(
         normalized = _helpers._normalize_doi(doi)
         if not normalized:
             return f"Error: '{doi}' does not appear to be a valid DOI."
+
+        # Resolve collection specs (keys/names/paths) BEFORE any network or
+        # write work — a bad spec must not produce an unfiled item.
+        try:
+            coll_keys = _resolve_collections_arg(read_zot, collections, ctx)
+        except ValueError as e:
+            return f"Error: {e}"
 
         ctx.info(f"Fetching metadata for DOI: {normalized}")
 
@@ -653,8 +691,7 @@ def add_by_doi(
         if tag_list:
             item_data["tags"] = [{"tag": t} for t in tag_list]
 
-        # Collections
-        coll_keys = _helpers._normalize_str_list_input(collections, "collections")
+        # Collections (resolved to live keys above, before the CrossRef fetch)
         if coll_keys:
             item_data["collections"] = coll_keys
 
@@ -671,15 +708,7 @@ def add_by_doi(
             missing = _helpers.ensure_collection_membership(
                 write_zot, item_key, coll_keys, ctx=ctx
             )
-            if coll_keys and missing:
-                collections_status = (
-                    f"Filed in {sorted(set(coll_keys) - set(missing))}; "
-                    f"FAILED to file in {missing}"
-                )
-            elif coll_keys:
-                collections_status = f"Filed in {coll_keys}"
-            else:
-                collections_status = "My Library (no collection)"
+            collections_status = _collections_status(coll_keys, missing)
 
             # Attempt open-access PDF attachment (pass CrossRef metadata for arXiv fallback)
             pdf_status = _helpers._try_attach_oa_pdf(write_zot, item_key, normalized, ctx,
@@ -718,8 +747,9 @@ def add_by_doi(
         "the routing and is more robust. For a local file use "
         "zotero_add_from_file. "
         "url: the URL to import. "
-        "collections: optional list of 8-character collection keys (or "
-        "names) to file the item under. "
+        "collections: optional list of collection keys, names, or "
+        "'/'-separated paths — resolved and validated before the item is "
+        "created; unknown or ambiguous specs fail the call. "
         "tags: optional list of tag strings to attach. "
         "attach_mode: 'auto' (default) attaches a PDF if one is "
         "available; 'none' skips; 'required' fails if no PDF can be "
@@ -764,9 +794,14 @@ def add_by_url(
         arxiv_id = _helpers._normalize_arxiv_id(url)
         if arxiv_id:
             return _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx,
-                                 attach_mode=attach_mode)
+                                 attach_mode=attach_mode, read_zot=read_zot)
 
         # Generic webpage
+        try:
+            coll_keys = _resolve_collections_arg(read_zot, collections, ctx)
+        except ValueError as e:
+            return f"Error: {e}"
+
         ctx.info(f"Creating webpage item for: {url}")
         template = write_zot.item_template("webpage")
         template["url"] = url
@@ -776,15 +811,18 @@ def add_by_url(
         tag_list = _helpers._normalize_str_list_input(tags, "tags")
         if tag_list:
             template["tags"] = [{"tag": t} for t in tag_list]
-        coll_keys = _helpers._normalize_str_list_input(collections, "collections")
         if coll_keys:
             template["collections"] = coll_keys
 
         result = write_zot.create_items([template])
         if isinstance(result, dict) and result.get("success"):
             item_key = next(iter(result["success"].values()))
+            missing = _helpers.ensure_collection_membership(
+                write_zot, item_key, coll_keys, ctx=ctx
+            )
             return (
-                f"Created webpage item for: {url}\n\nItem key: `{item_key}`\n\n"
+                f"Created webpage item for: {url}\n\nItem key: `{item_key}`\n"
+                f"Collections: {_collections_status(coll_keys, missing)}\n\n"
                 "_Note: To include this item in semantic search, run "
                 "zotero_update_search_database._"
             )
@@ -796,7 +834,8 @@ def add_by_url(
 
 
 @with_zotero_api_lock
-def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto"):
+def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto",
+                  read_zot=None):
     """Add an arXiv paper by ID. Internal helper for add_by_url.
 
     arXiv (export.arxiv.org) periodically sheds load — rate-limiting (429),
@@ -808,6 +847,11 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
     very recent preprint — so a clear, actionable message is returned when
     both routes fail, never a bare timeout.
     """
+    try:
+        coll_keys = _resolve_collections_arg(read_zot or write_zot, collections, ctx)
+    except ValueError as e:
+        return f"Error: {e}"
+
     ctx.info(f"Fetching arXiv metadata for: {arxiv_id}")
 
     resp = None
@@ -854,7 +898,7 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
         try:
             result = add_by_doi(
                 doi=arxiv_doi,
-                collections=collections,
+                collections=coll_keys,
                 tags=tags,
                 attach_mode=attach_mode,
                 ctx=ctx,
@@ -923,13 +967,15 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
     tag_list = _helpers._normalize_str_list_input(tags, "tags")
     if tag_list:
         template["tags"] = [{"tag": t} for t in tag_list]
-    coll_keys = _helpers._normalize_str_list_input(collections, "collections")
     if coll_keys:
         template["collections"] = coll_keys
 
     result = write_zot.create_items([template])
     if isinstance(result, dict) and result.get("success"):
         item_key = next(iter(result["success"].values()))
+        missing = _helpers.ensure_collection_membership(
+            write_zot, item_key, coll_keys, ctx=ctx
+        )
 
         # arXiv always has a free PDF — try to attach it
         pdf_url = f"https://arxiv.org/pdf/{arxiv_id}.pdf"
@@ -980,6 +1026,7 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
             f"Successfully added arXiv paper: **{title}**\n\n"
             f"Item key: `{item_key}`\n"
             f"arXiv ID: {arxiv_id}\n"
+            f"Collections: {_collections_status(coll_keys, missing)}\n"
             f"PDF: {pdf_status}\n\n"
             "_Note: To include this item in semantic search, run "
             "zotero_update_search_database._"
@@ -1144,6 +1191,11 @@ def add_by_isbn(
                 "(checksum failed or wrong length)."
             )
 
+        try:
+            coll_keys = _resolve_collections_arg(read_zot, collections, ctx)
+        except ValueError as e:
+            return f"Error: {e}"
+
         ctx.info(f"Resolving ISBN {normalized} via Open Library...")
         meta = _lookup_isbn_openlibrary(normalized, ctx)
         if not meta:
@@ -1177,18 +1229,21 @@ def add_by_isbn(
         tag_list = _helpers._normalize_str_list_input(tags, "tags")
         if tag_list:
             item_data["tags"] = [{"tag": t} for t in tag_list]
-        coll_keys = _helpers._normalize_str_list_input(collections, "collections")
         if coll_keys:
             item_data["collections"] = coll_keys
 
         result = write_zot.create_items([item_data])
         if isinstance(result, dict) and result.get("success"):
             item_key = next(iter(result["success"].values()))
+            missing = _helpers.ensure_collection_membership(
+                write_zot, item_key, coll_keys, ctx=ctx
+            )
             return (
                 f"Successfully added: **{item_data.get('title', normalized)}**\n\n"
                 f"Item key: `{item_key}`\n"
                 f"Type: book\n"
                 f"ISBN: {normalized}\n"
+                f"Collections: {_collections_status(coll_keys, missing)}\n"
                 f"Source: {meta['source']}\n\n"
                 "_Note: Open Library and Google Books metadata can be noisy "
                 "(publisher-as-author, concatenated places, off-by-one dates). "
@@ -2025,7 +2080,9 @@ def get_pdf_outline(
         "file_path: ABSOLUTE path to a .pdf or .epub file (relative "
         "paths fail). Other extensions are rejected. "
         "title: optional override if metadata extraction misses. "
-        "collections: optional list of 8-char keys/names to file under. "
+        "collections: optional list of collection keys, names, or "
+        "'/'-separated paths to file under — resolved and validated "
+        "before the item is created. "
         "tags: optional list of tag strings. "
         "Requires a writable library (fails in local-only mode). PDF "
         "uploads may hit the 300MB Zotero cloud free-tier quota — "
@@ -2060,6 +2117,11 @@ def add_from_file(
         file_path = os.path.realpath(file_path)
         if not os.path.isfile(file_path):
             return f"Error: File not found: {file_path}"
+
+        try:
+            coll_keys = _resolve_collections_arg(read_zot, collections, ctx)
+        except ValueError as e:
+            return f"Error: {e}"
 
         ext = os.path.splitext(file_path)[1].lower()
         allowed_exts = {".pdf", ".epub", ".djvu", ".doc", ".docx", ".odt", ".rtf"}
@@ -2101,7 +2163,7 @@ def add_from_file(
         # Create the metadata item
         if extracted_doi:
             ctx.info(f"Found DOI: {extracted_doi}")
-            result_msg = add_by_doi(doi=extracted_doi, collections=collections, tags=tags, ctx=ctx)
+            result_msg = add_by_doi(doi=extracted_doi, collections=coll_keys, tags=tags, ctx=ctx)
             # Extract item key from result
             key_match = re.search(r'Item key: `([^`]+)`', result_msg)
             if key_match:
@@ -2116,13 +2178,17 @@ def add_from_file(
             tag_list = _helpers._normalize_str_list_input(tags, "tags")
             if tag_list:
                 template["tags"] = [{"tag": t} for t in tag_list]
-            coll_keys = _helpers._normalize_str_list_input(collections, "collections")
             if coll_keys:
                 template["collections"] = coll_keys
 
             result = write_zot.create_items([template])
             if isinstance(result, dict) and result.get("success"):
                 parent_key = next(iter(result["success"].values()))
+                missing = _helpers.ensure_collection_membership(
+                    write_zot, parent_key, coll_keys, ctx=ctx
+                )
+                if missing:
+                    ctx.warning(f"Failed to file {parent_key} in {missing}")
             else:
                 return f"Failed to create item: {result}"
 
@@ -2492,20 +2558,28 @@ def _create_and_attach(
     """Create one Zotero item and, if it has a DOI, try to attach an OA PDF.
 
     Returns a dict ``{"ok": bool, "key": str|None, "doi": str|None,
-    "pdf_status": str|None, "error": str|None, "title": str}``.
+    "pdf_status": str|None, "error": str|None, "title": str,
+    "collections_failed": list[str]}``.
     """
     title = item_data.get("title") or "(untitled)"
     try:
         result = write_zot.create_items([item_data])
     except Exception as e:
         return {"ok": False, "key": None, "doi": None, "pdf_status": None,
-                "error": str(e), "title": title}
+                "error": str(e), "title": title, "collections_failed": []}
 
     if not (isinstance(result, dict) and result.get("success")):
         return {"ok": False, "key": None, "doi": None, "pdf_status": None,
-                "error": f"create_items failed: {result}", "title": title}
+                "error": f"create_items failed: {result}", "title": title,
+                "collections_failed": []}
 
     item_key = next(iter(result["success"].values()))
+
+    # #235 backstop: atomic filing via item["collections"] is intermittent.
+    collections_failed = _helpers.ensure_collection_membership(
+        write_zot, item_key, item_data.get("collections") or [], ctx=ctx
+    )
+
     doi_raw = item_data.get("DOI") or ""
     doi = _helpers._normalize_doi(doi_raw) if doi_raw else None
 
@@ -2519,7 +2593,8 @@ def _create_and_attach(
             pdf_status = f"OA PDF attach failed: {e}"
 
     return {"ok": True, "key": item_key, "doi": doi, "pdf_status": pdf_status,
-            "error": None, "title": title}
+            "error": None, "title": title,
+            "collections_failed": collections_failed}
 
 
 def _format_batch_result(header: str, results: list[dict]) -> str:
@@ -2536,6 +2611,10 @@ def _format_batch_result(header: str, results: list[dict]) -> str:
                 lines.append(f"DOI: {r['doi']}")
             if r["pdf_status"]:
                 lines.append(f"PDF: {r['pdf_status']}")
+            if r.get("collections_failed"):
+                lines.append(
+                    f"WARNING: failed to file in {r['collections_failed']}"
+                )
         else:
             lines.append(f"Failed to add **{r['title']}**: {r['error']}")
     else:
@@ -2548,6 +2627,8 @@ def _format_batch_result(header: str, results: list[dict]) -> str:
                     line += f" (DOI: {r['doi']})"
                 if r["pdf_status"]:
                     line += f" [{r['pdf_status']}]"
+                if r.get("collections_failed"):
+                    line += f" [failed to file in {r['collections_failed']}]"
                 lines.append(line)
             else:
                 lines.append(f"{i}. ❌ {r['title']}: {r['error']}")
@@ -2608,6 +2689,11 @@ def add_by_bibtex(
         if not entries:
             return "Error: No valid @entries found in the BibTeX input."
 
+        try:
+            coll_keys = _resolve_collections_arg(_read_zot, collections, ctx)
+        except ValueError as e:
+            return f"Error: {e}"
+
         ctx.info(f"Parsed {len(entries)} BibTeX entries")
 
         results = []
@@ -2624,7 +2710,7 @@ def add_by_bibtex(
                 })
                 continue
 
-            _apply_caller_tags_and_collections(item_data, tags, collections)
+            _apply_caller_tags_and_collections(item_data, tags, coll_keys)
             results.append(_create_and_attach(write_zot, item_data, attach_mode, ctx))
 
         return _format_batch_result("# zotero_add_by_bibtex", results)
@@ -2682,6 +2768,11 @@ def add_by_csl_json(
         if not entries:
             return "Error: No valid CSL JSON objects provided."
 
+        try:
+            coll_keys = _resolve_collections_arg(_read_zot, collections, ctx)
+        except ValueError as e:
+            return f"Error: {e}"
+
         ctx.info(f"Processing {len(entries)} CSL JSON entries")
 
         results = []
@@ -2698,7 +2789,7 @@ def add_by_csl_json(
                 })
                 continue
 
-            _apply_caller_tags_and_collections(item_data, tags, collections)
+            _apply_caller_tags_and_collections(item_data, tags, coll_keys)
             results.append(_create_and_attach(write_zot, item_data, attach_mode, ctx))
 
         return _format_batch_result("# zotero_add_by_csl_json", results)

--- a/tests/test_add_by_bibtex.py
+++ b/tests/test_add_by_bibtex.py
@@ -117,16 +117,37 @@ class TestTagsAndCollections:
 
     def test_collections_applied(self, monkeypatch, dummy_ctx):
         fake = _patch_hybrid(monkeypatch)
+        fake._collections = [
+            {"key": "COL00001", "data": {"name": "One", "parentCollection": False}},
+            {"key": "COL00002", "data": {"name": "Two", "parentCollection": False}},
+        ]
         _disable_oa_pdf(monkeypatch)
 
         bib = "@article{x, title={T}, author={A, B}, year={2020}}"
         server.add_by_bibtex(
             bibtex=bib,
-            collections=["COL001", "COL002"],
+            collections=["COL00001", "COL00002"],
             ctx=dummy_ctx,
         )
 
-        assert fake.created[0]["collections"] == ["COL001", "COL002"]
+        assert fake.created[0]["collections"] == ["COL00001", "COL00002"]
+
+    def test_collection_names_resolved(self, monkeypatch, dummy_ctx):
+        """Collection names resolve to keys once, before the entry loop."""
+        fake = _patch_hybrid(monkeypatch)
+        fake._collections = [
+            {"key": "COL00001", "data": {"name": "Reading List", "parentCollection": False}},
+        ]
+        _disable_oa_pdf(monkeypatch)
+
+        bib = "@article{x, title={T}, author={A, B}, year={2020}}"
+        server.add_by_bibtex(
+            bibtex=bib,
+            collections=["reading list"],
+            ctx=dummy_ctx,
+        )
+
+        assert fake.created[0]["collections"] == ["COL00001"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_add_by_csl_json.py
+++ b/tests/test_add_by_csl_json.py
@@ -125,15 +125,18 @@ class TestTagsAndCollections:
 
     def test_collections_applied(self, monkeypatch, dummy_ctx):
         fake = _patch_hybrid(monkeypatch)
+        fake._collections = [
+            {"key": "COL00001", "data": {"name": "One", "parentCollection": False}},
+        ]
         _disable_oa_pdf(monkeypatch)
 
         server.add_by_csl_json(
             csl_json=SAMPLE_ARTICLE,
-            collections=["COL001"],
+            collections=["COL00001"],
             ctx=dummy_ctx,
         )
 
-        assert fake.created[0]["collections"] == ["COL001"]
+        assert fake.created[0]["collections"] == ["COL00001"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_add_by_doi.py
+++ b/tests/test_add_by_doi.py
@@ -459,6 +459,9 @@ class TestTagsAndCollections:
     def test_collections_applied(
         self, monkeypatch, fake_zot, dummy_ctx
     ):
+        fake_zot._collections = [
+            {"key": "ABCD1234", "data": {"name": "Climate", "parentCollection": False}},
+        ]
         monkeypatch.setattr(
             "zotero_mcp.tools._helpers._get_write_client", lambda ctx: (fake_zot, fake_zot)
         )
@@ -474,6 +477,49 @@ class TestTagsAndCollections:
         item = fake_zot.created[0]
 
         assert "ABCD1234" in item["collections"]
+
+    def test_collection_name_resolved_to_key(
+        self, monkeypatch, fake_zot, dummy_ctx
+    ):
+        """A collection NAME resolves to its key before the item is created."""
+        fake_zot._collections = [
+            {"key": "ABCD1234", "data": {"name": "Climate", "parentCollection": False}},
+        ]
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client", lambda ctx: (fake_zot, fake_zot)
+        )
+        monkeypatch.setattr(
+            "requests.get", lambda *a, **kw: _make_crossref_response()
+        )
+
+        server.add_by_doi(
+            doi="10.1234/test.2024.001",
+            collections=["climate"],
+            ctx=dummy_ctx,
+        )
+        item = fake_zot.created[0]
+
+        assert item["collections"] == ["ABCD1234"]
+
+    def test_unknown_collection_fails_before_create(
+        self, monkeypatch, fake_zot, dummy_ctx
+    ):
+        """A bad collection spec must fail the add BEFORE any item is created."""
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client", lambda ctx: (fake_zot, fake_zot)
+        )
+        monkeypatch.setattr(
+            "requests.get", lambda *a, **kw: _make_crossref_response()
+        )
+
+        result = server.add_by_doi(
+            doi="10.1234/test.2024.001",
+            collections=["no-such-collection"],
+            ctx=dummy_ctx,
+        )
+
+        assert "not found" in result
+        assert fake_zot.created == []
 
     def test_no_tags_or_collections(
         self, monkeypatch, fake_zot, dummy_ctx

--- a/tests/test_add_by_isbn.py
+++ b/tests/test_add_by_isbn.py
@@ -281,6 +281,9 @@ class TestAddByIsbnEndToEnd:
 
     def test_tags_and_collections_applied(self, monkeypatch):
         fake = FakeZotero()
+        fake._collections = [
+            {"key": "COLL0001", "data": {"name": "Books", "parentCollection": False}},
+        ]
         monkeypatch.setattr(
             "zotero_mcp.tools._helpers._get_write_client",
             lambda ctx: (fake, fake),

--- a/tests/test_add_by_url.py
+++ b/tests/test_add_by_url.py
@@ -344,6 +344,10 @@ class TestArxivCrossrefFallback:
         """arXiv timeout → delegate to add_by_doi with the arXiv DOI; surface its result."""
         import requests as req_lib
 
+        fake_zot = patch_write_client
+        fake_zot._collections = [
+            {"key": "ABC12345", "data": {"name": "Preprints", "parentCollection": False}},
+        ]
         with patch("zotero_mcp.tools.write._time.sleep"), patch(
             "zotero_mcp.tools.write.requests.get",
             side_effect=req_lib.exceptions.Timeout("timed out"),
@@ -358,7 +362,8 @@ class TestArxivCrossrefFallback:
                 ctx=dummy_ctx,
             )
 
-        # Fallback fired with the arXiv DOI and forwarded collections/tags.
+        # Fallback fired with the arXiv DOI and forwarded the resolved
+        # collection keys and tags.
         mock_doi.assert_called_once()
         kwargs = mock_doi.call_args.kwargs
         assert kwargs.get("doi") == "10.48550/arXiv.2401.00001"
@@ -584,6 +589,9 @@ class TestTagsAndCollections:
     def test_collections_applied(self, dummy_ctx, patch_write_client):
         """Collections parameter should set the item's collections field."""
         fake_zot = patch_write_client
+        fake_zot._collections = [
+            {"key": "ABC12345", "data": {"name": "Preprints", "parentCollection": False}},
+        ]
         mock_resp = _make_arxiv_response(ARXIV_ATOM_XML)
 
         with patch("zotero_mcp.tools.write.requests.get", return_value=mock_resp):
@@ -597,9 +605,9 @@ class TestTagsAndCollections:
         assert "ABC12345" in item.get("collections", [])
 
     def test_collection_names_resolved(self, dummy_ctx, patch_write_client):
-        """Collection names passed as collections are used as-is (keys or names).
-        The arXiv flow passes them through _normalize_str_list_input, not
-        _resolve_collection_names, so names appear directly in collections."""
+        """Collection NAMES resolve to keys before the item is created —
+        the arXiv flow goes through resolve_collection_specs like every
+        other add path."""
         fake_zot = patch_write_client
         fake_zot._collections = [
             {"key": "COLL0001", "data": {"name": "My Papers"}},
@@ -615,8 +623,7 @@ class TestTagsAndCollections:
             )
 
         item = fake_zot.created[0]
-        # The name is passed through _normalize_str_list_input (not resolved to key)
-        assert "My Papers" in item.get("collections", [])
+        assert item.get("collections") == ["COLL0001"]
 
     def test_no_tags_or_collections(self, dummy_ctx, patch_write_client):
         """Omitting tags and collections should still create the item."""

--- a/tests/test_add_from_file.py
+++ b/tests/test_add_from_file.py
@@ -177,7 +177,11 @@ class TestDoiFromMetadata:
     def test_doi_in_subject_field(self, monkeypatch, dummy_ctx):
         fake_zot = FakeZoteroForFile()
         _patch_path_valid(monkeypatch)
-        _patch_hybrid_mode(monkeypatch, fake_zot)
+        read_zot = _patch_hybrid_mode(monkeypatch, fake_zot)
+        # Collection specs resolve against the READ client.
+        read_zot._collections = [
+            {"key": "COL00001", "data": {"name": "One", "parentCollection": False}},
+        ]
 
         fake_doc = FakeFitzDocument(
             metadata={"subject": "doi: 10.1234/test.2024.001", "keywords": ""},
@@ -200,13 +204,14 @@ class TestDoiFromMetadata:
             file_path="/Users/test/Documents/paper.pdf",
             title=None,
             item_type="document",
-            collections=["COL001"],
+            collections=["COL00001"],
             tags=["tag1"],
             ctx=dummy_ctx,
         )
 
         assert doi_called_with["doi"] == "10.1234/test.2024.001"
-        assert doi_called_with["collections"] == ["COL001"]
+        # add_from_file resolves specs itself and delegates resolved KEYS.
+        assert doi_called_with["collections"] == ["COL00001"]
         assert doi_called_with["tags"] == ["tag1"]
 
     def test_doi_in_keywords_field(self, monkeypatch, dummy_ctx):
@@ -599,7 +604,11 @@ class TestTagsAndCollections:
     def test_collections_applied_to_created_item(self, monkeypatch, dummy_ctx):
         fake_zot = FakeZoteroForFile()
         _patch_path_valid(monkeypatch)
-        _patch_hybrid_mode(monkeypatch, fake_zot)
+        read_zot = _patch_hybrid_mode(monkeypatch, fake_zot)
+        read_zot._collections = [
+            {"key": "COLKEY01", "data": {"name": "One", "parentCollection": False}},
+            {"key": "COLKEY02", "data": {"name": "Two", "parentCollection": False}},
+        ]
 
         fake_doc = FakeFitzDocument(metadata={}, first_page_text="No DOI here.")
         _patch_fitz(monkeypatch, fake_doc)
@@ -621,7 +630,10 @@ class TestTagsAndCollections:
     def test_tags_and_collections_together(self, monkeypatch, dummy_ctx):
         fake_zot = FakeZoteroForFile()
         _patch_path_valid(monkeypatch)
-        _patch_hybrid_mode(monkeypatch, fake_zot)
+        read_zot = _patch_hybrid_mode(monkeypatch, fake_zot)
+        read_zot._collections = [
+            {"key": "COL00001", "data": {"name": "One", "parentCollection": False}},
+        ]
 
         fake_doc = FakeFitzDocument(metadata={}, first_page_text="No DOI.")
         _patch_fitz(monkeypatch, fake_doc)
@@ -630,13 +642,13 @@ class TestTagsAndCollections:
             file_path="/Users/test/Documents/paper.pdf",
             title="Both",
             item_type="document",
-            collections=["COL001"],
+            collections=["COL00001"],
             tags=["tag1"],
             ctx=dummy_ctx,
         )
 
         created_item = fake_zot.created[0]
-        assert "COL001" in created_item.get("collections", [])
+        assert "COL00001" in created_item.get("collections", [])
         assert {"tag": "tag1"} in created_item.get("tags", [])
 
     def test_tags_passed_as_comma_string(self, monkeypatch, dummy_ctx):

--- a/tests/test_cli_standalone.py
+++ b/tests/test_cli_standalone.py
@@ -1,13 +1,15 @@
 """Tests for the standalone CLI module (zotero-cli entry point)."""
 
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
+import zotero_mcp.tools.write as write_tools
 from zotero_mcp.cli_standalone import (
     CLIContext,
     build_parser,
+    cmd_add,
     cmd_edit,
     cmd_notes,
     cmd_search,
@@ -127,6 +129,29 @@ class TestParser:
         args = self.parser.parse_args(["coll", "search", "my collection"])
         assert args.command in ("collections", "coll")
         assert args.subcommand == "search"
+
+    def test_add_file_flags(self):
+        args = self.parser.parse_args([
+            "add", "file", "--filepath", "/tmp/x.pdf",
+            "--title", "Override", "--item-type", "book",
+        ])
+        assert args.subcommand == "file"
+        assert args.filepath == "/tmp/x.pdf"
+        assert args.title == "Override"
+        assert args.item_type == "book"
+
+    def test_add_file_defaults(self):
+        args = self.parser.parse_args(["add", "file", "--filepath", "/tmp/x.pdf"])
+        assert args.title is None
+        assert args.item_type == "document"
+
+    def test_add_file_parent_key_removed(self):
+        # --parent-key never mapped to a real add_from_file parameter and made
+        # every `add file` invocation raise TypeError; it must stay removed.
+        with pytest.raises(SystemExit):
+            self.parser.parse_args([
+                "add", "file", "--filepath", "/tmp/x.pdf", "--parent-key", "ABC12345",
+            ])
 
 
 # ---------------------------------------------------------------------------
@@ -340,3 +365,77 @@ class TestCmdEdit:
 
         call_kwargs = mock_write.update_item.call_args.kwargs
         assert call_kwargs["add_tags"] == ["tag1", "tag2", "tag3"]
+
+
+# ---------------------------------------------------------------------------
+# cmd_add
+# ---------------------------------------------------------------------------
+
+class TestCmdAdd:
+    """cmd_add must call the write tools with kwargs their real signatures accept.
+
+    Plain MagicMocks hide kwarg mismatches (they accept anything), which is how
+    `add file` shipped passing a nonexistent parent_key= and raised TypeError on
+    every invocation. Autospec the real functions so signature drift fails here.
+    """
+
+    def _run(self, args):
+        mock_write = MagicMock()
+        for fn in ("add_by_doi", "add_by_url", "add_from_file"):
+            setattr(mock_write, fn,
+                    create_autospec(getattr(write_tools, fn), return_value="ok"))
+        with patch("zotero_mcp.cli_standalone.setup_zotero_environment"):
+            with patch("zotero_mcp.cli_standalone._import_tools",
+                       return_value=(MagicMock(), MagicMock(), MagicMock(),
+                                     mock_write, MagicMock())):
+                cmd_add(args)
+        return mock_write
+
+    def test_add_file_matches_real_signature(self, capsys):
+        # Regression: would raise TypeError while parent_key= was passed.
+        args = MagicMock(subcommand="file", filepath="/tmp/paper.pdf",
+                         title=None, item_type="document",
+                         collections=None, tags=None, verbose=False)
+        mock_write = self._run(args)
+
+        mock_write.add_from_file.assert_called_once()
+        call_kwargs = mock_write.add_from_file.call_args.kwargs
+        assert call_kwargs["file_path"] == "/tmp/paper.pdf"
+        assert call_kwargs["title"] is None
+        assert call_kwargs["item_type"] == "document"
+        assert "ok" in capsys.readouterr().out
+
+    def test_add_file_forwards_title_and_item_type(self):
+        args = MagicMock(subcommand="file", filepath="/tmp/book.epub",
+                         title="My Book", item_type="book",
+                         collections="ABCD1234,EFGH5678", tags="a,b",
+                         verbose=False)
+        mock_write = self._run(args)
+
+        call_kwargs = mock_write.add_from_file.call_args.kwargs
+        assert call_kwargs["title"] == "My Book"
+        assert call_kwargs["item_type"] == "book"
+        assert call_kwargs["collections"] == ["ABCD1234", "EFGH5678"]
+        assert call_kwargs["tags"] == ["a", "b"]
+
+    def test_add_doi_matches_real_signature(self):
+        args = MagicMock(subcommand="doi", doi="10.1234/test",
+                         attach_mode="auto", collections="ABCD1234",
+                         tags=None, verbose=False)
+        mock_write = self._run(args)
+
+        mock_write.add_by_doi.assert_called_once()
+        call_kwargs = mock_write.add_by_doi.call_args.kwargs
+        assert call_kwargs["doi"] == "10.1234/test"
+        assert call_kwargs["collections"] == ["ABCD1234"]
+
+    def test_add_url_matches_real_signature(self):
+        args = MagicMock(subcommand="url", url="https://arxiv.org/abs/2301.00001",
+                         attach_mode="auto", collections=None, tags=None,
+                         verbose=False)
+        mock_write = self._run(args)
+
+        mock_write.add_by_url.assert_called_once()
+        assert mock_write.add_by_url.call_args.kwargs["url"] == (
+            "https://arxiv.org/abs/2301.00001"
+        )

--- a/tests/test_collection_resolver.py
+++ b/tests/test_collection_resolver.py
@@ -1,0 +1,220 @@
+"""Tests for resolve_collection_specs / build_collection_paths (#3).
+
+The resolver lets every add path (and zotero_manage_collections) accept
+collection KEYS, NAMES, or '/'-separated PATHS interchangeably:
+
+- a key is used as-is, but only if it actually exists as a live collection
+  (shape alone is not enough — trashed/bogus keys must fail loudly);
+- a name matches case-insensitively anywhere in the tree;
+- a path like 'parent/child' suffix-matches the collection tree, so it
+  disambiguates same-named leaves;
+- ambiguity and misses raise ValueError with actionable messages;
+- create_missing=True creates the missing chain instead of raising.
+"""
+
+import pytest
+
+from conftest import DummyContext, FakeZotero
+from zotero_mcp.tools import _helpers
+
+
+def _coll(key, name, parent=False):
+    return {"key": key, "data": {"name": name, "parentCollection": parent}}
+
+
+class FakeZoteroResolver(FakeZotero):
+    """FakeZotero with collection-creation tracking and a stubbed trash."""
+
+    def __init__(self):
+        super().__init__()
+        self.created_collections = []
+        self._trashed = []
+        self._create_counter = 0
+
+    def create_collections(self, colls, **kwargs):
+        self.created_collections.extend(colls)
+        result = {}
+        for i, c in enumerate(colls):
+            self._create_counter += 1
+            new_key = f"NEW{self._create_counter:05d}"
+            result[str(i)] = new_key
+            self._collections.append(
+                _coll(new_key, c["name"], c.get("parentCollection") or False)
+            )
+        return {"success": result, "successful": {}, "failed": {}}
+
+    def _retrieve_data(self, path):
+        class _Resp:
+            def __init__(self, data):
+                self._data = data
+
+            def json(self):
+                return self._data
+
+        if path.endswith("/collections/trash"):
+            return _Resp(self._trashed)
+        raise Exception(f"unexpected path {path}")
+
+
+@pytest.fixture
+def zot():
+    z = FakeZoteroResolver()
+    z._collections = [
+        _coll("ROOT0001", "Machine Learning"),
+        _coll("CHLD0001", "Deep Learning", parent="ROOT0001"),
+        _coll("CHLD0002", "Optimisation", parent="ROOT0001"),
+        _coll("ROOT0002", "_project"),
+        _coll("CHLD0003", "Deep Learning", parent="ROOT0002"),  # duplicate leaf name
+        _coll("ROOT0003", "Reading List"),
+    ]
+    return z
+
+
+# ---------------------------------------------------------------------------
+# build_collection_paths
+# ---------------------------------------------------------------------------
+
+class TestBuildCollectionPaths:
+    def test_paths_built_from_parent_links(self, zot):
+        paths = _helpers.build_collection_paths(zot._collections)
+        assert paths["ROOT0001"] == ["Machine Learning"]
+        assert paths["CHLD0001"] == ["Machine Learning", "Deep Learning"]
+        assert paths["CHLD0003"] == ["_project", "Deep Learning"]
+
+    def test_orphaned_parent_degrades_to_short_path(self):
+        paths = _helpers.build_collection_paths(
+            [_coll("AAAA0001", "Orphan", parent="GONE0000")]
+        )
+        assert paths["AAAA0001"] == ["Orphan"]
+
+    def test_parent_cycle_does_not_hang(self):
+        paths = _helpers.build_collection_paths([
+            _coll("AAAA0001", "A", parent="BBBB0001"),
+            _coll("BBBB0001", "B", parent="AAAA0001"),
+        ])
+        assert "A" in "/".join(paths["AAAA0001"])
+        assert "B" in "/".join(paths["BBBB0001"])
+
+
+# ---------------------------------------------------------------------------
+# resolve_collection_specs — keys
+# ---------------------------------------------------------------------------
+
+class TestKeyResolution:
+    def test_live_key_passes_through(self, zot):
+        assert _helpers.resolve_collection_specs(zot, ["CHLD0001"]) == ["CHLD0001"]
+
+    def test_bogus_key_shaped_spec_errors(self, zot):
+        with pytest.raises(ValueError, match="not found"):
+            _helpers.resolve_collection_specs(zot, ["DEADBEEF"])
+
+    def test_trashed_key_reports_trash(self, zot):
+        zot._trashed = [_coll("DEAD0001", "Old Stuff")]
+        with pytest.raises(ValueError, match="Trash"):
+            _helpers.resolve_collection_specs(zot, ["DEAD0001"])
+
+    def test_key_shaped_name_resolves_as_name(self, zot):
+        # 8-char uppercase name that is NOT a live key → name resolution.
+        zot._collections.append(_coll("ROOT0004", "ARCHIVES"))
+        assert _helpers.resolve_collection_specs(zot, ["ARCHIVES"]) == ["ROOT0004"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_collection_specs — names and paths
+# ---------------------------------------------------------------------------
+
+class TestNameAndPathResolution:
+    def test_exact_name_case_insensitive(self, zot):
+        assert _helpers.resolve_collection_specs(zot, ["machine learning"]) == ["ROOT0001"]
+
+    def test_nested_name_matches_anywhere(self, zot):
+        assert _helpers.resolve_collection_specs(zot, ["Optimisation"]) == ["CHLD0002"]
+
+    def test_ambiguous_name_lists_candidates(self, zot):
+        with pytest.raises(ValueError) as exc:
+            _helpers.resolve_collection_specs(zot, ["Deep Learning"])
+        msg = str(exc.value)
+        assert "ambiguous" in msg
+        assert "CHLD0001" in msg and "CHLD0003" in msg
+        assert "Machine Learning/Deep Learning" in msg
+
+    def test_path_disambiguates(self, zot):
+        assert _helpers.resolve_collection_specs(
+            zot, ["_project/Deep Learning"]
+        ) == ["CHLD0003"]
+
+    def test_path_is_case_insensitive(self, zot):
+        assert _helpers.resolve_collection_specs(
+            zot, ["machine learning/deep learning"]
+        ) == ["CHLD0001"]
+
+    def test_unknown_name_suggests_close_matches(self, zot):
+        with pytest.raises(ValueError) as exc:
+            _helpers.resolve_collection_specs(zot, ["learning"])
+        # 'learning' is a substring of several collections but an exact match
+        # of none → ambiguous-or-missing must surface candidates.
+        msg = str(exc.value)
+        assert "not found" in msg
+        assert "Machine Learning" in msg
+
+    def test_mixed_specs_resolve_in_order_and_dedupe(self, zot):
+        out = _helpers.resolve_collection_specs(
+            zot, ["ROOT0003", "reading list", "Optimisation"]
+        )
+        assert out == ["ROOT0003", "CHLD0002"]
+
+    def test_empty_specs_no_fetch(self):
+        class Boom:
+            def collections(self, **kw):
+                raise AssertionError("should not fetch for empty specs")
+
+        assert _helpers.resolve_collection_specs(Boom(), []) == []
+        assert _helpers.resolve_collection_specs(Boom(), None) == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_collection_specs — create_missing
+# ---------------------------------------------------------------------------
+
+class TestCreateMissing:
+    def test_creates_single_name_at_root(self, zot):
+        out = _helpers.resolve_collection_specs(
+            zot, ["Brand New"], create_missing=True, write_zot=zot,
+            ctx=DummyContext(),
+        )
+        assert out == ["NEW00001"]
+        assert zot.created_collections == [
+            {"name": "Brand New", "parentCollection": False}
+        ]
+
+    def test_creates_chain_under_existing_prefix(self, zot):
+        out = _helpers.resolve_collection_specs(
+            zot, ["_project/intertemporal/drafts"], create_missing=True,
+            write_zot=zot, ctx=DummyContext(),
+        )
+        # '_project' exists (ROOT0002); 'intertemporal' and 'drafts' created.
+        assert [c["name"] for c in zot.created_collections] == [
+            "intertemporal", "drafts",
+        ]
+        assert zot.created_collections[0]["parentCollection"] == "ROOT0002"
+        assert out == ["NEW00002"]
+
+    def test_existing_spec_not_recreated(self, zot):
+        out = _helpers.resolve_collection_specs(
+            zot, ["Reading List"], create_missing=True, write_zot=zot,
+        )
+        assert out == ["ROOT0003"]
+        assert zot.created_collections == []
+
+    def test_ambiguous_parent_prefix_errors(self, zot):
+        with pytest.raises(ValueError, match="ambiguous"):
+            _helpers.resolve_collection_specs(
+                zot, ["Deep Learning/subtopic"], create_missing=True,
+                write_zot=zot,
+            )
+
+    def test_create_missing_without_write_client_errors(self, zot):
+        with pytest.raises(ValueError, match="writable"):
+            _helpers.resolve_collection_specs(
+                zot, ["Brand New"], create_missing=True,
+            )

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -427,7 +427,7 @@ class TestManageCollections:
         since the version number must match the server the write goes to."""
         read_zot = FakeZoteroCollections()
         read_zot._collections = [
-            {"key": "COL001", "data": {"name": "Test", "parentCollection": False}},
+            {"key": "COL00001", "data": {"name": "Test", "parentCollection": False}},
         ]
         write_zot = FakeZoteroCollections()
         write_zot._collections = list(read_zot._collections)  # both endpoints see the same collections
@@ -443,7 +443,7 @@ class TestManageCollections:
 
         result = server.manage_collections(
             item_keys=["ITEM0001"],
-            add_to=["COL001"],
+            add_to=["COL00001"],
             ctx=ctx,
         )
 
@@ -474,8 +474,8 @@ class TestManageCollections:
         assert "error" in result.lower() or "must specify" in result.lower()
 
     def test_collection_name_resolution_in_add_to(self, monkeypatch, fake_zot, ctx):
-        """add_to values are passed directly as collection keys (no name resolution).
-        The implementation uses _normalize_str_list_input, not _resolve_collection_names."""
+        """add_to values may be collection NAMES — resolved to keys before
+        any filing happens (resolve_collection_specs)."""
         _patch_web_only(monkeypatch, fake_zot)
 
         result = server.manage_collections(
@@ -484,10 +484,23 @@ class TestManageCollections:
             ctx=ctx,
         )
 
-        # The value is passed through as-is (not resolved to a key)
-        if fake_zot.added_to_collections:
-            coll_key, _ = fake_zot.added_to_collections[0]
-            assert coll_key == "NLP Papers"
+        assert fake_zot.added_to_collections, f"nothing filed: {result}"
+        coll_key, _ = fake_zot.added_to_collections[0]
+        assert coll_key == "ABC00003"
+
+    def test_collection_path_resolution_in_add_to(self, monkeypatch, fake_zot, ctx):
+        """A 'parent/child' path disambiguates nested collections."""
+        _patch_web_only(monkeypatch, fake_zot)
+
+        result = server.manage_collections(
+            item_keys=["ITEM0001"],
+            add_to=["Machine Learning/Deep Learning"],
+            ctx=ctx,
+        )
+
+        assert fake_zot.added_to_collections, f"nothing filed: {result}"
+        coll_key, _ = fake_zot.added_to_collections[0]
+        assert coll_key == "ABC00002"
 
     def test_multiple_items_batched(self, monkeypatch, fake_zot, ctx):
         """Multiple items should all be processed."""

--- a/tests/test_collections_backstop.py
+++ b/tests/test_collections_backstop.py
@@ -136,6 +136,9 @@ def test_add_by_doi_string_collection_routes_correctly(monkeypatch):
     """The bare-string ``collections="KEY"`` form must produce the same routing
     as the array form (#235)."""
     z = _RecordingZotero(atomic_filing_works=True)
+    z._collections = [
+        {"key": "A75DWWBH", "data": {"name": "Target", "parentCollection": False}},
+    ]
     _patch_write_client(monkeypatch, z)
 
     result = server.add_by_doi(
@@ -151,6 +154,9 @@ def test_add_by_doi_string_collection_with_atomic_failure_backstops(monkeypatch)
     """If pyzotero's atomic filing on ``create_items`` no-ops, the backstop
     must explicitly ``addto_collection`` so the item still lands correctly."""
     z = _RecordingZotero(atomic_filing_works=False)
+    z._collections = [
+        {"key": "A75DWWBH", "data": {"name": "Target", "parentCollection": False}},
+    ]
     _patch_write_client(monkeypatch, z)
 
     result = server.add_by_doi(

--- a/tests/test_regression_bugs.py
+++ b/tests/test_regression_bugs.py
@@ -34,11 +34,14 @@ class TestManageCollectionsPayloadShape:
                 return _FakeResponse(204)
 
         fake = FakeZotManage()
+        fake._collections = [
+            {"key": "COL00001", "data": {"name": "Test Collection", "parentCollection": False}},
+        ]
         monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client", lambda ctx: (fake, fake))
 
         ctx = DummyContext()
         server.manage_collections(
-            item_keys=["ITEM01"], add_to=["COL01"], ctx=ctx
+            item_keys=["ITEM01"], add_to=["COL00001"], ctx=ctx
         )
 
         assert len(received) == 1


### PR DESCRIPTION
Closes #336

> **Stacked on #339.** Cross-fork PRs can only target `main`, so this diff includes #339's commit; the new work here is the **last commit** (`feat(collections): resolve names/paths/keys…`). I'll rebase as the predecessors merge.

## What

Collection specs passed to every add tool (and `zotero_manage_collections`) now accept **keys, names, or `/`-separated paths** interchangeably — and are validated before anything is created. This makes the long-standing tool-description claim ("collection names — resolved automatically") actually true: today names are written into `item_data["collections"]` as bogus keys in every `add_by_*` path (`_resolve_collection_names` is only wired into `create_collection` and `update_item`).

```bash
uv run zotero-cli add doi 10.1145/3708319 --collections "intertemporal_decisions"
uv run zotero-cli add url https://arxiv.org/abs/2401.00001 --collections "_project/Deep Learning"
uv run zotero-cli collections manage --item-keys KEY123 --add-to "Reading List"
```

## How

New shared helpers in `tools/_helpers.py`:

- `build_collection_paths(collections)` — key → full path segments, from `parentCollection` links (cycle/orphan safe).
- `resolve_collection_specs(zot, specs, *, create_missing=False, write_zot=None, ctx=None)` — per spec:
  1. **Key**: 8-char shape **and** live in the library → as-is. Existence is checked, not just shape, so a trashed or bogus key fails loudly *before* the item is created (same failure class as #233) instead of yielding an invisibly-filed/unfiled item.
  2. **Name/path**: split on `/`, suffix-matched case-insensitively against the tree — a bare name matches anywhere; `parent/name` disambiguates duplicate leaves.
  3. Ambiguity → `ValueError` listing every candidate with its full path. Miss → `ValueError` with near-miss suggestions, or — with `create_missing=True` — create the missing chain (anchored at the longest resolvable prefix; exposed as a tool/CLI flag in the follow-up PR for #337).

Wired into: `add_by_doi`, `add_by_url` (webpage branch), `_add_by_arxiv` (including its CrossRef outage fallback, which now receives pre-resolved keys), `add_by_isbn`, `add_by_bibtex`, `add_by_csl_json`, `add_from_file`, `manage_collections`. Resolution runs **before** any network fetch or `create_items` call. The CLI gains all of this for free (same functions).

Also:

- The #235 `ensure_collection_membership` post-create backstop now runs in **every** add path (previously only `add_by_doi`), and each tool result reports a `Collections:` status line.
- `manage_collections` validation switches from N× `collection(key)` calls to the resolver's single collections fetch, preserving the #233 error contract ("Trash"/"not found" messages — covered by the existing tests).
- Tool descriptions and README updated to describe the real behavior.

## Behavior changes

- Passing an unknown/trashed/ambiguous collection spec to an add tool now **fails the add early** with an actionable message (previously: silent mis-filing or an unfiled item).
- `manage_collections` `add_to`/`remove_from` accept names/paths.
- On multiple exact-name matches the resolver **errors with candidates** rather than filing into all matches (the warn-and-use-all behavior of `_resolve_collection_names` survives only in `update_item.collection_names`, untouched here).

## Tests

- New `tests/test_collection_resolver.py` (20 tests): path building, key/name/path resolution, ambiguity, trash messaging, suggestions, `create_missing` chains.
- New integration checks: name→key resolution in `add_by_doi`/`add_by_url`/`add_by_bibtex`/`manage_collections` (one existing test previously asserted the bug — "names are used as-is" — and now asserts resolution).
- Existing add-path tests' fakes updated to register the collections they reference (the resolver validates existence now).
- Full suite: 925 passed; the 5 remaining failures (`test_lifespan` ×3, `test_place_field_reads` ×2) are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
