### PR TITLE
feat(cli): add isbn / bibtex / csl-json subcommands for MCP parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,10 @@ zotero-cli ann search "highlight text"
 zotero-cli add doi 10.1038/s41586-021-03819-2
 zotero-cli add url https://arxiv.org/abs/2301.00001
 zotero-cli add file --filepath /path/to/paper.pdf --title "Override Title"
+zotero-cli add isbn 9780262046305
+zotero-cli add bibtex --file refs.bib                # or --bibtex '@article{...}'
+zotero-cli add bibtex --bibtex - < refs.bib          # stdin via -
+zotero-cli add csl-json --file refs.json             # or --json '...' / --json -
 
 # --collections accepts keys, names, or parent/child paths — resolved and
 # validated before the item is created (a typo fails the add, with suggestions,
@@ -506,6 +510,9 @@ zotero_remove_item_relation(
 ### 📦 Item & Collection Management Tools
 - `zotero_add_by_doi`: Add a paper by DOI with automatic metadata and open-access PDF attachment
 - `zotero_add_by_url`: Add a paper by URL (arXiv, DOI URLs, and general webpages)
+- `zotero_add_by_isbn`: Add a book by ISBN (Open Library + Google Books cascade)
+- `zotero_add_by_bibtex`: Add one or more items from BibTeX (inline or .bib file)
+- `zotero_add_by_csl_json`: Add one or more items from CSL JSON (inline or file)
 - `zotero_add_from_file`: Import a local PDF or EPUB file with automatic DOI extraction
 
 All add tools take a `collections` parameter accepting collection keys, names, or `parent/child` paths — resolved and validated before the item is created, so unknown or ambiguous specs fail with suggestions instead of producing an unfiled item. They also take `if_exists` (`"duplicate"` — default — always creates; `"file"` reuses an existing item matching the DOI/arXiv ID/ISBN/URL, filing it into missing collections and adding missing tags; `"skip"` leaves a match untouched) and `create_missing_collections` (create unknown collection specs, including path chains, instead of failing). The `zotero-cli add` commands default to `--if-exists file`.

--- a/README.md
+++ b/README.md
@@ -385,6 +385,12 @@ zotero-cli add doi 10.1038/s41586-021-03819-2
 zotero-cli add url https://arxiv.org/abs/2301.00001
 zotero-cli add file --filepath /path/to/paper.pdf --title "Override Title"
 
+# --collections accepts keys, names, or parent/child paths — resolved and
+# validated before the item is created (a typo fails the add, with suggestions,
+# instead of leaving an unfiled item)
+zotero-cli add doi 10.1038/s41586-021-03819-2 --collections "Reading List"
+zotero-cli collections manage --item-keys ABC123 --add-to "_project/topic"
+
 # Collections and tags
 zotero-cli coll list                          # list collections (short alias)
 zotero-cli coll search "PhD Research"
@@ -491,9 +497,11 @@ zotero_remove_item_relation(
 - `zotero_add_by_doi`: Add a paper by DOI with automatic metadata and open-access PDF attachment
 - `zotero_add_by_url`: Add a paper by URL (arXiv, DOI URLs, and general webpages)
 - `zotero_add_from_file`: Import a local PDF or EPUB file with automatic DOI extraction
+
+All add tools take a `collections` parameter accepting collection keys, names, or `parent/child` paths — resolved and validated before the item is created, so unknown or ambiguous specs fail with suggestions instead of producing an unfiled item.
 - `zotero_create_collection`: Create a new collection (folder/project) in your library
 - `zotero_search_collections`: Search for collections by name to find their keys
-- `zotero_manage_collections`: Add or remove items from collections
+- `zotero_manage_collections`: Add or remove items from collections (accepts keys, names, or `parent/child` paths)
 - `zotero_update_item`: Update metadata for an existing item (title, tags, abstract, date, etc.)
 - `zotero_find_duplicates`: Find duplicate items by title and/or DOI
 - `zotero_merge_duplicates`: Merge duplicate items with dry-run preview; consolidates all child items

--- a/README.md
+++ b/README.md
@@ -391,6 +391,16 @@ zotero-cli add file --filepath /path/to/paper.pdf --title "Override Title"
 zotero-cli add doi 10.1038/s41586-021-03819-2 --collections "Reading List"
 zotero-cli collections manage --item-keys ABC123 --add-to "_project/topic"
 
+# Adds are idempotent by default (--if-exists file): if the item is already in
+# the library it is reused — filed into any missing collections, given any
+# missing tags — instead of duplicated. Re-running the same command is a no-op.
+zotero-cli add doi 10.1038/s41586-021-03819-2 -c "Reading List"   # run it twice: converges
+zotero-cli add doi 10.1038/s41586-021-03819-2 --if-exists skip       # never touch existing
+zotero-cli add doi 10.1038/s41586-021-03819-2 --if-exists duplicate  # old behavior
+zotero-cli add doi 10.1038/s41586-021-03819-2 -c "New Topic" --create-collections
+# -c/--collection is repeatable and never comma-split (names with commas work);
+# --collections remains the comma-separated form
+
 # Collections and tags
 zotero-cli coll list                          # list collections (short alias)
 zotero-cli coll search "PhD Research"
@@ -498,7 +508,7 @@ zotero_remove_item_relation(
 - `zotero_add_by_url`: Add a paper by URL (arXiv, DOI URLs, and general webpages)
 - `zotero_add_from_file`: Import a local PDF or EPUB file with automatic DOI extraction
 
-All add tools take a `collections` parameter accepting collection keys, names, or `parent/child` paths — resolved and validated before the item is created, so unknown or ambiguous specs fail with suggestions instead of producing an unfiled item.
+All add tools take a `collections` parameter accepting collection keys, names, or `parent/child` paths — resolved and validated before the item is created, so unknown or ambiguous specs fail with suggestions instead of producing an unfiled item. They also take `if_exists` (`"duplicate"` — default — always creates; `"file"` reuses an existing item matching the DOI/arXiv ID/ISBN/URL, filing it into missing collections and adding missing tags; `"skip"` leaves a match untouched) and `create_missing_collections` (create unknown collection specs, including path chains, instead of failing). The `zotero-cli add` commands default to `--if-exists file`.
 - `zotero_create_collection`: Create a new collection (folder/project) in your library
 - `zotero_search_collections`: Search for collections by name to find their keys
 - `zotero_manage_collections`: Add or remove items from collections (accepts keys, names, or `parent/child` paths)

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ zotero-cli ann search "highlight text"
 # Add items
 zotero-cli add doi 10.1038/s41586-021-03819-2
 zotero-cli add url https://arxiv.org/abs/2301.00001
-zotero-cli add file /path/to/paper.pdf
+zotero-cli add file --filepath /path/to/paper.pdf --title "Override Title"
 
 # Collections and tags
 zotero-cli coll list                          # list collections (short alias)

--- a/src/zotero_mcp/cli_standalone.py
+++ b/src/zotero_mcp/cli_standalone.py
@@ -217,28 +217,48 @@ def cmd_notes(args):
         sys.exit(1)
 
 
+def _collect_collection_specs(args) -> list | None:
+    """Merge --collections (comma-split) with repeatable -c/--collection.
+
+    Each -c value is ONE spec, never comma-split — so names containing
+    commas work. Returns None when neither flag was given.
+    """
+    specs = []
+    if getattr(args, "collections", None):
+        specs.extend(s.strip() for s in args.collections.split(",") if s.strip())
+    for spec in getattr(args, "collection", None) or []:
+        if spec.strip():
+            specs.append(spec.strip())
+    return specs or None
+
+
 def cmd_add(args):
     setup_zotero_environment()
     search_mod, retrieval, annotations, write_mod, _client = _import_tools()
     ctx = _ctx(args)
     tags = args.tags.split(",") if args.tags else None
-    collections = args.collections.split(",") if args.collections else None
+    collections = _collect_collection_specs(args)
+    if_exists = getattr(args, "if_exists", "file")
+    create_missing = getattr(args, "create_collections", False)
 
     if args.subcommand == "doi":
         print(write_mod.add_by_doi(
             doi=args.doi, collections=collections, tags=tags,
-            attach_mode=args.attach_mode, ctx=ctx,
+            attach_mode=args.attach_mode, if_exists=if_exists,
+            create_missing_collections=create_missing, ctx=ctx,
         ))
     elif args.subcommand == "url":
         print(write_mod.add_by_url(
             url=args.url, collections=collections, tags=tags,
-            attach_mode=args.attach_mode, ctx=ctx,
+            attach_mode=args.attach_mode, if_exists=if_exists,
+            create_missing_collections=create_missing, ctx=ctx,
         ))
     elif args.subcommand == "file":
         print(write_mod.add_from_file(
             file_path=args.filepath, title=getattr(args, "title", None),
             item_type=getattr(args, "item_type", "document"),
-            collections=collections, tags=tags, ctx=ctx,
+            collections=collections, tags=tags, if_exists=if_exists,
+            create_missing_collections=create_missing, ctx=ctx,
         ))
     else:
         print(f"Unknown 'add' subcommand: {args.subcommand}", file=sys.stderr)
@@ -616,23 +636,41 @@ def build_parser() -> argparse.ArgumentParser:
     # add
     add_p = sub.add_parser("add", help="Add items to your library")
     add_sub = add_p.add_subparsers(dest="subcommand")
+
+    def _add_common_flags(p):
+        """Collection/idempotency flags shared by every `add` subcommand."""
+        p.add_argument("--collections",
+                       help="Comma-separated collection keys, names, or paths")
+        p.add_argument("-c", "--collection", action="append", metavar="SPEC",
+                       help="Collection key, name, or parent/child path "
+                            "(repeatable; not comma-split, so names with "
+                            "commas work)")
+        p.add_argument("--tags", help="Comma-separated tags")
+        p.add_argument("--if-exists", dest="if_exists",
+                       choices=["file", "skip", "duplicate"], default="file",
+                       help="When the item already exists: 'file' (default) "
+                            "reuses it and adds missing collections/tags; "
+                            "'skip' leaves it untouched; 'duplicate' creates "
+                            "a new item anyway")
+        p.add_argument("--create-collections", dest="create_collections",
+                       action="store_true",
+                       help="Create collections that don't exist yet "
+                            "(including parent/child paths)")
+
     adoi = add_sub.add_parser("doi", help="Add item by DOI")
     adoi.add_argument("doi")
-    adoi.add_argument("--collections")
-    adoi.add_argument("--tags")
+    _add_common_flags(adoi)
     adoi.add_argument("--attach-mode", choices=["auto", "linked_url", "import_file"], default="auto")
     aurl = add_sub.add_parser("url", help="Add item by URL")
     aurl.add_argument("url")
-    aurl.add_argument("--collections")
-    aurl.add_argument("--tags")
+    _add_common_flags(aurl)
     aurl.add_argument("--attach-mode", choices=["auto", "linked_url", "import_file"], default="auto")
     afil = add_sub.add_parser("file", help="Add item from local file (.pdf/.epub)")
     afil.add_argument("--filepath", required=True)
     afil.add_argument("--title", help="Override title if metadata extraction misses")
     afil.add_argument("--item-type", default="document",
                       help="Zotero item type for the new item (default: document)")
-    afil.add_argument("--collections")
-    afil.add_argument("--tags")
+    _add_common_flags(afil)
 
     # collections
     col_p = sub.add_parser("collections", help="Manage collections", aliases=["coll"])

--- a/src/zotero_mcp/cli_standalone.py
+++ b/src/zotero_mcp/cli_standalone.py
@@ -236,7 +236,8 @@ def cmd_add(args):
         ))
     elif args.subcommand == "file":
         print(write_mod.add_from_file(
-            file_path=args.filepath, parent_key=getattr(args, "parent_key", None),
+            file_path=args.filepath, title=getattr(args, "title", None),
+            item_type=getattr(args, "item_type", "document"),
             collections=collections, tags=tags, ctx=ctx,
         ))
     else:
@@ -625,9 +626,11 @@ def build_parser() -> argparse.ArgumentParser:
     aurl.add_argument("--collections")
     aurl.add_argument("--tags")
     aurl.add_argument("--attach-mode", choices=["auto", "linked_url", "import_file"], default="auto")
-    afil = add_sub.add_parser("file", help="Add item from local file")
+    afil = add_sub.add_parser("file", help="Add item from local file (.pdf/.epub)")
     afil.add_argument("--filepath", required=True)
-    afil.add_argument("--parent-key")
+    afil.add_argument("--title", help="Override title if metadata extraction misses")
+    afil.add_argument("--item-type", default="document",
+                      help="Zotero item type for the new item (default: document)")
     afil.add_argument("--collections")
     afil.add_argument("--tags")
 

--- a/src/zotero_mcp/cli_standalone.py
+++ b/src/zotero_mcp/cli_standalone.py
@@ -5,8 +5,11 @@ Usage:
     zotero-cli search "Einstein 1905"
     zotero-cli get metadata ITEM_KEY
     zotero-cli get collections
-    zotero-cli add doi 10.1234/example
+    zotero-cli add doi 10.1234/example -c "Reading List"
     zotero-cli add url https://arxiv.org/abs/2301.00001
+    zotero-cli add isbn 9780262046305 -c "_project/books"
+    zotero-cli add bibtex --file refs.bib -c topic
+    zotero-cli add csl-json --json - -c topic   # reads stdin
     zotero-cli edit ITEM_KEY --title "New Title"
     zotero-cli notes list
     zotero-cli annotations list --item-key ITEM_KEY
@@ -258,6 +261,28 @@ def cmd_add(args):
             file_path=args.filepath, title=getattr(args, "title", None),
             item_type=getattr(args, "item_type", "document"),
             collections=collections, tags=tags, if_exists=if_exists,
+            create_missing_collections=create_missing, ctx=ctx,
+        ))
+    elif args.subcommand == "isbn":
+        print(write_mod.add_by_isbn(
+            isbn=args.isbn, collections=collections, tags=tags,
+            if_exists=if_exists, create_missing_collections=create_missing,
+            ctx=ctx,
+        ))
+    elif args.subcommand == "bibtex":
+        bibtex = sys.stdin.read() if args.bibtex == "-" else args.bibtex
+        print(write_mod.add_by_bibtex(
+            bibtex=bibtex, file_path=getattr(args, "file", None),
+            collections=collections, tags=tags,
+            attach_mode=args.attach_mode, if_exists=if_exists,
+            create_missing_collections=create_missing, ctx=ctx,
+        ))
+    elif args.subcommand == "csl-json":
+        csl_json = sys.stdin.read() if args.json == "-" else args.json
+        print(write_mod.add_by_csl_json(
+            csl_json=csl_json, file_path=getattr(args, "file", None),
+            collections=collections, tags=tags,
+            attach_mode=args.attach_mode, if_exists=if_exists,
             create_missing_collections=create_missing, ctx=ctx,
         ))
     else:
@@ -671,6 +696,23 @@ def build_parser() -> argparse.ArgumentParser:
     afil.add_argument("--item-type", default="document",
                       help="Zotero item type for the new item (default: document)")
     _add_common_flags(afil)
+    aisbn = add_sub.add_parser("isbn", help="Add book by ISBN")
+    aisbn.add_argument("isbn")
+    _add_common_flags(aisbn)
+    abib = add_sub.add_parser("bibtex", help="Add items from BibTeX")
+    abib.add_argument("--bibtex",
+                      help="Inline BibTeX (use - to read from stdin)")
+    abib.add_argument("--file", help="Path to a .bib/.bibtex file")
+    _add_common_flags(abib)
+    abib.add_argument("--attach-mode", choices=["auto", "linked_url", "import_file"],
+                      default="auto")
+    acsl = add_sub.add_parser("csl-json", help="Add items from CSL JSON")
+    acsl.add_argument("--json", dest="json",
+                      help="Inline CSL JSON (use - to read from stdin)")
+    acsl.add_argument("--file", help="Path to a .json/.csljson file")
+    _add_common_flags(acsl)
+    acsl.add_argument("--attach-mode", choices=["auto", "linked_url", "import_file"],
+                      default="auto")
 
     # collections
     col_p = sub.add_parser("collections", help="Manage collections", aliases=["coll"])

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -343,6 +343,198 @@ def _resolve_collection_names(zot, names, ctx=None):
     return results
 
 
+_COLLECTION_KEY_RE = re.compile(r"^[A-Z0-9]{8}$")
+
+
+def build_collection_paths(collections) -> dict[str, list[str]]:
+    """Map collection key → full path segments ``[root, ..., name]``.
+
+    Built from ``data.parentCollection`` links. A parent that isn't in the
+    fetched set (e.g. trashed) or a parent cycle degrades to a shorter path
+    rather than failing.
+    """
+    by_key = {c["key"]: c for c in collections if c.get("key")}
+    paths: dict[str, list[str]] = {}
+
+    def _segments(key: str, seen: set[str]) -> list[str]:
+        if key in paths:
+            return paths[key]
+        coll = by_key[key]
+        name = coll.get("data", {}).get("name") or key
+        parent = coll.get("data", {}).get("parentCollection")
+        if parent in by_key and parent not in seen:
+            seen.add(key)
+            segs = _segments(parent, seen) + [name]
+        else:
+            segs = [name]
+        paths[key] = segs
+        return segs
+
+    for key in by_key:
+        _segments(key, {key})
+    return paths
+
+
+def resolve_collection_specs(
+    zot,
+    specs,
+    *,
+    create_missing: bool = False,
+    write_zot=None,
+    ctx=None,
+) -> list[str]:
+    """Resolve collection *specs* — keys, names, or '/'-paths — to live keys.
+
+    Resolution order per spec:
+
+    1. **Key**: 8-char uppercase-alphanumeric AND currently a live collection
+       key → used as-is. Existence is checked, not just shape, so trashed or
+       bogus keys fail loudly here instead of producing an invisibly-filed or
+       unfiled item after creation (#233/#235).
+    2. **Name/path**: the spec is split on '/' and matched case-insensitively
+       against the *trailing* path segments of every collection, so a bare
+       name matches anywhere in the tree and 'parent/name' disambiguates
+       same-named leaves.
+
+    An ambiguous spec raises ValueError listing every candidate. An unknown
+    spec raises ValueError with near-miss suggestions — unless
+    ``create_missing`` is True, in which case the collection (including any
+    missing intermediate path segments) is created via ``write_zot``.
+
+    Returns resolved keys in input order, deduplicated.
+    """
+    cleaned = [str(s).strip() for s in (specs or []) if str(s).strip()]
+    if not cleaned:
+        return []
+
+    paths = build_collection_paths(_paginate(zot.collections))
+
+    resolved: list[str] = []
+    for spec in cleaned:
+        if _COLLECTION_KEY_RE.match(spec) and spec in paths:
+            resolved.append(spec)
+            continue
+
+        wanted = [seg.strip().lower() for seg in spec.split("/") if seg.strip()]
+        if not wanted:
+            raise ValueError(f"Collection spec '{spec}' is empty.")
+
+        matches = [
+            key for key, segs in paths.items()
+            if len(segs) >= len(wanted)
+            and [s.lower() for s in segs[-len(wanted):]] == wanted
+        ]
+
+        if len(matches) > 1:
+            candidates = "; ".join(
+                f"'{'/'.join(paths[k])}' ({k})"
+                for k in sorted(matches, key=lambda k: paths[k])
+            )
+            raise ValueError(
+                f"Collection spec '{spec}' is ambiguous — it matches: "
+                f"{candidates}. Disambiguate with a longer path or the "
+                "8-character collection key."
+            )
+        if matches:
+            resolved.append(matches[0])
+            continue
+
+        if create_missing:
+            if write_zot is None:
+                raise ValueError(
+                    f"Collection '{spec}' not found and no writable client "
+                    "is available to create it."
+                )
+            resolved.append(
+                _create_collection_path(write_zot, paths, spec, ctx=ctx)
+            )
+            continue
+
+        raise ValueError(_collection_not_found_message(zot, spec, paths))
+
+    seen: set[str] = set()
+    return [k for k in resolved if not (k in seen or seen.add(k))]
+
+
+def _create_collection_path(write_zot, paths, spec, ctx=None) -> str:
+    """Create the collections needed to satisfy *spec*; return the leaf key.
+
+    The longest prefix of the path that already resolves (unique trailing-
+    segment match) anchors the chain; remaining segments are created beneath
+    it, or at the library root when nothing resolves. Mutates *paths* with
+    the created entries so later specs in the same call see them.
+    """
+    names = [seg.strip() for seg in spec.split("/") if seg.strip()]
+
+    parent_key = None
+    start = 0
+    for i in range(len(names) - 1, 0, -1):
+        prefix = [s.lower() for s in names[:i]]
+        matches = [
+            key for key, segs in paths.items()
+            if len(segs) >= len(prefix)
+            and [s.lower() for s in segs[-len(prefix):]] == prefix
+        ]
+        if len(matches) > 1:
+            candidates = "; ".join(f"'{'/'.join(paths[k])}' ({k})" for k in matches)
+            raise ValueError(
+                f"Cannot create '{spec}': parent path "
+                f"'{'/'.join(names[:i])}' is ambiguous — it matches: "
+                f"{candidates}."
+            )
+        if matches:
+            parent_key = matches[0]
+            start = i
+            break
+
+    for name in names[start:]:
+        payload = {"name": name, "parentCollection": parent_key or False}
+        result = write_zot.create_collections([payload])
+        if not (isinstance(result, dict) and result.get("success")):
+            raise ValueError(f"Failed to create collection '{name}': {result}")
+        new_key = next(iter(result["success"].values()))
+        paths[new_key] = (paths[parent_key] if parent_key else []) + [name]
+        if ctx is not None:
+            ctx.info(f"Created collection '{'/'.join(paths[new_key])}' ({new_key})")
+        parent_key = new_key
+    return parent_key
+
+
+def _collection_not_found_message(zot, spec, paths) -> str:
+    """Build the error message for an unresolvable collection spec."""
+    if _COLLECTION_KEY_RE.match(spec):
+        try:
+            trashed = {c.get("key") for c in fetch_trashed_collections(zot)}
+        except Exception:
+            trashed = set()
+        if spec in trashed:
+            return (
+                f"Collection '{spec}' is in the Zotero Trash. Restore it in "
+                "Zotero (or use another collection) before filing items into it."
+            )
+    msg = (
+        f"Collection '{spec}' not found in the active library "
+        "(tried key, name, and path matching)."
+    )
+    words = [w for w in spec.lower().replace("/", " ").split() if w]
+    suggestions = [
+        key for key, segs in paths.items()
+        if all(w in "/".join(segs).lower() for w in words)
+    ]
+    if suggestions:
+        shown = ", ".join(
+            f"'{'/'.join(paths[k])}' ({k})"
+            for k in sorted(suggestions, key=lambda k: paths[k])[:5]
+        )
+        msg += f" Close matches: {shown}."
+    else:
+        msg += (
+            " Use zotero_search_collections (or `zotero-cli collections "
+            "search`) to list available collections."
+        )
+    return msg
+
+
 def _normalize_doi(raw):
     """Normalize a DOI string from various input formats."""
     if not raw:

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -500,6 +500,69 @@ def _create_collection_path(write_zot, paths, spec, ctx=None) -> str:
     return parent_key
 
 
+def find_existing_items(zot, *, doi=None, arxiv_id=None, isbn=None, url=None,
+                        ctx=None) -> list[dict]:
+    """Find non-attachment items already in the library by a normalized id.
+
+    Exactly one of doi / arxiv_id / isbn / url should be given (already
+    normalized via the corresponding ``_normalize_*`` helper, except url).
+    A server-side quick search (``q=<id>, qmode='everything',
+    itemType='-attachment'``) narrows candidates cheaply; a client-side
+    normalized comparison confirms real matches. Searching with the BARE
+    identifier means the substring quick-search also catches values stored
+    with prefixes ('https://doi.org/10...', 'arXiv:...'). The items endpoint
+    excludes the Trash, so a trashed copy never blocks a re-add.
+
+    Returns full item dicts (with ``key``/``version``/``data``) so callers
+    can update them without re-fetching. Returns [] on search failure —
+    callers treat that as "nothing found" and proceed to create.
+    """
+    if doi:
+        query = doi
+        def _matches(data):
+            return _normalize_doi(data.get("DOI") or "") == doi
+    elif arxiv_id:
+        query = arxiv_id
+        def _matches(data):
+            if _normalize_arxiv_id(data.get("url") or "") == arxiv_id:
+                return True
+            return f"arxiv:{arxiv_id}".lower() in (data.get("extra") or "").lower()
+    elif isbn:
+        query = isbn
+        def _matches(data):
+            # Zotero's ISBN field may hold several space-separated values,
+            # in 10- or 13-digit form; compare each normalized to ISBN-13.
+            raw = data.get("ISBN") or ""
+            for token in re.split(r"[,;\s]+", raw):
+                if token and _normalize_isbn(token) == isbn:
+                    return True
+            return False
+    elif url:
+        query = url
+        def _matches(data):
+            return (data.get("url") or "").rstrip("/") == url.rstrip("/")
+    else:
+        return []
+
+    try:
+        candidates = zot.items(
+            q=query, qmode="everything", itemType="-attachment", limit=50
+        )
+    except Exception as e:
+        if ctx is not None:
+            ctx.warning(f"Existing-item search failed (treating as no match): {e}")
+        return []
+
+    matches = []
+    for item in candidates or []:
+        data = item.get("data", {})
+        if data.get("itemType") in ("attachment", "note", "annotation"):
+            continue
+        if _matches(data):
+            matches.append(item)
+    return matches
+
+
 def _collection_not_found_message(zot, spec, paths) -> str:
     """Build the error message for an unresolvable collection spec."""
     if _COLLECTION_KEY_RE.match(spec):

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -59,6 +59,110 @@ def _collections_status(coll_keys: list[str], missing: list[str]) -> str:
     return f"Filed in {coll_keys}"
 
 
+_IF_EXISTS_VALUES = ("duplicate", "file", "skip")
+
+
+def _converge_existing_item(write_zot, item, coll_keys, tags, ctx) -> dict:
+    """Additively converge an existing item to the requested state.
+
+    Adds the item to any of *coll_keys* it isn't in yet and attaches any of
+    *tags* it doesn't carry yet. Never removes anything. Returns a summary
+    dict: ``{"key", "title", "colls_added", "colls_already", "colls_failed",
+    "tags_added", "tags_failed"}``.
+    """
+    item_key = item.get("key")
+    data = item.get("data", {})
+    title = data.get("title") or "(untitled)"
+
+    current_colls = set(data.get("collections") or [])
+    to_add = [k for k in coll_keys if k not in current_colls]
+    already = [k for k in coll_keys if k in current_colls]
+
+    tag_list = _helpers._normalize_str_list_input(tags, "tags")
+    current_tags = {t.get("tag") for t in data.get("tags") or []}
+    tags_to_add = [t for t in tag_list if t not in current_tags]
+
+    tags_failed = False
+    if tags_to_add:
+        # Update tags first, on our fetched copy (current version); the
+        # collection backstop below re-fetches, so it sees the new version.
+        item["data"]["tags"] = (data.get("tags") or []) + [
+            {"tag": t} for t in tags_to_add
+        ]
+        try:
+            resp = write_zot.update_item(item)
+            tags_failed = not _helpers._handle_write_response(resp, ctx)
+        except Exception as e:
+            tags_failed = True
+            if ctx is not None:
+                ctx.warning(f"Could not add tags to {item_key}: {e}")
+
+    colls_failed = _helpers.ensure_collection_membership(
+        write_zot, item_key, to_add, ctx=ctx
+    )
+    colls_added = [k for k in to_add if k not in colls_failed]
+
+    return {
+        "key": item_key,
+        "title": title,
+        "colls_added": colls_added,
+        "colls_already": already,
+        "colls_failed": colls_failed,
+        "tags_added": [] if tags_failed else tags_to_add,
+        "tags_failed": tags_failed,
+    }
+
+
+def _handle_existing_item(write_zot, existing, coll_keys, tags, if_exists,
+                          matched_by, ctx) -> str:
+    """Render the if_exists='file'/'skip' outcome for a single-item add tool.
+
+    The report keeps the ``Item key: `KEY``` line that callers (and
+    add_from_file's key extraction) rely on.
+    """
+    item = existing[0]
+    item_key = item.get("key")
+    title = item.get("data", {}).get("title") or "(untitled)"
+
+    note = ""
+    if len(existing) > 1:
+        other = [i.get("key") for i in existing[1:]]
+        note = (
+            f"\n\nNote: {len(existing)} items match ({other} besides the one "
+            "used); consider zotero_find_duplicates / zotero_merge_duplicates."
+        )
+
+    header = (
+        f"Already in library: **{title}** (`{item_key}`, matched by {matched_by})\n\n"
+        f"Item key: `{item_key}`\n"
+    )
+
+    if if_exists == "skip":
+        return header + "No changes made (if_exists='skip')." + note
+
+    summary = _converge_existing_item(write_zot, item, coll_keys, tags, ctx)
+
+    lines = []
+    coll_bits = []
+    if summary["colls_added"]:
+        coll_bits.append(f"added to {summary['colls_added']}")
+    if summary["colls_failed"]:
+        coll_bits.append(f"FAILED to add to {summary['colls_failed']}")
+    if summary["colls_already"]:
+        coll_bits.append(f"already in {summary['colls_already']}")
+    if coll_keys:
+        lines.append("Collections: " + "; ".join(coll_bits))
+    if summary["tags_added"]:
+        lines.append(f"Tags: added {summary['tags_added']}")
+    elif summary["tags_failed"]:
+        lines.append("Tags: FAILED to update")
+
+    if not lines:
+        lines.append("Nothing to change — item already in the requested state.")
+
+    return header + "\n".join(lines) + note
+
+
 @mcp.tool(
     name="zotero_batch_update_tags",
     description=(
@@ -553,6 +657,14 @@ def manage_collections(
         "specs fail the call with suggestions instead of producing an "
         "unfiled item. "
         "tags: optional list of tag strings to attach. "
+        "if_exists: 'duplicate' (default) always creates a new item; "
+        "'file' makes the call idempotent — when an item with this DOI "
+        "already exists it is reused, filed into any missing collections "
+        "and given any missing tags (nothing is ever removed); 'skip' "
+        "leaves an existing match untouched. "
+        "create_missing_collections: when True, collection specs that "
+        "don't resolve are created (including path chains) instead of "
+        "failing. "
         "attach_mode: 'auto' (default) downloads a PDF if CrossRef links "
         "one and storage is available; 'none' skips PDF download; "
         "'required' fails if no PDF can be attached. PDF uploads may fail "
@@ -571,6 +683,8 @@ def add_by_doi(
     collections: list[str] | str | None = None,
     tags: list[str] | str | None = None,
     attach_mode: str = "auto",
+    if_exists: Literal["duplicate", "file", "skip"] = "duplicate",
+    create_missing_collections: bool = False,
     *,
     ctx: Context
 ) -> str:
@@ -580,6 +694,8 @@ def add_by_doi(
         return str(e)
 
     try:
+        if if_exists not in _IF_EXISTS_VALUES:
+            return f"Error: if_exists must be one of {_IF_EXISTS_VALUES}."
         normalized = _helpers._normalize_doi(doi)
         if not normalized:
             return f"Error: '{doi}' does not appear to be a valid DOI."
@@ -587,9 +703,20 @@ def add_by_doi(
         # Resolve collection specs (keys/names/paths) BEFORE any network or
         # write work — a bad spec must not produce an unfiled item.
         try:
-            coll_keys = _resolve_collections_arg(read_zot, collections, ctx)
+            coll_keys = _resolve_collections_arg(
+                read_zot, collections, ctx,
+                create_missing=create_missing_collections, write_zot=write_zot,
+            )
         except ValueError as e:
             return f"Error: {e}"
+
+        if if_exists != "duplicate":
+            existing = _helpers.find_existing_items(read_zot, doi=normalized, ctx=ctx)
+            if existing:
+                return _handle_existing_item(
+                    write_zot, existing, coll_keys, tags, if_exists,
+                    matched_by=f"DOI {normalized}", ctx=ctx,
+                )
 
         ctx.info(f"Fetching metadata for DOI: {normalized}")
 
@@ -751,6 +878,11 @@ def add_by_doi(
         "'/'-separated paths — resolved and validated before the item is "
         "created; unknown or ambiguous specs fail the call. "
         "tags: optional list of tag strings to attach. "
+        "if_exists: 'duplicate' (default) always creates; 'file' reuses "
+        "an existing item matching the arXiv ID / DOI / URL, filing it "
+        "into missing collections and adding missing tags; 'skip' leaves "
+        "a match untouched. create_missing_collections: create unknown "
+        "collection specs instead of failing. "
         "attach_mode: 'auto' (default) attaches a PDF if one is "
         "available; 'none' skips; 'required' fails if no PDF can be "
         "attached. PDF uploads may fail on the Zotero cloud free-tier "
@@ -771,6 +903,8 @@ def add_by_url(
     collections: list[str] | str | None = None,
     tags: list[str] | str | None = None,
     attach_mode: str = "auto",
+    if_exists: Literal["duplicate", "file", "skip"] = "duplicate",
+    create_missing_collections: bool = False,
     *,
     ctx: Context
 ) -> str:
@@ -780,6 +914,8 @@ def add_by_url(
         return str(e)
 
     try:
+        if if_exists not in _IF_EXISTS_VALUES:
+            return f"Error: if_exists must be one of {_IF_EXISTS_VALUES}."
         url = (url or "").strip()
         if not url:
             return "Error: No URL provided."
@@ -788,19 +924,34 @@ def add_by_url(
         doi = _helpers._normalize_doi(url)
         if doi:
             return add_by_doi(doi=url, collections=collections, tags=tags,
-                              attach_mode=attach_mode, ctx=ctx)
+                              attach_mode=attach_mode, if_exists=if_exists,
+                              create_missing_collections=create_missing_collections,
+                              ctx=ctx)
 
         # arXiv URL routing
         arxiv_id = _helpers._normalize_arxiv_id(url)
         if arxiv_id:
             return _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx,
-                                 attach_mode=attach_mode, read_zot=read_zot)
+                                 attach_mode=attach_mode, read_zot=read_zot,
+                                 if_exists=if_exists,
+                                 create_missing_collections=create_missing_collections)
 
         # Generic webpage
         try:
-            coll_keys = _resolve_collections_arg(read_zot, collections, ctx)
+            coll_keys = _resolve_collections_arg(
+                read_zot, collections, ctx,
+                create_missing=create_missing_collections, write_zot=write_zot,
+            )
         except ValueError as e:
             return f"Error: {e}"
+
+        if if_exists != "duplicate":
+            existing = _helpers.find_existing_items(read_zot, url=url, ctx=ctx)
+            if existing:
+                return _handle_existing_item(
+                    write_zot, existing, coll_keys, tags, if_exists,
+                    matched_by=f"URL {url}", ctx=ctx,
+                )
 
         ctx.info(f"Creating webpage item for: {url}")
         template = write_zot.item_template("webpage")
@@ -835,7 +986,8 @@ def add_by_url(
 
 @with_zotero_api_lock
 def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto",
-                  read_zot=None):
+                  read_zot=None, if_exists="duplicate",
+                  create_missing_collections=False):
     """Add an arXiv paper by ID. Internal helper for add_by_url.
 
     arXiv (export.arxiv.org) periodically sheds load — rate-limiting (429),
@@ -848,9 +1000,22 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
     both routes fail, never a bare timeout.
     """
     try:
-        coll_keys = _resolve_collections_arg(read_zot or write_zot, collections, ctx)
+        coll_keys = _resolve_collections_arg(
+            read_zot or write_zot, collections, ctx,
+            create_missing=create_missing_collections, write_zot=write_zot,
+        )
     except ValueError as e:
         return f"Error: {e}"
+
+    if if_exists != "duplicate":
+        existing = _helpers.find_existing_items(
+            read_zot or write_zot, arxiv_id=arxiv_id, ctx=ctx
+        )
+        if existing:
+            return _handle_existing_item(
+                write_zot, existing, coll_keys, tags, if_exists,
+                matched_by=f"arXiv ID {arxiv_id}", ctx=ctx,
+            )
 
     ctx.info(f"Fetching arXiv metadata for: {arxiv_id}")
 
@@ -901,6 +1066,7 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
                 collections=coll_keys,
                 tags=tags,
                 attach_mode=attach_mode,
+                if_exists=if_exists,
                 ctx=ctx,
             )
         except Exception as e:  # noqa: BLE001 — fallback must not raise
@@ -1168,13 +1334,20 @@ def _lookup_isbn_google_books(isbn, ctx):
         "Add a book to your Zotero library by ISBN. Resolves metadata via "
         "Open Library (primary) and Google Books (fallback). Accepts ISBN-10, "
         "ISBN-13, with or without hyphens, or a URL/isbn: prefix. Response "
-        "includes the resolver source so you can audit metadata quality."
+        "includes the resolver source so you can audit metadata quality. "
+        "collections accepts keys, names, or '/'-paths (validated before "
+        "create). if_exists: 'duplicate' (default) | 'file' (reuse an "
+        "existing item with this ISBN — add missing collections/tags) | "
+        "'skip'. create_missing_collections: create unknown collection "
+        "specs instead of failing."
     )
 )
 def add_by_isbn(
     isbn: str,
     collections: list[str] | str | None = None,
     tags: list[str] | str | None = None,
+    if_exists: Literal["duplicate", "file", "skip"] = "duplicate",
+    create_missing_collections: bool = False,
     *,
     ctx: Context
 ) -> str:
@@ -1184,6 +1357,8 @@ def add_by_isbn(
         return str(e)
 
     try:
+        if if_exists not in _IF_EXISTS_VALUES:
+            return f"Error: if_exists must be one of {_IF_EXISTS_VALUES}."
         normalized = _helpers._normalize_isbn(isbn)
         if not normalized:
             return (
@@ -1192,9 +1367,20 @@ def add_by_isbn(
             )
 
         try:
-            coll_keys = _resolve_collections_arg(read_zot, collections, ctx)
+            coll_keys = _resolve_collections_arg(
+                read_zot, collections, ctx,
+                create_missing=create_missing_collections, write_zot=write_zot,
+            )
         except ValueError as e:
             return f"Error: {e}"
+
+        if if_exists != "duplicate":
+            existing = _helpers.find_existing_items(read_zot, isbn=normalized, ctx=ctx)
+            if existing:
+                return _handle_existing_item(
+                    write_zot, existing, coll_keys, tags, if_exists,
+                    matched_by=f"ISBN {normalized}", ctx=ctx,
+                )
 
         ctx.info(f"Resolving ISBN {normalized} via Open Library...")
         meta = _lookup_isbn_openlibrary(normalized, ctx)
@@ -2084,6 +2270,11 @@ def get_pdf_outline(
         "'/'-separated paths to file under — resolved and validated "
         "before the item is created. "
         "tags: optional list of tag strings. "
+        "if_exists: 'duplicate' (default) | 'file' (when the extracted "
+        "DOI matches an existing item, reuse it: file into missing "
+        "collections, attach the file to it unless an attachment with "
+        "the same filename exists) | 'skip' (no item, no attachment). "
+        "create_missing_collections: create unknown collection specs. "
         "Requires a writable library (fails in local-only mode). PDF "
         "uploads may hit the 300MB Zotero cloud free-tier quota — "
         "metadata still lands. Run zotero_update_search_database "
@@ -2099,6 +2290,8 @@ def add_from_file(
     item_type: str = "document",
     collections: list[str] | str | None = None,
     tags: list[str] | str | None = None,
+    if_exists: Literal["duplicate", "file", "skip"] = "duplicate",
+    create_missing_collections: bool = False,
     *,
     ctx: Context
 ) -> str:
@@ -2108,6 +2301,8 @@ def add_from_file(
         return str(e)
 
     try:
+        if if_exists not in _IF_EXISTS_VALUES:
+            return f"Error: if_exists must be one of {_IF_EXISTS_VALUES}."
         # Path validation — check symlink BEFORE resolving
         if os.path.islink(file_path):
             return "Error: Symlinks are not allowed for security reasons."
@@ -2119,7 +2314,10 @@ def add_from_file(
             return f"Error: File not found: {file_path}"
 
         try:
-            coll_keys = _resolve_collections_arg(read_zot, collections, ctx)
+            coll_keys = _resolve_collections_arg(
+                read_zot, collections, ctx,
+                create_missing=create_missing_collections, write_zot=write_zot,
+            )
         except ValueError as e:
             return f"Error: {e}"
 
@@ -2160,10 +2358,13 @@ def add_from_file(
             except Exception as e:
                 ctx.info(f"DOI extraction failed (non-fatal): {e}")
 
-        # Create the metadata item
+        # Create the metadata item. With if_exists='file' and a known DOI,
+        # add_by_doi reuses the existing item — the attachment below then
+        # lands on it instead of on a fresh duplicate.
         if extracted_doi:
             ctx.info(f"Found DOI: {extracted_doi}")
-            result_msg = add_by_doi(doi=extracted_doi, collections=coll_keys, tags=tags, ctx=ctx)
+            result_msg = add_by_doi(doi=extracted_doi, collections=coll_keys,
+                                    tags=tags, if_exists=if_exists, ctx=ctx)
             # Extract item key from result
             key_match = re.search(r'Item key: `([^`]+)`', result_msg)
             if key_match:
@@ -2192,9 +2393,31 @@ def add_from_file(
             else:
                 return f"Failed to create item: {result}"
 
-        # Attach the file
+        item_reused = bool(extracted_doi) and result_msg.startswith("Already in library")
+        if item_reused and if_exists == "skip":
+            return result_msg + "\n\nFile NOT attached (if_exists='skip')."
+
+        # Attach the file. When reusing an existing item, skip the upload if
+        # an attachment with the same filename is already there — re-running
+        # the command must converge, not accumulate duplicate attachments.
         try:
             display_name = os.path.basename(file_path)
+            if item_reused:
+                try:
+                    kids = write_zot.children(parent_key)
+                except Exception:
+                    kids = []
+                if any(
+                    (k.get("data", {}) or {}).get("filename") == display_name
+                    for k in kids
+                ):
+                    return (
+                        f"{result_msg}\n"
+                        f"Attachment already present: {display_name} (not re-uploaded)\n\n"
+                        "_Note: To include this item in semantic search, run "
+                        "zotero_update_search_database._"
+                    )
+
             attach_result = write_zot.attachment_both(
                 [(display_name, file_path)],
                 parentid=parent_key,
@@ -2597,18 +2820,68 @@ def _create_and_attach(
             "collections_failed": collections_failed}
 
 
+def _maybe_reuse_existing(read_zot, write_zot, item_data, coll_keys, tags,
+                          if_exists, ctx) -> dict | None:
+    """Batch-import dedup: reuse an existing item matching the entry's DOI.
+
+    Returns a result dict for _format_batch_result when if_exists is
+    'file'/'skip' and a DOI match exists; otherwise None (proceed to
+    create). Entries without a DOI always create — title matching is out
+    of scope (#4).
+    """
+    if if_exists == "duplicate":
+        return None
+    doi_raw = item_data.get("DOI") or ""
+    doi = _helpers._normalize_doi(doi_raw) if doi_raw else None
+    if not doi:
+        return None
+    existing = _helpers.find_existing_items(read_zot, doi=doi, ctx=ctx)
+    if not existing:
+        return None
+
+    item = existing[0]
+    if if_exists == "skip":
+        return {
+            "ok": True, "key": item.get("key"), "doi": doi,
+            "pdf_status": None, "error": None,
+            "title": item.get("data", {}).get("title") or "(untitled)",
+            "collections_failed": [],
+            "existed": "skipped — already in library",
+        }
+
+    summary = _converge_existing_item(write_zot, item, coll_keys, tags, ctx)
+    bits = []
+    if summary["colls_added"]:
+        bits.append(f"added to {summary['colls_added']}")
+    if summary["colls_already"]:
+        bits.append(f"already in {summary['colls_already']}")
+    if summary["tags_added"]:
+        bits.append(f"tags added {summary['tags_added']}")
+    detail = "; ".join(bits) if bits else "already in requested state"
+    return {
+        "ok": True, "key": summary["key"], "doi": doi, "pdf_status": None,
+        "error": None, "title": summary["title"],
+        "collections_failed": summary["colls_failed"],
+        "existed": f"reused existing — {detail}",
+    }
+
+
 def _format_batch_result(header: str, results: list[dict]) -> str:
     """Render a per-entry markdown summary for add_by_bibtex / add_by_csl_json."""
     ok_count = sum(1 for r in results if r["ok"])
+    reused_count = sum(1 for r in results if r["ok"] and r.get("existed"))
     lines = [header, ""]
     if len(results) == 1:
         r = results[0]
         if r["ok"]:
-            lines.append(f"Successfully added: **{r['title']}**")
+            verb = "Already in library" if r.get("existed") else "Successfully added"
+            lines.append(f"{verb}: **{r['title']}**")
             lines.append("")
             lines.append(f"Item key: `{r['key']}`")
             if r["doi"]:
                 lines.append(f"DOI: {r['doi']}")
+            if r.get("existed"):
+                lines.append(f"Status: {r['existed']}")
             if r["pdf_status"]:
                 lines.append(f"PDF: {r['pdf_status']}")
             if r.get("collections_failed"):
@@ -2618,13 +2891,18 @@ def _format_batch_result(header: str, results: list[dict]) -> str:
         else:
             lines.append(f"Failed to add **{r['title']}**: {r['error']}")
     else:
-        lines.append(f"Added {ok_count}/{len(results)} items.")
+        summary_line = f"Added {ok_count - reused_count}/{len(results)} items."
+        if reused_count:
+            summary_line += f" {reused_count} already existed (reused, not duplicated)."
+        lines.append(summary_line)
         lines.append("")
         for i, r in enumerate(results, 1):
             if r["ok"]:
                 line = f"{i}. `{r['key']}` — {r['title']}"
                 if r["doi"]:
                     line += f" (DOI: {r['doi']})"
+                if r.get("existed"):
+                    line += f" [{r['existed']}]"
                 if r["pdf_status"]:
                     line += f" [{r['pdf_status']}]"
                 if r.get("collections_failed"):
@@ -2648,7 +2926,13 @@ def _format_batch_result(header: str, results: list[dict]) -> str:
         "(absolute path to a .bib / .bibtex file) — not both. "
         "Supports multiple @entries per call. "
         "The citation key from each entry is preserved in the Extra field. "
-        "If an entry has a DOI, an open-access PDF attachment is attempted."
+        "If an entry has a DOI, an open-access PDF attachment is attempted. "
+        "collections accepts keys, names, or '/'-paths (validated before "
+        "create). if_exists: 'duplicate' (default) | 'file' (entries whose "
+        "DOI already exists reuse that item — add missing collections/tags "
+        "instead of duplicating) | 'skip' (leave existing matches "
+        "untouched); entries without a DOI always create. "
+        "create_missing_collections: create unknown collection specs."
     )
 )
 def add_by_bibtex(
@@ -2657,6 +2941,8 @@ def add_by_bibtex(
     collections: list[str] | str | None = None,
     tags: list[str] | str | None = None,
     attach_mode: str = "auto",
+    if_exists: Literal["duplicate", "file", "skip"] = "duplicate",
+    create_missing_collections: bool = False,
     *,
     ctx: Context
 ) -> str:
@@ -2666,6 +2952,8 @@ def add_by_bibtex(
         return str(e)
 
     try:
+        if if_exists not in _IF_EXISTS_VALUES:
+            return f"Error: if_exists must be one of {_IF_EXISTS_VALUES}."
         bibtex_provided = bool((bibtex or "").strip())
         if bibtex_provided and file_path:
             return "Error: Provide either `bibtex` or `file_path`, not both."
@@ -2690,7 +2978,10 @@ def add_by_bibtex(
             return "Error: No valid @entries found in the BibTeX input."
 
         try:
-            coll_keys = _resolve_collections_arg(_read_zot, collections, ctx)
+            coll_keys = _resolve_collections_arg(
+                _read_zot, collections, ctx,
+                create_missing=create_missing_collections, write_zot=write_zot,
+            )
         except ValueError as e:
             return f"Error: {e}"
 
@@ -2710,6 +3001,13 @@ def add_by_bibtex(
                 })
                 continue
 
+            reused = _maybe_reuse_existing(
+                _read_zot, write_zot, item_data, coll_keys, tags, if_exists, ctx
+            )
+            if reused is not None:
+                results.append(reused)
+                continue
+
             _apply_caller_tags_and_collections(item_data, tags, coll_keys)
             results.append(_create_and_attach(write_zot, item_data, attach_mode, ctx))
 
@@ -2727,7 +3025,12 @@ def add_by_bibtex(
         "Provide EITHER `csl_json` (inline — a JSON string, object, or array) "
         "OR `file_path` (absolute path to a .json / .csljson file) — not both. "
         "The `id` field is preserved in the Extra field as the Citation Key. "
-        "If an entry has a DOI, an open-access PDF attachment is attempted."
+        "If an entry has a DOI, an open-access PDF attachment is attempted. "
+        "collections accepts keys, names, or '/'-paths (validated before "
+        "create). if_exists: 'duplicate' (default) | 'file' (entries whose "
+        "DOI already exists reuse that item — add missing collections/tags) "
+        "| 'skip'; entries without a DOI always create. "
+        "create_missing_collections: create unknown collection specs."
     )
 )
 def add_by_csl_json(
@@ -2736,6 +3039,8 @@ def add_by_csl_json(
     collections: list[str] | str | None = None,
     tags: list[str] | str | None = None,
     attach_mode: str = "auto",
+    if_exists: Literal["duplicate", "file", "skip"] = "duplicate",
+    create_missing_collections: bool = False,
     *,
     ctx: Context
 ) -> str:
@@ -2745,6 +3050,8 @@ def add_by_csl_json(
         return str(e)
 
     try:
+        if if_exists not in _IF_EXISTS_VALUES:
+            return f"Error: if_exists must be one of {_IF_EXISTS_VALUES}."
         csl_provided = csl_json not in (None, "", [], {})
         if csl_provided and file_path:
             return "Error: Provide either `csl_json` or `file_path`, not both."
@@ -2769,7 +3076,10 @@ def add_by_csl_json(
             return "Error: No valid CSL JSON objects provided."
 
         try:
-            coll_keys = _resolve_collections_arg(_read_zot, collections, ctx)
+            coll_keys = _resolve_collections_arg(
+                _read_zot, collections, ctx,
+                create_missing=create_missing_collections, write_zot=write_zot,
+            )
         except ValueError as e:
             return f"Error: {e}"
 
@@ -2787,6 +3097,13 @@ def add_by_csl_json(
                     "error": f"conversion failed: {e}",
                     "title": str(entry.get("id") or entry.get("title") or "(unknown)"),
                 })
+                continue
+
+            reused = _maybe_reuse_existing(
+                _read_zot, write_zot, item_data, coll_keys, tags, if_exists, ctx
+            )
+            if reused is not None:
+                results.append(reused)
                 continue
 
             _apply_caller_tags_and_collections(item_data, tags, coll_keys)

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -23,6 +23,42 @@ from zotero_mcp.tools import _helpers
 CROSSREF_TYPE_MAP = _helpers.CROSSREF_TYPE_MAP
 
 
+def _resolve_collections_arg(
+    read_zot,
+    collections,
+    ctx,
+    *,
+    create_missing: bool = False,
+    write_zot=None,
+) -> list[str]:
+    """Normalize the caller's ``collections`` argument and resolve every spec
+    (key, name, or '/'-path) to a live collection key.
+
+    Raises ValueError with a user-facing message on unknown or ambiguous
+    specs — callers should fail the add *before* creating an item, so a typo
+    can't produce an unfiled or invisibly-filed item.
+    """
+    specs = _helpers._normalize_str_list_input(collections, "collections")
+    if not specs:
+        return []
+    return _helpers.resolve_collection_specs(
+        read_zot, specs,
+        create_missing=create_missing, write_zot=write_zot, ctx=ctx,
+    )
+
+
+def _collections_status(coll_keys: list[str], missing: list[str]) -> str:
+    """Render the post-create collection-membership state for tool output."""
+    if not coll_keys:
+        return "My Library (no collection)"
+    if missing:
+        return (
+            f"Filed in {sorted(set(coll_keys) - set(missing))}; "
+            f"FAILED to file in {missing}"
+        )
+    return f"Filed in {coll_keys}"
+
+
 @mcp.tool(
     name="zotero_batch_update_tags",
     description=(
@@ -416,7 +452,9 @@ def search_collections(
     description=(
         "Add or remove one or more items from collections. "
         "item_keys must be an ARRAY of item keys, e.g. [\"KEY1\", \"KEY2\"] — not a single string. "
-        "add_to and remove_from also accept arrays of collection keys. "
+        "add_to and remove_from accept arrays of collection keys, names, or "
+        "'/'-separated paths (resolved and validated automatically; unknown, "
+        "trashed, or ambiguous specs fail before anything is changed). "
         "Use zotero_search_items to find item keys and zotero_search_collections to find collection keys."
     )
 )
@@ -435,37 +473,28 @@ def manage_collections(
 
     try:
         keys = _helpers._normalize_str_list_input(item_keys, "item_keys")
-        add_colls = _helpers._normalize_str_list_input(add_to, "add_to")
-        remove_colls = _helpers._normalize_str_list_input(remove_from, "remove_from")
+        add_specs = _helpers._normalize_str_list_input(add_to, "add_to")
+        remove_specs = _helpers._normalize_str_list_input(remove_from, "remove_from")
 
         if not keys:
             return "Error: No item keys provided."
-        if not add_colls and not remove_colls:
+        if not add_specs and not remove_specs:
             return "Error: Must specify add_to and/or remove_from."
 
-        # Validate collection keys before doing any work — Zotero will happily
-        # accept add/remove against a trashed collection, leaving items
-        # parented under an invisible bucket so the caller sees "success" but
-        # nothing renders in the desktop client (#233).
-        validation_errors: list[str] = []
-        for coll_key in list(add_colls) + list(remove_colls):
-            trashed = _helpers.is_collection_trashed(write_zot, coll_key)
-            if trashed is None:
-                validation_errors.append(
-                    f"Collection '{coll_key}' was not found in the active "
-                    f"library. Use zotero_search_collections (with "
-                    f"include_trashed=True if needed) to find a valid key."
-                )
-            elif trashed:
-                validation_errors.append(
-                    f"Collection '{coll_key}' is in the Trash. Restore it "
-                    f"in Zotero (or create a new collection) before adding "
-                    f"or removing items — the underlying API will accept "
-                    f"the call but the change won't be visible in the "
-                    f"normal collection tree."
-                )
-        if validation_errors:
-            return "Error:\n" + "\n".join(validation_errors)
+        # Resolve specs (keys, names, or '/'-paths) to live collection keys
+        # before doing any work. Resolution also validates existence — Zotero
+        # will happily accept add/remove against a trashed collection, leaving
+        # items parented under an invisible bucket so the caller sees
+        # "success" but nothing renders in the desktop client (#233).
+        try:
+            add_colls = _helpers.resolve_collection_specs(
+                read_zot, add_specs, ctx=ctx
+            )
+            remove_colls = _helpers.resolve_collection_specs(
+                read_zot, remove_specs, ctx=ctx
+            )
+        except ValueError as e:
+            return f"Error: {e}"
 
         results = []
 
@@ -518,9 +547,11 @@ def manage_collections(
         "zotero_add_from_file. "
         "doi: the DOI string (with or without the '10.' prefix, with or "
         "without a leading 'https://doi.org/'). "
-        "collections: optional list of 8-character collection keys (or "
-        "collection names — resolved automatically) to file the item "
-        "under. "
+        "collections: optional list of collection keys, names, or "
+        "'/'-separated paths (e.g. '_project/topic') — resolved and "
+        "validated before the item is created; unknown or ambiguous "
+        "specs fail the call with suggestions instead of producing an "
+        "unfiled item. "
         "tags: optional list of tag strings to attach. "
         "attach_mode: 'auto' (default) downloads a PDF if CrossRef links "
         "one and storage is available; 'none' skips PDF download; "
@@ -552,6 +583,13 @@ def add_by_doi(
         normalized = _helpers._normalize_doi(doi)
         if not normalized:
             return f"Error: '{doi}' does not appear to be a valid DOI."
+
+        # Resolve collection specs (keys/names/paths) BEFORE any network or
+        # write work — a bad spec must not produce an unfiled item.
+        try:
+            coll_keys = _resolve_collections_arg(read_zot, collections, ctx)
+        except ValueError as e:
+            return f"Error: {e}"
 
         ctx.info(f"Fetching metadata for DOI: {normalized}")
 
@@ -653,8 +691,7 @@ def add_by_doi(
         if tag_list:
             item_data["tags"] = [{"tag": t} for t in tag_list]
 
-        # Collections
-        coll_keys = _helpers._normalize_str_list_input(collections, "collections")
+        # Collections (resolved to live keys above, before the CrossRef fetch)
         if coll_keys:
             item_data["collections"] = coll_keys
 
@@ -671,15 +708,7 @@ def add_by_doi(
             missing = _helpers.ensure_collection_membership(
                 write_zot, item_key, coll_keys, ctx=ctx
             )
-            if coll_keys and missing:
-                collections_status = (
-                    f"Filed in {sorted(set(coll_keys) - set(missing))}; "
-                    f"FAILED to file in {missing}"
-                )
-            elif coll_keys:
-                collections_status = f"Filed in {coll_keys}"
-            else:
-                collections_status = "My Library (no collection)"
+            collections_status = _collections_status(coll_keys, missing)
 
             # Attempt open-access PDF attachment (pass CrossRef metadata for arXiv fallback)
             pdf_status = _helpers._try_attach_oa_pdf(write_zot, item_key, normalized, ctx,
@@ -718,8 +747,9 @@ def add_by_doi(
         "the routing and is more robust. For a local file use "
         "zotero_add_from_file. "
         "url: the URL to import. "
-        "collections: optional list of 8-character collection keys (or "
-        "names) to file the item under. "
+        "collections: optional list of collection keys, names, or "
+        "'/'-separated paths — resolved and validated before the item is "
+        "created; unknown or ambiguous specs fail the call. "
         "tags: optional list of tag strings to attach. "
         "attach_mode: 'auto' (default) attaches a PDF if one is "
         "available; 'none' skips; 'required' fails if no PDF can be "
@@ -764,9 +794,14 @@ def add_by_url(
         arxiv_id = _helpers._normalize_arxiv_id(url)
         if arxiv_id:
             return _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx,
-                                 attach_mode=attach_mode)
+                                 attach_mode=attach_mode, read_zot=read_zot)
 
         # Generic webpage
+        try:
+            coll_keys = _resolve_collections_arg(read_zot, collections, ctx)
+        except ValueError as e:
+            return f"Error: {e}"
+
         ctx.info(f"Creating webpage item for: {url}")
         template = write_zot.item_template("webpage")
         template["url"] = url
@@ -776,15 +811,18 @@ def add_by_url(
         tag_list = _helpers._normalize_str_list_input(tags, "tags")
         if tag_list:
             template["tags"] = [{"tag": t} for t in tag_list]
-        coll_keys = _helpers._normalize_str_list_input(collections, "collections")
         if coll_keys:
             template["collections"] = coll_keys
 
         result = write_zot.create_items([template])
         if isinstance(result, dict) and result.get("success"):
             item_key = next(iter(result["success"].values()))
+            missing = _helpers.ensure_collection_membership(
+                write_zot, item_key, coll_keys, ctx=ctx
+            )
             return (
-                f"Created webpage item for: {url}\n\nItem key: `{item_key}`\n\n"
+                f"Created webpage item for: {url}\n\nItem key: `{item_key}`\n"
+                f"Collections: {_collections_status(coll_keys, missing)}\n\n"
                 "_Note: To include this item in semantic search, run "
                 "zotero_update_search_database._"
             )
@@ -796,7 +834,8 @@ def add_by_url(
 
 
 @with_zotero_api_lock
-def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto"):
+def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto",
+                  read_zot=None):
     """Add an arXiv paper by ID. Internal helper for add_by_url.
 
     arXiv (export.arxiv.org) periodically sheds load — rate-limiting (429),
@@ -808,6 +847,11 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
     very recent preprint — so a clear, actionable message is returned when
     both routes fail, never a bare timeout.
     """
+    try:
+        coll_keys = _resolve_collections_arg(read_zot or write_zot, collections, ctx)
+    except ValueError as e:
+        return f"Error: {e}"
+
     ctx.info(f"Fetching arXiv metadata for: {arxiv_id}")
 
     resp = None
@@ -854,7 +898,7 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
         try:
             result = add_by_doi(
                 doi=arxiv_doi,
-                collections=collections,
+                collections=coll_keys,
                 tags=tags,
                 attach_mode=attach_mode,
                 ctx=ctx,
@@ -923,13 +967,15 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
     tag_list = _helpers._normalize_str_list_input(tags, "tags")
     if tag_list:
         template["tags"] = [{"tag": t} for t in tag_list]
-    coll_keys = _helpers._normalize_str_list_input(collections, "collections")
     if coll_keys:
         template["collections"] = coll_keys
 
     result = write_zot.create_items([template])
     if isinstance(result, dict) and result.get("success"):
         item_key = next(iter(result["success"].values()))
+        missing = _helpers.ensure_collection_membership(
+            write_zot, item_key, coll_keys, ctx=ctx
+        )
 
         # arXiv always has a free PDF — try to attach it
         pdf_url = f"https://arxiv.org/pdf/{arxiv_id}.pdf"
@@ -980,6 +1026,7 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
             f"Successfully added arXiv paper: **{title}**\n\n"
             f"Item key: `{item_key}`\n"
             f"arXiv ID: {arxiv_id}\n"
+            f"Collections: {_collections_status(coll_keys, missing)}\n"
             f"PDF: {pdf_status}\n\n"
             "_Note: To include this item in semantic search, run "
             "zotero_update_search_database._"
@@ -1144,6 +1191,11 @@ def add_by_isbn(
                 "(checksum failed or wrong length)."
             )
 
+        try:
+            coll_keys = _resolve_collections_arg(read_zot, collections, ctx)
+        except ValueError as e:
+            return f"Error: {e}"
+
         ctx.info(f"Resolving ISBN {normalized} via Open Library...")
         meta = _lookup_isbn_openlibrary(normalized, ctx)
         if not meta:
@@ -1177,18 +1229,21 @@ def add_by_isbn(
         tag_list = _helpers._normalize_str_list_input(tags, "tags")
         if tag_list:
             item_data["tags"] = [{"tag": t} for t in tag_list]
-        coll_keys = _helpers._normalize_str_list_input(collections, "collections")
         if coll_keys:
             item_data["collections"] = coll_keys
 
         result = write_zot.create_items([item_data])
         if isinstance(result, dict) and result.get("success"):
             item_key = next(iter(result["success"].values()))
+            missing = _helpers.ensure_collection_membership(
+                write_zot, item_key, coll_keys, ctx=ctx
+            )
             return (
                 f"Successfully added: **{item_data.get('title', normalized)}**\n\n"
                 f"Item key: `{item_key}`\n"
                 f"Type: book\n"
                 f"ISBN: {normalized}\n"
+                f"Collections: {_collections_status(coll_keys, missing)}\n"
                 f"Source: {meta['source']}\n\n"
                 "_Note: Open Library and Google Books metadata can be noisy "
                 "(publisher-as-author, concatenated places, off-by-one dates). "
@@ -2025,7 +2080,9 @@ def get_pdf_outline(
         "file_path: ABSOLUTE path to a .pdf or .epub file (relative "
         "paths fail). Other extensions are rejected. "
         "title: optional override if metadata extraction misses. "
-        "collections: optional list of 8-char keys/names to file under. "
+        "collections: optional list of collection keys, names, or "
+        "'/'-separated paths to file under — resolved and validated "
+        "before the item is created. "
         "tags: optional list of tag strings. "
         "Requires a writable library (fails in local-only mode). PDF "
         "uploads may hit the 300MB Zotero cloud free-tier quota — "
@@ -2060,6 +2117,11 @@ def add_from_file(
         file_path = os.path.realpath(file_path)
         if not os.path.isfile(file_path):
             return f"Error: File not found: {file_path}"
+
+        try:
+            coll_keys = _resolve_collections_arg(read_zot, collections, ctx)
+        except ValueError as e:
+            return f"Error: {e}"
 
         ext = os.path.splitext(file_path)[1].lower()
         allowed_exts = {".pdf", ".epub", ".djvu", ".doc", ".docx", ".odt", ".rtf"}
@@ -2101,7 +2163,7 @@ def add_from_file(
         # Create the metadata item
         if extracted_doi:
             ctx.info(f"Found DOI: {extracted_doi}")
-            result_msg = add_by_doi(doi=extracted_doi, collections=collections, tags=tags, ctx=ctx)
+            result_msg = add_by_doi(doi=extracted_doi, collections=coll_keys, tags=tags, ctx=ctx)
             # Extract item key from result
             key_match = re.search(r'Item key: `([^`]+)`', result_msg)
             if key_match:
@@ -2116,13 +2178,17 @@ def add_from_file(
             tag_list = _helpers._normalize_str_list_input(tags, "tags")
             if tag_list:
                 template["tags"] = [{"tag": t} for t in tag_list]
-            coll_keys = _helpers._normalize_str_list_input(collections, "collections")
             if coll_keys:
                 template["collections"] = coll_keys
 
             result = write_zot.create_items([template])
             if isinstance(result, dict) and result.get("success"):
                 parent_key = next(iter(result["success"].values()))
+                missing = _helpers.ensure_collection_membership(
+                    write_zot, parent_key, coll_keys, ctx=ctx
+                )
+                if missing:
+                    ctx.warning(f"Failed to file {parent_key} in {missing}")
             else:
                 return f"Failed to create item: {result}"
 
@@ -2492,20 +2558,28 @@ def _create_and_attach(
     """Create one Zotero item and, if it has a DOI, try to attach an OA PDF.
 
     Returns a dict ``{"ok": bool, "key": str|None, "doi": str|None,
-    "pdf_status": str|None, "error": str|None, "title": str}``.
+    "pdf_status": str|None, "error": str|None, "title": str,
+    "collections_failed": list[str]}``.
     """
     title = item_data.get("title") or "(untitled)"
     try:
         result = write_zot.create_items([item_data])
     except Exception as e:
         return {"ok": False, "key": None, "doi": None, "pdf_status": None,
-                "error": str(e), "title": title}
+                "error": str(e), "title": title, "collections_failed": []}
 
     if not (isinstance(result, dict) and result.get("success")):
         return {"ok": False, "key": None, "doi": None, "pdf_status": None,
-                "error": f"create_items failed: {result}", "title": title}
+                "error": f"create_items failed: {result}", "title": title,
+                "collections_failed": []}
 
     item_key = next(iter(result["success"].values()))
+
+    # #235 backstop: atomic filing via item["collections"] is intermittent.
+    collections_failed = _helpers.ensure_collection_membership(
+        write_zot, item_key, item_data.get("collections") or [], ctx=ctx
+    )
+
     doi_raw = item_data.get("DOI") or ""
     doi = _helpers._normalize_doi(doi_raw) if doi_raw else None
 
@@ -2519,7 +2593,8 @@ def _create_and_attach(
             pdf_status = f"OA PDF attach failed: {e}"
 
     return {"ok": True, "key": item_key, "doi": doi, "pdf_status": pdf_status,
-            "error": None, "title": title}
+            "error": None, "title": title,
+            "collections_failed": collections_failed}
 
 
 def _format_batch_result(header: str, results: list[dict]) -> str:
@@ -2536,6 +2611,10 @@ def _format_batch_result(header: str, results: list[dict]) -> str:
                 lines.append(f"DOI: {r['doi']}")
             if r["pdf_status"]:
                 lines.append(f"PDF: {r['pdf_status']}")
+            if r.get("collections_failed"):
+                lines.append(
+                    f"WARNING: failed to file in {r['collections_failed']}"
+                )
         else:
             lines.append(f"Failed to add **{r['title']}**: {r['error']}")
     else:
@@ -2548,6 +2627,8 @@ def _format_batch_result(header: str, results: list[dict]) -> str:
                     line += f" (DOI: {r['doi']})"
                 if r["pdf_status"]:
                     line += f" [{r['pdf_status']}]"
+                if r.get("collections_failed"):
+                    line += f" [failed to file in {r['collections_failed']}]"
                 lines.append(line)
             else:
                 lines.append(f"{i}. ❌ {r['title']}: {r['error']}")
@@ -2608,6 +2689,11 @@ def add_by_bibtex(
         if not entries:
             return "Error: No valid @entries found in the BibTeX input."
 
+        try:
+            coll_keys = _resolve_collections_arg(_read_zot, collections, ctx)
+        except ValueError as e:
+            return f"Error: {e}"
+
         ctx.info(f"Parsed {len(entries)} BibTeX entries")
 
         results = []
@@ -2624,7 +2710,7 @@ def add_by_bibtex(
                 })
                 continue
 
-            _apply_caller_tags_and_collections(item_data, tags, collections)
+            _apply_caller_tags_and_collections(item_data, tags, coll_keys)
             results.append(_create_and_attach(write_zot, item_data, attach_mode, ctx))
 
         return _format_batch_result("# zotero_add_by_bibtex", results)
@@ -2682,6 +2768,11 @@ def add_by_csl_json(
         if not entries:
             return "Error: No valid CSL JSON objects provided."
 
+        try:
+            coll_keys = _resolve_collections_arg(_read_zot, collections, ctx)
+        except ValueError as e:
+            return f"Error: {e}"
+
         ctx.info(f"Processing {len(entries)} CSL JSON entries")
 
         results = []
@@ -2698,7 +2789,7 @@ def add_by_csl_json(
                 })
                 continue
 
-            _apply_caller_tags_and_collections(item_data, tags, collections)
+            _apply_caller_tags_and_collections(item_data, tags, coll_keys)
             results.append(_create_and_attach(write_zot, item_data, attach_mode, ctx))
 
         return _format_batch_result("# zotero_add_by_csl_json", results)

--- a/tests/test_add_by_bibtex.py
+++ b/tests/test_add_by_bibtex.py
@@ -117,16 +117,37 @@ class TestTagsAndCollections:
 
     def test_collections_applied(self, monkeypatch, dummy_ctx):
         fake = _patch_hybrid(monkeypatch)
+        fake._collections = [
+            {"key": "COL00001", "data": {"name": "One", "parentCollection": False}},
+            {"key": "COL00002", "data": {"name": "Two", "parentCollection": False}},
+        ]
         _disable_oa_pdf(monkeypatch)
 
         bib = "@article{x, title={T}, author={A, B}, year={2020}}"
         server.add_by_bibtex(
             bibtex=bib,
-            collections=["COL001", "COL002"],
+            collections=["COL00001", "COL00002"],
             ctx=dummy_ctx,
         )
 
-        assert fake.created[0]["collections"] == ["COL001", "COL002"]
+        assert fake.created[0]["collections"] == ["COL00001", "COL00002"]
+
+    def test_collection_names_resolved(self, monkeypatch, dummy_ctx):
+        """Collection names resolve to keys once, before the entry loop."""
+        fake = _patch_hybrid(monkeypatch)
+        fake._collections = [
+            {"key": "COL00001", "data": {"name": "Reading List", "parentCollection": False}},
+        ]
+        _disable_oa_pdf(monkeypatch)
+
+        bib = "@article{x, title={T}, author={A, B}, year={2020}}"
+        server.add_by_bibtex(
+            bibtex=bib,
+            collections=["reading list"],
+            ctx=dummy_ctx,
+        )
+
+        assert fake.created[0]["collections"] == ["COL00001"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_add_by_csl_json.py
+++ b/tests/test_add_by_csl_json.py
@@ -125,15 +125,18 @@ class TestTagsAndCollections:
 
     def test_collections_applied(self, monkeypatch, dummy_ctx):
         fake = _patch_hybrid(monkeypatch)
+        fake._collections = [
+            {"key": "COL00001", "data": {"name": "One", "parentCollection": False}},
+        ]
         _disable_oa_pdf(monkeypatch)
 
         server.add_by_csl_json(
             csl_json=SAMPLE_ARTICLE,
-            collections=["COL001"],
+            collections=["COL00001"],
             ctx=dummy_ctx,
         )
 
-        assert fake.created[0]["collections"] == ["COL001"]
+        assert fake.created[0]["collections"] == ["COL00001"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_add_by_doi.py
+++ b/tests/test_add_by_doi.py
@@ -459,6 +459,9 @@ class TestTagsAndCollections:
     def test_collections_applied(
         self, monkeypatch, fake_zot, dummy_ctx
     ):
+        fake_zot._collections = [
+            {"key": "ABCD1234", "data": {"name": "Climate", "parentCollection": False}},
+        ]
         monkeypatch.setattr(
             "zotero_mcp.tools._helpers._get_write_client", lambda ctx: (fake_zot, fake_zot)
         )
@@ -474,6 +477,49 @@ class TestTagsAndCollections:
         item = fake_zot.created[0]
 
         assert "ABCD1234" in item["collections"]
+
+    def test_collection_name_resolved_to_key(
+        self, monkeypatch, fake_zot, dummy_ctx
+    ):
+        """A collection NAME resolves to its key before the item is created."""
+        fake_zot._collections = [
+            {"key": "ABCD1234", "data": {"name": "Climate", "parentCollection": False}},
+        ]
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client", lambda ctx: (fake_zot, fake_zot)
+        )
+        monkeypatch.setattr(
+            "requests.get", lambda *a, **kw: _make_crossref_response()
+        )
+
+        server.add_by_doi(
+            doi="10.1234/test.2024.001",
+            collections=["climate"],
+            ctx=dummy_ctx,
+        )
+        item = fake_zot.created[0]
+
+        assert item["collections"] == ["ABCD1234"]
+
+    def test_unknown_collection_fails_before_create(
+        self, monkeypatch, fake_zot, dummy_ctx
+    ):
+        """A bad collection spec must fail the add BEFORE any item is created."""
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client", lambda ctx: (fake_zot, fake_zot)
+        )
+        monkeypatch.setattr(
+            "requests.get", lambda *a, **kw: _make_crossref_response()
+        )
+
+        result = server.add_by_doi(
+            doi="10.1234/test.2024.001",
+            collections=["no-such-collection"],
+            ctx=dummy_ctx,
+        )
+
+        assert "not found" in result
+        assert fake_zot.created == []
 
     def test_no_tags_or_collections(
         self, monkeypatch, fake_zot, dummy_ctx

--- a/tests/test_add_by_isbn.py
+++ b/tests/test_add_by_isbn.py
@@ -281,6 +281,9 @@ class TestAddByIsbnEndToEnd:
 
     def test_tags_and_collections_applied(self, monkeypatch):
         fake = FakeZotero()
+        fake._collections = [
+            {"key": "COLL0001", "data": {"name": "Books", "parentCollection": False}},
+        ]
         monkeypatch.setattr(
             "zotero_mcp.tools._helpers._get_write_client",
             lambda ctx: (fake, fake),

--- a/tests/test_add_by_url.py
+++ b/tests/test_add_by_url.py
@@ -344,6 +344,10 @@ class TestArxivCrossrefFallback:
         """arXiv timeout → delegate to add_by_doi with the arXiv DOI; surface its result."""
         import requests as req_lib
 
+        fake_zot = patch_write_client
+        fake_zot._collections = [
+            {"key": "ABC12345", "data": {"name": "Preprints", "parentCollection": False}},
+        ]
         with patch("zotero_mcp.tools.write._time.sleep"), patch(
             "zotero_mcp.tools.write.requests.get",
             side_effect=req_lib.exceptions.Timeout("timed out"),
@@ -358,7 +362,8 @@ class TestArxivCrossrefFallback:
                 ctx=dummy_ctx,
             )
 
-        # Fallback fired with the arXiv DOI and forwarded collections/tags.
+        # Fallback fired with the arXiv DOI and forwarded the resolved
+        # collection keys and tags.
         mock_doi.assert_called_once()
         kwargs = mock_doi.call_args.kwargs
         assert kwargs.get("doi") == "10.48550/arXiv.2401.00001"
@@ -584,6 +589,9 @@ class TestTagsAndCollections:
     def test_collections_applied(self, dummy_ctx, patch_write_client):
         """Collections parameter should set the item's collections field."""
         fake_zot = patch_write_client
+        fake_zot._collections = [
+            {"key": "ABC12345", "data": {"name": "Preprints", "parentCollection": False}},
+        ]
         mock_resp = _make_arxiv_response(ARXIV_ATOM_XML)
 
         with patch("zotero_mcp.tools.write.requests.get", return_value=mock_resp):
@@ -597,9 +605,9 @@ class TestTagsAndCollections:
         assert "ABC12345" in item.get("collections", [])
 
     def test_collection_names_resolved(self, dummy_ctx, patch_write_client):
-        """Collection names passed as collections are used as-is (keys or names).
-        The arXiv flow passes them through _normalize_str_list_input, not
-        _resolve_collection_names, so names appear directly in collections."""
+        """Collection NAMES resolve to keys before the item is created —
+        the arXiv flow goes through resolve_collection_specs like every
+        other add path."""
         fake_zot = patch_write_client
         fake_zot._collections = [
             {"key": "COLL0001", "data": {"name": "My Papers"}},
@@ -615,8 +623,7 @@ class TestTagsAndCollections:
             )
 
         item = fake_zot.created[0]
-        # The name is passed through _normalize_str_list_input (not resolved to key)
-        assert "My Papers" in item.get("collections", [])
+        assert item.get("collections") == ["COLL0001"]
 
     def test_no_tags_or_collections(self, dummy_ctx, patch_write_client):
         """Omitting tags and collections should still create the item."""

--- a/tests/test_add_from_file.py
+++ b/tests/test_add_from_file.py
@@ -192,7 +192,7 @@ class TestDoiFromMetadata:
         # Mock the add_by_doi function to verify delegation
         doi_called_with = {}
 
-        def mock_add_by_doi(doi, collections=None, tags=None, *, ctx):
+        def mock_add_by_doi(doi, collections=None, tags=None, if_exists="duplicate", *, ctx):
             doi_called_with["doi"] = doi
             doi_called_with["collections"] = collections
             doi_called_with["tags"] = tags
@@ -229,7 +229,7 @@ class TestDoiFromMetadata:
 
         doi_captured = {}
 
-        def mock_add_by_doi(doi, collections=None, tags=None, *, ctx):
+        def mock_add_by_doi(doi, collections=None, tags=None, if_exists="duplicate", *, ctx):
             doi_captured["doi"] = doi
             return "Added by DOI: Item key: `KEY0001`"
 
@@ -270,7 +270,7 @@ class TestDoiFromFirstPageText:
 
         doi_captured = {}
 
-        def mock_add_by_doi(doi, collections=None, tags=None, *, ctx):
+        def mock_add_by_doi(doi, collections=None, tags=None, if_exists="duplicate", *, ctx):
             doi_captured["doi"] = doi
             return "Added by DOI"
 
@@ -302,7 +302,7 @@ class TestDoiFromFirstPageText:
         # add_by_doi should NOT be called
         add_by_doi_called = False
 
-        def mock_add_by_doi(doi, collections=None, tags=None, *, ctx):
+        def mock_add_by_doi(doi, collections=None, tags=None, if_exists="duplicate", *, ctx):
             nonlocal add_by_doi_called
             add_by_doi_called = True
             return "should not happen"

--- a/tests/test_add_from_file.py
+++ b/tests/test_add_from_file.py
@@ -177,7 +177,11 @@ class TestDoiFromMetadata:
     def test_doi_in_subject_field(self, monkeypatch, dummy_ctx):
         fake_zot = FakeZoteroForFile()
         _patch_path_valid(monkeypatch)
-        _patch_hybrid_mode(monkeypatch, fake_zot)
+        read_zot = _patch_hybrid_mode(monkeypatch, fake_zot)
+        # Collection specs resolve against the READ client.
+        read_zot._collections = [
+            {"key": "COL00001", "data": {"name": "One", "parentCollection": False}},
+        ]
 
         fake_doc = FakeFitzDocument(
             metadata={"subject": "doi: 10.1234/test.2024.001", "keywords": ""},
@@ -200,13 +204,14 @@ class TestDoiFromMetadata:
             file_path="/Users/test/Documents/paper.pdf",
             title=None,
             item_type="document",
-            collections=["COL001"],
+            collections=["COL00001"],
             tags=["tag1"],
             ctx=dummy_ctx,
         )
 
         assert doi_called_with["doi"] == "10.1234/test.2024.001"
-        assert doi_called_with["collections"] == ["COL001"]
+        # add_from_file resolves specs itself and delegates resolved KEYS.
+        assert doi_called_with["collections"] == ["COL00001"]
         assert doi_called_with["tags"] == ["tag1"]
 
     def test_doi_in_keywords_field(self, monkeypatch, dummy_ctx):
@@ -599,7 +604,11 @@ class TestTagsAndCollections:
     def test_collections_applied_to_created_item(self, monkeypatch, dummy_ctx):
         fake_zot = FakeZoteroForFile()
         _patch_path_valid(monkeypatch)
-        _patch_hybrid_mode(monkeypatch, fake_zot)
+        read_zot = _patch_hybrid_mode(monkeypatch, fake_zot)
+        read_zot._collections = [
+            {"key": "COLKEY01", "data": {"name": "One", "parentCollection": False}},
+            {"key": "COLKEY02", "data": {"name": "Two", "parentCollection": False}},
+        ]
 
         fake_doc = FakeFitzDocument(metadata={}, first_page_text="No DOI here.")
         _patch_fitz(monkeypatch, fake_doc)
@@ -621,7 +630,10 @@ class TestTagsAndCollections:
     def test_tags_and_collections_together(self, monkeypatch, dummy_ctx):
         fake_zot = FakeZoteroForFile()
         _patch_path_valid(monkeypatch)
-        _patch_hybrid_mode(monkeypatch, fake_zot)
+        read_zot = _patch_hybrid_mode(monkeypatch, fake_zot)
+        read_zot._collections = [
+            {"key": "COL00001", "data": {"name": "One", "parentCollection": False}},
+        ]
 
         fake_doc = FakeFitzDocument(metadata={}, first_page_text="No DOI.")
         _patch_fitz(monkeypatch, fake_doc)
@@ -630,13 +642,13 @@ class TestTagsAndCollections:
             file_path="/Users/test/Documents/paper.pdf",
             title="Both",
             item_type="document",
-            collections=["COL001"],
+            collections=["COL00001"],
             tags=["tag1"],
             ctx=dummy_ctx,
         )
 
         created_item = fake_zot.created[0]
-        assert "COL001" in created_item.get("collections", [])
+        assert "COL00001" in created_item.get("collections", [])
         assert {"tag": "tag1"} in created_item.get("tags", [])
 
     def test_tags_passed_as_comma_string(self, monkeypatch, dummy_ctx):

--- a/tests/test_cli_standalone.py
+++ b/tests/test_cli_standalone.py
@@ -153,6 +153,40 @@ class TestParser:
                 "add", "file", "--filepath", "/tmp/x.pdf", "--parent-key", "ABC12345",
             ])
 
+    def test_add_doi_if_exists_defaults_to_file(self):
+        args = self.parser.parse_args(["add", "doi", "10.1234/x"])
+        assert args.if_exists == "file"
+        assert args.create_collections is False
+        assert args.collection is None
+
+    def test_add_doi_if_exists_choices(self):
+        args = self.parser.parse_args(
+            ["add", "doi", "10.1234/x", "--if-exists", "duplicate"]
+        )
+        assert args.if_exists == "duplicate"
+        with pytest.raises(SystemExit):
+            self.parser.parse_args(["add", "doi", "10.1234/x", "--if-exists", "bogus"])
+
+    def test_add_doi_repeatable_collection_flag(self):
+        args = self.parser.parse_args([
+            "add", "doi", "10.1234/x",
+            "-c", "Reading List", "-c", "_project/topic",
+            "--collections", "KEY00001",
+            "--create-collections",
+        ])
+        assert args.collection == ["Reading List", "_project/topic"]
+        assert args.collections == "KEY00001"
+        assert args.create_collections is True
+
+    def test_add_url_and_file_share_common_flags(self):
+        for argv in (
+            ["add", "url", "https://example.com", "-c", "X", "--if-exists", "skip"],
+            ["add", "file", "--filepath", "/tmp/x.pdf", "-c", "X", "--if-exists", "skip"],
+        ):
+            args = self.parser.parse_args(argv)
+            assert args.collection == ["X"]
+            assert args.if_exists == "skip"
+
 
 # ---------------------------------------------------------------------------
 # main() dispatch
@@ -379,6 +413,14 @@ class TestCmdAdd:
     every invocation. Autospec the real functions so signature drift fails here.
     """
 
+    def _args(self, **kwargs):
+        defaults = dict(
+            verbose=False, collections=None, collection=None, tags=None,
+            if_exists="file", create_collections=False,
+        )
+        defaults.update(kwargs)
+        return MagicMock(**defaults)
+
     def _run(self, args):
         mock_write = MagicMock()
         for fn in ("add_by_doi", "add_by_url", "add_from_file"):
@@ -393,9 +435,8 @@ class TestCmdAdd:
 
     def test_add_file_matches_real_signature(self, capsys):
         # Regression: would raise TypeError while parent_key= was passed.
-        args = MagicMock(subcommand="file", filepath="/tmp/paper.pdf",
-                         title=None, item_type="document",
-                         collections=None, tags=None, verbose=False)
+        args = self._args(subcommand="file", filepath="/tmp/paper.pdf",
+                          title=None, item_type="document")
         mock_write = self._run(args)
 
         mock_write.add_from_file.assert_called_once()
@@ -406,10 +447,9 @@ class TestCmdAdd:
         assert "ok" in capsys.readouterr().out
 
     def test_add_file_forwards_title_and_item_type(self):
-        args = MagicMock(subcommand="file", filepath="/tmp/book.epub",
-                         title="My Book", item_type="book",
-                         collections="ABCD1234,EFGH5678", tags="a,b",
-                         verbose=False)
+        args = self._args(subcommand="file", filepath="/tmp/book.epub",
+                          title="My Book", item_type="book",
+                          collections="ABCD1234,EFGH5678", tags="a,b")
         mock_write = self._run(args)
 
         call_kwargs = mock_write.add_from_file.call_args.kwargs
@@ -419,9 +459,8 @@ class TestCmdAdd:
         assert call_kwargs["tags"] == ["a", "b"]
 
     def test_add_doi_matches_real_signature(self):
-        args = MagicMock(subcommand="doi", doi="10.1234/test",
-                         attach_mode="auto", collections="ABCD1234",
-                         tags=None, verbose=False)
+        args = self._args(subcommand="doi", doi="10.1234/test",
+                          attach_mode="auto", collections="ABCD1234")
         mock_write = self._run(args)
 
         mock_write.add_by_doi.assert_called_once()
@@ -430,12 +469,43 @@ class TestCmdAdd:
         assert call_kwargs["collections"] == ["ABCD1234"]
 
     def test_add_url_matches_real_signature(self):
-        args = MagicMock(subcommand="url", url="https://arxiv.org/abs/2301.00001",
-                         attach_mode="auto", collections=None, tags=None,
-                         verbose=False)
+        args = self._args(subcommand="url",
+                          url="https://arxiv.org/abs/2301.00001",
+                          attach_mode="auto")
         mock_write = self._run(args)
 
         mock_write.add_by_url.assert_called_once()
         assert mock_write.add_by_url.call_args.kwargs["url"] == (
             "https://arxiv.org/abs/2301.00001"
         )
+
+    def test_add_doi_forwards_if_exists_and_create_flags(self):
+        args = self._args(subcommand="doi", doi="10.1234/test",
+                          attach_mode="auto", if_exists="skip",
+                          create_collections=True)
+        mock_write = self._run(args)
+
+        call_kwargs = mock_write.add_by_doi.call_args.kwargs
+        assert call_kwargs["if_exists"] == "skip"
+        assert call_kwargs["create_missing_collections"] is True
+
+    def test_add_doi_default_if_exists_is_file(self):
+        """The CLI defaults to convergent behavior; MCP keeps 'duplicate'."""
+        args = self._args(subcommand="doi", doi="10.1234/test",
+                          attach_mode="auto")
+        mock_write = self._run(args)
+
+        assert mock_write.add_by_doi.call_args.kwargs["if_exists"] == "file"
+
+    def test_repeatable_collection_flag_merges_without_splitting(self):
+        # -c values are single specs (never comma-split — names may contain
+        # commas); --collections is comma-split; both merge in order.
+        args = self._args(subcommand="doi", doi="10.1234/test",
+                          attach_mode="auto",
+                          collections="KEY00001,Reading List",
+                          collection=["_project/a, b topic", "Other"])
+        mock_write = self._run(args)
+
+        assert mock_write.add_by_doi.call_args.kwargs["collections"] == [
+            "KEY00001", "Reading List", "_project/a, b topic", "Other",
+        ]

--- a/tests/test_cli_standalone.py
+++ b/tests/test_cli_standalone.py
@@ -1,13 +1,15 @@
 """Tests for the standalone CLI module (zotero-cli entry point)."""
 
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
+import zotero_mcp.tools.write as write_tools
 from zotero_mcp.cli_standalone import (
     CLIContext,
     build_parser,
+    cmd_add,
     cmd_edit,
     cmd_notes,
     cmd_search,
@@ -127,6 +129,29 @@ class TestParser:
         args = self.parser.parse_args(["coll", "search", "my collection"])
         assert args.command in ("collections", "coll")
         assert args.subcommand == "search"
+
+    def test_add_file_flags(self):
+        args = self.parser.parse_args([
+            "add", "file", "--filepath", "/tmp/x.pdf",
+            "--title", "Override", "--item-type", "book",
+        ])
+        assert args.subcommand == "file"
+        assert args.filepath == "/tmp/x.pdf"
+        assert args.title == "Override"
+        assert args.item_type == "book"
+
+    def test_add_file_defaults(self):
+        args = self.parser.parse_args(["add", "file", "--filepath", "/tmp/x.pdf"])
+        assert args.title is None
+        assert args.item_type == "document"
+
+    def test_add_file_parent_key_removed(self):
+        # --parent-key never mapped to a real add_from_file parameter and made
+        # every `add file` invocation raise TypeError; it must stay removed.
+        with pytest.raises(SystemExit):
+            self.parser.parse_args([
+                "add", "file", "--filepath", "/tmp/x.pdf", "--parent-key", "ABC12345",
+            ])
 
 
 # ---------------------------------------------------------------------------
@@ -340,3 +365,77 @@ class TestCmdEdit:
 
         call_kwargs = mock_write.update_item.call_args.kwargs
         assert call_kwargs["add_tags"] == ["tag1", "tag2", "tag3"]
+
+
+# ---------------------------------------------------------------------------
+# cmd_add
+# ---------------------------------------------------------------------------
+
+class TestCmdAdd:
+    """cmd_add must call the write tools with kwargs their real signatures accept.
+
+    Plain MagicMocks hide kwarg mismatches (they accept anything), which is how
+    `add file` shipped passing a nonexistent parent_key= and raised TypeError on
+    every invocation. Autospec the real functions so signature drift fails here.
+    """
+
+    def _run(self, args):
+        mock_write = MagicMock()
+        for fn in ("add_by_doi", "add_by_url", "add_from_file"):
+            setattr(mock_write, fn,
+                    create_autospec(getattr(write_tools, fn), return_value="ok"))
+        with patch("zotero_mcp.cli_standalone.setup_zotero_environment"):
+            with patch("zotero_mcp.cli_standalone._import_tools",
+                       return_value=(MagicMock(), MagicMock(), MagicMock(),
+                                     mock_write, MagicMock())):
+                cmd_add(args)
+        return mock_write
+
+    def test_add_file_matches_real_signature(self, capsys):
+        # Regression: would raise TypeError while parent_key= was passed.
+        args = MagicMock(subcommand="file", filepath="/tmp/paper.pdf",
+                         title=None, item_type="document",
+                         collections=None, tags=None, verbose=False)
+        mock_write = self._run(args)
+
+        mock_write.add_from_file.assert_called_once()
+        call_kwargs = mock_write.add_from_file.call_args.kwargs
+        assert call_kwargs["file_path"] == "/tmp/paper.pdf"
+        assert call_kwargs["title"] is None
+        assert call_kwargs["item_type"] == "document"
+        assert "ok" in capsys.readouterr().out
+
+    def test_add_file_forwards_title_and_item_type(self):
+        args = MagicMock(subcommand="file", filepath="/tmp/book.epub",
+                         title="My Book", item_type="book",
+                         collections="ABCD1234,EFGH5678", tags="a,b",
+                         verbose=False)
+        mock_write = self._run(args)
+
+        call_kwargs = mock_write.add_from_file.call_args.kwargs
+        assert call_kwargs["title"] == "My Book"
+        assert call_kwargs["item_type"] == "book"
+        assert call_kwargs["collections"] == ["ABCD1234", "EFGH5678"]
+        assert call_kwargs["tags"] == ["a", "b"]
+
+    def test_add_doi_matches_real_signature(self):
+        args = MagicMock(subcommand="doi", doi="10.1234/test",
+                         attach_mode="auto", collections="ABCD1234",
+                         tags=None, verbose=False)
+        mock_write = self._run(args)
+
+        mock_write.add_by_doi.assert_called_once()
+        call_kwargs = mock_write.add_by_doi.call_args.kwargs
+        assert call_kwargs["doi"] == "10.1234/test"
+        assert call_kwargs["collections"] == ["ABCD1234"]
+
+    def test_add_url_matches_real_signature(self):
+        args = MagicMock(subcommand="url", url="https://arxiv.org/abs/2301.00001",
+                         attach_mode="auto", collections=None, tags=None,
+                         verbose=False)
+        mock_write = self._run(args)
+
+        mock_write.add_by_url.assert_called_once()
+        assert mock_write.add_by_url.call_args.kwargs["url"] == (
+            "https://arxiv.org/abs/2301.00001"
+        )

--- a/tests/test_cli_standalone.py
+++ b/tests/test_cli_standalone.py
@@ -187,6 +187,31 @@ class TestParser:
             assert args.collection == ["X"]
             assert args.if_exists == "skip"
 
+    def test_add_isbn_subcommand(self):
+        args = self.parser.parse_args(
+            ["add", "isbn", "9780262046305", "-c", "Books"]
+        )
+        assert args.subcommand == "isbn"
+        assert args.isbn == "9780262046305"
+        assert args.collection == ["Books"]
+        assert args.if_exists == "file"
+
+    def test_add_bibtex_subcommand(self):
+        args = self.parser.parse_args(
+            ["add", "bibtex", "--file", "/tmp/refs.bib", "-c", "Topic"]
+        )
+        assert args.subcommand == "bibtex"
+        assert args.file == "/tmp/refs.bib"
+        assert args.bibtex is None
+
+    def test_add_csl_json_subcommand(self):
+        args = self.parser.parse_args(
+            ["add", "csl-json", "--json", "-", "--if-exists", "duplicate"]
+        )
+        assert args.subcommand == "csl-json"
+        assert args.json == "-"
+        assert args.if_exists == "duplicate"
+
 
 # ---------------------------------------------------------------------------
 # main() dispatch
@@ -423,7 +448,8 @@ class TestCmdAdd:
 
     def _run(self, args):
         mock_write = MagicMock()
-        for fn in ("add_by_doi", "add_by_url", "add_from_file"):
+        for fn in ("add_by_doi", "add_by_url", "add_from_file",
+                   "add_by_isbn", "add_by_bibtex", "add_by_csl_json"):
             setattr(mock_write, fn,
                     create_autospec(getattr(write_tools, fn), return_value="ok"))
         with patch("zotero_mcp.cli_standalone.setup_zotero_environment"):
@@ -509,3 +535,45 @@ class TestCmdAdd:
         assert mock_write.add_by_doi.call_args.kwargs["collections"] == [
             "KEY00001", "Reading List", "_project/a, b topic", "Other",
         ]
+
+    def test_add_isbn_matches_real_signature(self):
+        args = self._args(subcommand="isbn", isbn="9780262046305",
+                          collections="Books")
+        mock_write = self._run(args)
+
+        mock_write.add_by_isbn.assert_called_once()
+        call_kwargs = mock_write.add_by_isbn.call_args.kwargs
+        assert call_kwargs["isbn"] == "9780262046305"
+        assert call_kwargs["collections"] == ["Books"]
+        assert call_kwargs["if_exists"] == "file"
+
+    def test_add_bibtex_inline_matches_real_signature(self):
+        args = self._args(subcommand="bibtex", bibtex="@article{x, title={T}}",
+                          file=None, attach_mode="auto")
+        mock_write = self._run(args)
+
+        mock_write.add_by_bibtex.assert_called_once()
+        call_kwargs = mock_write.add_by_bibtex.call_args.kwargs
+        assert call_kwargs["bibtex"] == "@article{x, title={T}}"
+        assert call_kwargs["file_path"] is None
+
+    def test_add_bibtex_reads_stdin_when_dash(self, monkeypatch):
+        monkeypatch.setattr("sys.stdin",
+                            MagicMock(read=lambda: "@book{y, title={Y}}"))
+        args = self._args(subcommand="bibtex", bibtex="-", file=None,
+                          attach_mode="auto")
+        mock_write = self._run(args)
+
+        assert mock_write.add_by_bibtex.call_args.kwargs["bibtex"] == (
+            "@book{y, title={Y}}"
+        )
+
+    def test_add_csl_json_file_matches_real_signature(self):
+        args = self._args(subcommand="csl-json", json=None,
+                          file="/tmp/refs.json", attach_mode="auto")
+        mock_write = self._run(args)
+
+        mock_write.add_by_csl_json.assert_called_once()
+        call_kwargs = mock_write.add_by_csl_json.call_args.kwargs
+        assert call_kwargs["file_path"] == "/tmp/refs.json"
+        assert call_kwargs["csl_json"] is None

--- a/tests/test_collection_resolver.py
+++ b/tests/test_collection_resolver.py
@@ -1,0 +1,220 @@
+"""Tests for resolve_collection_specs / build_collection_paths (#3).
+
+The resolver lets every add path (and zotero_manage_collections) accept
+collection KEYS, NAMES, or '/'-separated PATHS interchangeably:
+
+- a key is used as-is, but only if it actually exists as a live collection
+  (shape alone is not enough — trashed/bogus keys must fail loudly);
+- a name matches case-insensitively anywhere in the tree;
+- a path like 'parent/child' suffix-matches the collection tree, so it
+  disambiguates same-named leaves;
+- ambiguity and misses raise ValueError with actionable messages;
+- create_missing=True creates the missing chain instead of raising.
+"""
+
+import pytest
+
+from conftest import DummyContext, FakeZotero
+from zotero_mcp.tools import _helpers
+
+
+def _coll(key, name, parent=False):
+    return {"key": key, "data": {"name": name, "parentCollection": parent}}
+
+
+class FakeZoteroResolver(FakeZotero):
+    """FakeZotero with collection-creation tracking and a stubbed trash."""
+
+    def __init__(self):
+        super().__init__()
+        self.created_collections = []
+        self._trashed = []
+        self._create_counter = 0
+
+    def create_collections(self, colls, **kwargs):
+        self.created_collections.extend(colls)
+        result = {}
+        for i, c in enumerate(colls):
+            self._create_counter += 1
+            new_key = f"NEW{self._create_counter:05d}"
+            result[str(i)] = new_key
+            self._collections.append(
+                _coll(new_key, c["name"], c.get("parentCollection") or False)
+            )
+        return {"success": result, "successful": {}, "failed": {}}
+
+    def _retrieve_data(self, path):
+        class _Resp:
+            def __init__(self, data):
+                self._data = data
+
+            def json(self):
+                return self._data
+
+        if path.endswith("/collections/trash"):
+            return _Resp(self._trashed)
+        raise Exception(f"unexpected path {path}")
+
+
+@pytest.fixture
+def zot():
+    z = FakeZoteroResolver()
+    z._collections = [
+        _coll("ROOT0001", "Machine Learning"),
+        _coll("CHLD0001", "Deep Learning", parent="ROOT0001"),
+        _coll("CHLD0002", "Optimisation", parent="ROOT0001"),
+        _coll("ROOT0002", "_project"),
+        _coll("CHLD0003", "Deep Learning", parent="ROOT0002"),  # duplicate leaf name
+        _coll("ROOT0003", "Reading List"),
+    ]
+    return z
+
+
+# ---------------------------------------------------------------------------
+# build_collection_paths
+# ---------------------------------------------------------------------------
+
+class TestBuildCollectionPaths:
+    def test_paths_built_from_parent_links(self, zot):
+        paths = _helpers.build_collection_paths(zot._collections)
+        assert paths["ROOT0001"] == ["Machine Learning"]
+        assert paths["CHLD0001"] == ["Machine Learning", "Deep Learning"]
+        assert paths["CHLD0003"] == ["_project", "Deep Learning"]
+
+    def test_orphaned_parent_degrades_to_short_path(self):
+        paths = _helpers.build_collection_paths(
+            [_coll("AAAA0001", "Orphan", parent="GONE0000")]
+        )
+        assert paths["AAAA0001"] == ["Orphan"]
+
+    def test_parent_cycle_does_not_hang(self):
+        paths = _helpers.build_collection_paths([
+            _coll("AAAA0001", "A", parent="BBBB0001"),
+            _coll("BBBB0001", "B", parent="AAAA0001"),
+        ])
+        assert "A" in "/".join(paths["AAAA0001"])
+        assert "B" in "/".join(paths["BBBB0001"])
+
+
+# ---------------------------------------------------------------------------
+# resolve_collection_specs — keys
+# ---------------------------------------------------------------------------
+
+class TestKeyResolution:
+    def test_live_key_passes_through(self, zot):
+        assert _helpers.resolve_collection_specs(zot, ["CHLD0001"]) == ["CHLD0001"]
+
+    def test_bogus_key_shaped_spec_errors(self, zot):
+        with pytest.raises(ValueError, match="not found"):
+            _helpers.resolve_collection_specs(zot, ["DEADBEEF"])
+
+    def test_trashed_key_reports_trash(self, zot):
+        zot._trashed = [_coll("DEAD0001", "Old Stuff")]
+        with pytest.raises(ValueError, match="Trash"):
+            _helpers.resolve_collection_specs(zot, ["DEAD0001"])
+
+    def test_key_shaped_name_resolves_as_name(self, zot):
+        # 8-char uppercase name that is NOT a live key → name resolution.
+        zot._collections.append(_coll("ROOT0004", "ARCHIVES"))
+        assert _helpers.resolve_collection_specs(zot, ["ARCHIVES"]) == ["ROOT0004"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_collection_specs — names and paths
+# ---------------------------------------------------------------------------
+
+class TestNameAndPathResolution:
+    def test_exact_name_case_insensitive(self, zot):
+        assert _helpers.resolve_collection_specs(zot, ["machine learning"]) == ["ROOT0001"]
+
+    def test_nested_name_matches_anywhere(self, zot):
+        assert _helpers.resolve_collection_specs(zot, ["Optimisation"]) == ["CHLD0002"]
+
+    def test_ambiguous_name_lists_candidates(self, zot):
+        with pytest.raises(ValueError) as exc:
+            _helpers.resolve_collection_specs(zot, ["Deep Learning"])
+        msg = str(exc.value)
+        assert "ambiguous" in msg
+        assert "CHLD0001" in msg and "CHLD0003" in msg
+        assert "Machine Learning/Deep Learning" in msg
+
+    def test_path_disambiguates(self, zot):
+        assert _helpers.resolve_collection_specs(
+            zot, ["_project/Deep Learning"]
+        ) == ["CHLD0003"]
+
+    def test_path_is_case_insensitive(self, zot):
+        assert _helpers.resolve_collection_specs(
+            zot, ["machine learning/deep learning"]
+        ) == ["CHLD0001"]
+
+    def test_unknown_name_suggests_close_matches(self, zot):
+        with pytest.raises(ValueError) as exc:
+            _helpers.resolve_collection_specs(zot, ["learning"])
+        # 'learning' is a substring of several collections but an exact match
+        # of none → ambiguous-or-missing must surface candidates.
+        msg = str(exc.value)
+        assert "not found" in msg
+        assert "Machine Learning" in msg
+
+    def test_mixed_specs_resolve_in_order_and_dedupe(self, zot):
+        out = _helpers.resolve_collection_specs(
+            zot, ["ROOT0003", "reading list", "Optimisation"]
+        )
+        assert out == ["ROOT0003", "CHLD0002"]
+
+    def test_empty_specs_no_fetch(self):
+        class Boom:
+            def collections(self, **kw):
+                raise AssertionError("should not fetch for empty specs")
+
+        assert _helpers.resolve_collection_specs(Boom(), []) == []
+        assert _helpers.resolve_collection_specs(Boom(), None) == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_collection_specs — create_missing
+# ---------------------------------------------------------------------------
+
+class TestCreateMissing:
+    def test_creates_single_name_at_root(self, zot):
+        out = _helpers.resolve_collection_specs(
+            zot, ["Brand New"], create_missing=True, write_zot=zot,
+            ctx=DummyContext(),
+        )
+        assert out == ["NEW00001"]
+        assert zot.created_collections == [
+            {"name": "Brand New", "parentCollection": False}
+        ]
+
+    def test_creates_chain_under_existing_prefix(self, zot):
+        out = _helpers.resolve_collection_specs(
+            zot, ["_project/intertemporal/drafts"], create_missing=True,
+            write_zot=zot, ctx=DummyContext(),
+        )
+        # '_project' exists (ROOT0002); 'intertemporal' and 'drafts' created.
+        assert [c["name"] for c in zot.created_collections] == [
+            "intertemporal", "drafts",
+        ]
+        assert zot.created_collections[0]["parentCollection"] == "ROOT0002"
+        assert out == ["NEW00002"]
+
+    def test_existing_spec_not_recreated(self, zot):
+        out = _helpers.resolve_collection_specs(
+            zot, ["Reading List"], create_missing=True, write_zot=zot,
+        )
+        assert out == ["ROOT0003"]
+        assert zot.created_collections == []
+
+    def test_ambiguous_parent_prefix_errors(self, zot):
+        with pytest.raises(ValueError, match="ambiguous"):
+            _helpers.resolve_collection_specs(
+                zot, ["Deep Learning/subtopic"], create_missing=True,
+                write_zot=zot,
+            )
+
+    def test_create_missing_without_write_client_errors(self, zot):
+        with pytest.raises(ValueError, match="writable"):
+            _helpers.resolve_collection_specs(
+                zot, ["Brand New"], create_missing=True,
+            )

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -427,7 +427,7 @@ class TestManageCollections:
         since the version number must match the server the write goes to."""
         read_zot = FakeZoteroCollections()
         read_zot._collections = [
-            {"key": "COL001", "data": {"name": "Test", "parentCollection": False}},
+            {"key": "COL00001", "data": {"name": "Test", "parentCollection": False}},
         ]
         write_zot = FakeZoteroCollections()
         write_zot._collections = list(read_zot._collections)  # both endpoints see the same collections
@@ -443,7 +443,7 @@ class TestManageCollections:
 
         result = server.manage_collections(
             item_keys=["ITEM0001"],
-            add_to=["COL001"],
+            add_to=["COL00001"],
             ctx=ctx,
         )
 
@@ -474,8 +474,8 @@ class TestManageCollections:
         assert "error" in result.lower() or "must specify" in result.lower()
 
     def test_collection_name_resolution_in_add_to(self, monkeypatch, fake_zot, ctx):
-        """add_to values are passed directly as collection keys (no name resolution).
-        The implementation uses _normalize_str_list_input, not _resolve_collection_names."""
+        """add_to values may be collection NAMES — resolved to keys before
+        any filing happens (resolve_collection_specs)."""
         _patch_web_only(monkeypatch, fake_zot)
 
         result = server.manage_collections(
@@ -484,10 +484,23 @@ class TestManageCollections:
             ctx=ctx,
         )
 
-        # The value is passed through as-is (not resolved to a key)
-        if fake_zot.added_to_collections:
-            coll_key, _ = fake_zot.added_to_collections[0]
-            assert coll_key == "NLP Papers"
+        assert fake_zot.added_to_collections, f"nothing filed: {result}"
+        coll_key, _ = fake_zot.added_to_collections[0]
+        assert coll_key == "ABC00003"
+
+    def test_collection_path_resolution_in_add_to(self, monkeypatch, fake_zot, ctx):
+        """A 'parent/child' path disambiguates nested collections."""
+        _patch_web_only(monkeypatch, fake_zot)
+
+        result = server.manage_collections(
+            item_keys=["ITEM0001"],
+            add_to=["Machine Learning/Deep Learning"],
+            ctx=ctx,
+        )
+
+        assert fake_zot.added_to_collections, f"nothing filed: {result}"
+        coll_key, _ = fake_zot.added_to_collections[0]
+        assert coll_key == "ABC00002"
 
     def test_multiple_items_batched(self, monkeypatch, fake_zot, ctx):
         """Multiple items should all be processed."""

--- a/tests/test_collections_backstop.py
+++ b/tests/test_collections_backstop.py
@@ -136,6 +136,9 @@ def test_add_by_doi_string_collection_routes_correctly(monkeypatch):
     """The bare-string ``collections="KEY"`` form must produce the same routing
     as the array form (#235)."""
     z = _RecordingZotero(atomic_filing_works=True)
+    z._collections = [
+        {"key": "A75DWWBH", "data": {"name": "Target", "parentCollection": False}},
+    ]
     _patch_write_client(monkeypatch, z)
 
     result = server.add_by_doi(
@@ -151,6 +154,9 @@ def test_add_by_doi_string_collection_with_atomic_failure_backstops(monkeypatch)
     """If pyzotero's atomic filing on ``create_items`` no-ops, the backstop
     must explicitly ``addto_collection`` so the item still lands correctly."""
     z = _RecordingZotero(atomic_filing_works=False)
+    z._collections = [
+        {"key": "A75DWWBH", "data": {"name": "Target", "parentCollection": False}},
+    ]
     _patch_write_client(monkeypatch, z)
 
     result = server.add_by_doi(

--- a/tests/test_idempotent_adds.py
+++ b/tests/test_idempotent_adds.py
@@ -1,0 +1,396 @@
+"""Tests for idempotent adds (#4): find_existing_items + if_exists semantics.
+
+if_exists contract on the add_by_* family:
+
+- 'duplicate' (default): today's behavior — always create, even when an
+  identical identifier exists.
+- 'file': converge. Reuse the existing item, add it to any requested
+  collections it isn't in, add any missing tags. Nothing is ever removed.
+  Re-running the same command is a no-op.
+- 'skip': report the existing item, change nothing.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from conftest import DummyContext, FakeZotero, _FakeResponse
+from zotero_mcp import server
+from zotero_mcp.tools import _helpers
+
+
+DOI = "10.1234/test.2024.001"
+
+
+def _make_crossref_response():
+    msg = {
+        "type": "journal-article",
+        "title": ["Fresh Paper"],
+        "DOI": DOI,
+        "author": [{"given": "A", "family": "Author"}],
+    }
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"status": "ok", "message": msg}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class FakeZoteroIdem(FakeZotero):
+    """FakeZotero with addto/update tracking against stored items."""
+
+    def __init__(self):
+        super().__init__()
+        self.addto_calls = []
+
+    def addto_collection(self, collection_key, item, **kwargs):
+        key = item["key"] if isinstance(item, dict) else item
+        self.addto_calls.append((collection_key, key))
+        for it in self._items:
+            if it.get("key") == key:
+                cols = it["data"].setdefault("collections", [])
+                if collection_key not in cols:
+                    cols.append(collection_key)
+        return _FakeResponse(204)
+
+
+@pytest.fixture
+def fake_zot():
+    z = FakeZoteroIdem()
+    z._collections = [
+        {"key": "COLA0001", "data": {"name": "Old Coll", "parentCollection": False}},
+        {"key": "COLB0001", "data": {"name": "Target", "parentCollection": False}},
+    ]
+    z._items = [
+        {
+            "key": "EXIST001",
+            "version": 5,
+            "data": {
+                "itemType": "journalArticle",
+                "title": "Existing Paper",
+                "DOI": DOI,
+                "collections": ["COLA0001"],
+                "tags": [{"tag": "old"}],
+            },
+        },
+    ]
+    return z
+
+
+@pytest.fixture
+def dummy_ctx():
+    return DummyContext()
+
+
+def _patch_clients(monkeypatch, zot):
+    monkeypatch.setattr(
+        "zotero_mcp.tools._helpers._get_write_client", lambda ctx: (zot, zot)
+    )
+    monkeypatch.setattr(
+        "requests.get", lambda *a, **kw: _make_crossref_response()
+    )
+    monkeypatch.setattr(
+        "zotero_mcp.tools._helpers._try_attach_oa_pdf",
+        lambda *a, **kw: "skipped (test)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# find_existing_items
+# ---------------------------------------------------------------------------
+
+class TestFindExistingItems:
+    def test_doi_match(self, fake_zot):
+        out = _helpers.find_existing_items(fake_zot, doi=DOI)
+        assert [i["key"] for i in out] == ["EXIST001"]
+
+    def test_doi_match_with_prefixed_stored_value(self, fake_zot):
+        fake_zot._items[0]["data"]["DOI"] = f"https://doi.org/{DOI}"
+        out = _helpers.find_existing_items(fake_zot, doi=DOI)
+        assert [i["key"] for i in out] == ["EXIST001"]
+
+    def test_doi_no_match(self, fake_zot):
+        assert _helpers.find_existing_items(fake_zot, doi="10.9999/other") == []
+
+    def test_attachments_excluded(self, fake_zot):
+        fake_zot._items.append({
+            "key": "ATTACH01",
+            "version": 1,
+            "data": {"itemType": "attachment", "DOI": DOI},
+        })
+        out = _helpers.find_existing_items(fake_zot, doi=DOI)
+        assert [i["key"] for i in out] == ["EXIST001"]
+
+    def test_arxiv_match_via_url(self, fake_zot):
+        fake_zot._items.append({
+            "key": "ARXIV001",
+            "version": 1,
+            "data": {
+                "itemType": "preprint",
+                "url": "https://arxiv.org/abs/2401.00001",
+                "extra": "",
+            },
+        })
+        out = _helpers.find_existing_items(fake_zot, arxiv_id="2401.00001")
+        assert [i["key"] for i in out] == ["ARXIV001"]
+
+    def test_arxiv_match_via_extra(self, fake_zot):
+        fake_zot._items.append({
+            "key": "ARXIV002",
+            "version": 1,
+            "data": {"itemType": "preprint", "url": "", "extra": "arXiv:2401.00002"},
+        })
+        out = _helpers.find_existing_items(fake_zot, arxiv_id="2401.00002")
+        assert [i["key"] for i in out] == ["ARXIV002"]
+
+    def test_isbn_match_across_10_13_forms(self, fake_zot):
+        # ISBN-10 0306406152 == ISBN-13 9780306406157
+        fake_zot._items.append({
+            "key": "BOOK0001",
+            "version": 1,
+            "data": {"itemType": "book", "ISBN": "0-306-40615-2 9999999999"},
+        })
+        out = _helpers.find_existing_items(fake_zot, isbn="9780306406157")
+        assert [i["key"] for i in out] == ["BOOK0001"]
+
+    def test_url_match_modulo_trailing_slash(self, fake_zot):
+        fake_zot._items.append({
+            "key": "PAGE0001",
+            "version": 1,
+            "data": {"itemType": "webpage", "url": "https://example.com/post/"},
+        })
+        out = _helpers.find_existing_items(fake_zot, url="https://example.com/post")
+        assert [i["key"] for i in out] == ["PAGE0001"]
+
+    def test_search_failure_returns_empty(self, dummy_ctx):
+        class Boom(FakeZotero):
+            def items(self, **kw):
+                raise RuntimeError("api down")
+
+        assert _helpers.find_existing_items(Boom(), doi=DOI, ctx=dummy_ctx) == []
+
+    def test_no_identifier_returns_empty(self, fake_zot):
+        assert _helpers.find_existing_items(fake_zot) == []
+
+
+# ---------------------------------------------------------------------------
+# add_by_doi × if_exists
+# ---------------------------------------------------------------------------
+
+class TestAddByDoiIfExists:
+    def test_file_mode_reuses_and_converges(self, monkeypatch, fake_zot, dummy_ctx):
+        _patch_clients(monkeypatch, fake_zot)
+
+        result = server.add_by_doi(
+            doi=DOI, collections=["COLB0001"], tags=["new-tag"],
+            if_exists="file", ctx=dummy_ctx,
+        )
+
+        assert fake_zot.created == []                      # no duplicate item
+        assert ("COLB0001", "EXIST001") in fake_zot.addto_calls
+        assert len(fake_zot.updated) == 1                  # tags update
+        new_tags = {t["tag"] for t in fake_zot.updated[0]["data"]["tags"]}
+        assert new_tags == {"old", "new-tag"}
+        assert "Already in library" in result
+        assert "EXIST001" in result
+        assert "added to ['COLB0001']" in result
+
+    def test_file_mode_second_run_is_noop(self, monkeypatch, fake_zot, dummy_ctx):
+        _patch_clients(monkeypatch, fake_zot)
+
+        server.add_by_doi(doi=DOI, collections=["COLB0001"], tags=["new-tag"],
+                          if_exists="file", ctx=dummy_ctx)
+        addto_after_first = list(fake_zot.addto_calls)
+        updates_after_first = len(fake_zot.updated)
+
+        result = server.add_by_doi(doi=DOI, collections=["COLB0001"],
+                                   tags=["new-tag"], if_exists="file",
+                                   ctx=dummy_ctx)
+
+        assert fake_zot.created == []
+        assert fake_zot.addto_calls == addto_after_first   # nothing re-filed
+        assert len(fake_zot.updated) == updates_after_first  # no tag rewrite
+        assert "already in ['COLB0001']" in result
+
+    def test_skip_mode_touches_nothing(self, monkeypatch, fake_zot, dummy_ctx):
+        _patch_clients(monkeypatch, fake_zot)
+
+        result = server.add_by_doi(
+            doi=DOI, collections=["COLB0001"], tags=["new-tag"],
+            if_exists="skip", ctx=dummy_ctx,
+        )
+
+        assert fake_zot.created == []
+        assert fake_zot.addto_calls == []
+        assert fake_zot.updated == []
+        assert "No changes made" in result
+
+    def test_duplicate_default_still_creates(self, monkeypatch, fake_zot, dummy_ctx):
+        _patch_clients(monkeypatch, fake_zot)
+
+        result = server.add_by_doi(doi=DOI, ctx=dummy_ctx)
+
+        assert len(fake_zot.created) == 1
+        assert "Successfully added" in result
+
+    def test_file_mode_creates_when_no_match(self, monkeypatch, fake_zot, dummy_ctx):
+        fake_zot._items = []          # nothing in the library
+        _patch_clients(monkeypatch, fake_zot)
+
+        result = server.add_by_doi(
+            doi=DOI, collections=["COLB0001"], if_exists="file", ctx=dummy_ctx,
+        )
+
+        assert len(fake_zot.created) == 1
+        assert "Successfully added" in result
+
+    def test_invalid_if_exists_rejected(self, monkeypatch, fake_zot, dummy_ctx):
+        _patch_clients(monkeypatch, fake_zot)
+        result = server.add_by_doi(doi=DOI, if_exists="bogus", ctx=dummy_ctx)
+        assert "if_exists" in result
+        assert fake_zot.created == []
+
+
+# ---------------------------------------------------------------------------
+# add_by_url × if_exists (arXiv + webpage routing)
+# ---------------------------------------------------------------------------
+
+class TestAddByUrlIfExists:
+    def test_arxiv_reused_without_network(self, monkeypatch, fake_zot, dummy_ctx):
+        fake_zot._items.append({
+            "key": "ARXIV001",
+            "version": 2,
+            "data": {
+                "itemType": "preprint",
+                "title": "An arXiv Paper",
+                "url": "https://arxiv.org/abs/2401.00001",
+                "extra": "arXiv:2401.00001",
+                "collections": [],
+                "tags": [],
+            },
+        })
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client",
+            lambda ctx: (fake_zot, fake_zot),
+        )
+
+        def _no_network(*a, **kw):
+            raise AssertionError("network must not be hit when reusing")
+
+        monkeypatch.setattr("zotero_mcp.tools.write.requests.get", _no_network)
+
+        result = server.add_by_url(
+            url="https://arxiv.org/abs/2401.00001",
+            collections=["COLB0001"], if_exists="file", ctx=dummy_ctx,
+        )
+
+        assert fake_zot.created == []
+        assert ("COLB0001", "ARXIV001") in fake_zot.addto_calls
+        assert "Already in library" in result
+
+    def test_webpage_reused_by_url(self, monkeypatch, fake_zot, dummy_ctx):
+        fake_zot._items.append({
+            "key": "PAGE0001",
+            "version": 3,
+            "data": {
+                "itemType": "webpage",
+                "title": "A Post",
+                "url": "https://example.com/post/",
+                "collections": [],
+                "tags": [],
+            },
+        })
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client",
+            lambda ctx: (fake_zot, fake_zot),
+        )
+
+        result = server.add_by_url(
+            url="https://example.com/post", collections=["COLB0001"],
+            if_exists="file", ctx=dummy_ctx,
+        )
+
+        assert fake_zot.created == []
+        assert ("COLB0001", "PAGE0001") in fake_zot.addto_calls
+        assert "Already in library" in result
+
+
+# ---------------------------------------------------------------------------
+# add_by_isbn × if_exists
+# ---------------------------------------------------------------------------
+
+class TestAddByIsbnIfExists:
+    def test_existing_isbn_reused_across_forms(self, monkeypatch, fake_zot, dummy_ctx):
+        fake_zot._items.append({
+            "key": "BOOK0001",
+            "version": 4,
+            "data": {
+                "itemType": "book",
+                "title": "A Book",
+                "ISBN": "0-306-40615-2",   # ISBN-10 form of 9780306406157
+                "collections": [],
+                "tags": [],
+            },
+        })
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client",
+            lambda ctx: (fake_zot, fake_zot),
+        )
+
+        result = server.add_by_isbn(
+            isbn="9780306406157", collections=["COLB0001"],
+            if_exists="file", ctx=dummy_ctx,
+        )
+
+        assert fake_zot.created == []
+        assert ("COLB0001", "BOOK0001") in fake_zot.addto_calls
+        assert "Already in library" in result
+
+
+# ---------------------------------------------------------------------------
+# add_by_bibtex × if_exists (batch: mixed existing/new)
+# ---------------------------------------------------------------------------
+
+class TestAddByBibtexIfExists:
+    def test_mixed_batch_reuses_and_creates(self, monkeypatch, fake_zot, dummy_ctx):
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client",
+            lambda ctx: (fake_zot, fake_zot),
+        )
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._try_attach_oa_pdf",
+            lambda *a, **kw: "skipped (test)",
+        )
+
+        bib = (
+            "@article{exists, title={Existing Paper}, author={A, B}, "
+            "year={2024}, doi={" + DOI + "}}\n"
+            "@article{fresh, title={Fresh Paper}, author={C, D}, year={2024}}"
+        )
+        result = server.add_by_bibtex(
+            bibtex=bib, collections=["COLB0001"], if_exists="file",
+            ctx=dummy_ctx,
+        )
+
+        # Only the DOI-less entry creates a new item.
+        assert len(fake_zot.created) == 1
+        assert ("COLB0001", "EXIST001") in fake_zot.addto_calls
+        assert "1 already existed" in result
+        assert "reused existing" in result
+
+    def test_skip_mode_reports_without_changes(self, monkeypatch, fake_zot, dummy_ctx):
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client",
+            lambda ctx: (fake_zot, fake_zot),
+        )
+
+        bib = ("@article{exists, title={Existing Paper}, author={A, B}, "
+               "year={2024}, doi={" + DOI + "}}")
+        result = server.add_by_bibtex(
+            bibtex=bib, collections=["COLB0001"], if_exists="skip",
+            ctx=dummy_ctx,
+        )
+
+        assert fake_zot.created == []
+        assert fake_zot.addto_calls == []
+        assert "skipped — already in library" in result

--- a/tests/test_regression_bugs.py
+++ b/tests/test_regression_bugs.py
@@ -34,11 +34,14 @@ class TestManageCollectionsPayloadShape:
                 return _FakeResponse(204)
 
         fake = FakeZotManage()
+        fake._collections = [
+            {"key": "COL00001", "data": {"name": "Test Collection", "parentCollection": False}},
+        ]
         monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client", lambda ctx: (fake, fake))
 
         ctx = DummyContext()
         server.manage_collections(
-            item_keys=["ITEM01"], add_to=["COL01"], ctx=ctx
+            item_keys=["ITEM01"], add_to=["COL00001"], ctx=ctx
         )
 
         assert len(received) == 1


### PR DESCRIPTION
Closes #338 (the subcommand part; the optional `--json` output / exit-code polish stays open there).

> **Stacked on #341** (← #340 ← #339). Cross-fork PRs can only target `main`, so this diff includes the predecessors; the new work here is the **last commit** (`feat(cli): add isbn / bibtex / csl-json…`). I'll rebase as the predecessors merge.

## What

`zotero-cli add` gains the three ingestion routes the MCP server already had, with the same collection/idempotency flags as `doi`/`url`/`file`:

```bash
zotero-cli add isbn 9780262046305 -c Books
zotero-cli add bibtex --file refs.bib -c topic
zotero-cli add bibtex --bibtex - < refs.bib       # stdin via -
zotero-cli add csl-json --json - -c topic         # stdin via -
zotero-cli add csl-json --file refs.json --if-exists skip
```

All three get `-c/--collection` (repeatable), `--collections`, `--tags`, `--if-exists`, `--create-collections`; `bibtex`/`csl-json` also take `--attach-mode`. `--bibtex -` / `--json -` read stdin, matching the existing `notes create --text -` convention. Inline-vs-file mutual exclusion is enforced by the underlying tool functions.

Also adds `zotero_add_by_isbn` / `zotero_add_by_bibtex` / `zotero_add_by_csl_json` to the README's Available Tools list — they were missing entirely.

## Tests

Parser tests for the three subcommands and `TestCmdAdd` autospec coverage (including stdin-dash reading), so CLI↔tool signature drift fails the suite. Full run: 960 passed; same 5 pre-existing failures as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
