### PR TITLE
feat(webdav): allow tuning upload read timeout via `ZOTERO_WEBDAV_TIMEOUT` env var (#344)

### DIFF
--- a/src/zotero_mcp/webdav.py
+++ b/src/zotero_mcp/webdav.py
@@ -146,7 +146,7 @@ def upload_attachment_to_webdav(
     file_path: str | Path,
     md5: str | None = None,
     mtime_ms: int | None = None,
-    timeout: float = 60.0,
+    timeout: float | None = None,
 ) -> tuple[str, int]:
     """Upload an attachment to WebDAV in Zotero's expected layout.
 
@@ -158,9 +158,18 @@ def upload_attachment_to_webdav(
     values to the Zotero attachment item via the web API, keeping the
     two sides of the sync consistent.
 
+    ``timeout`` is the read-side timeout passed to ``requests``. When
+    ``None`` (the default), the value is read from the
+    ``ZOTERO_WEBDAV_TIMEOUT`` environment variable; if that is unset,
+    falls back to ``60.0``. An explicit float bypasses the env lookup.
+
     Raises ``WebDAVNotConfiguredError`` when the env vars are missing,
     or ``requests.HTTPError`` on a non-2xx response from the PUTs.
     """
+    if timeout is None:
+        env_timeout = _get_env_value("ZOTERO_WEBDAV_TIMEOUT")
+        timeout = float(env_timeout) if env_timeout is not None else 60.0
+
     config = get_webdav_config()
     if not config:
         raise WebDAVNotConfiguredError(

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -130,9 +130,11 @@ class _RecordingPutSession:
         self.auth = None
         self.trust_env = True
         self.calls = []  # list of (url, data, headers)
+        self.timeouts = []  # parallel list of the timeout passed to each PUT
 
     def put(self, url, data=None, headers=None, timeout=None):
         self.calls.append((url, data, dict(headers or {})))
+        self.timeouts.append(timeout)
 
         class _Resp:
             def __init__(self_inner, sc):
@@ -235,3 +237,47 @@ def test_upload_attachment_escapes_key_in_urls(tmp_path, monkeypatch):
 
     assert session.calls[0][0] == "https://dav.example.com/zotero/AB%2FCD.zip"
     assert session.calls[1][0] == "https://dav.example.com/zotero/AB%2FCD.prop"
+
+
+@skip_on_ci
+def test_upload_default_timeout_is_60s(tmp_path, monkeypatch):
+    src = tmp_path / "paper.pdf"
+    src.write_bytes(b"x")
+    session = _RecordingPutSession()
+    _setup_webdav_env(monkeypatch)
+    monkeypatch.delenv("ZOTERO_WEBDAV_TIMEOUT", raising=False)
+    monkeypatch.setattr("requests.Session", lambda: session)
+
+    webdav.upload_attachment_to_webdav("ABCD1234", src)
+
+    # Both PUTs use the historic default — (10s connect, 60s read).
+    assert session.timeouts == [(10.0, 60.0), (10.0, 60.0)]
+
+
+@skip_on_ci
+def test_upload_env_override_respected(tmp_path, monkeypatch):
+    src = tmp_path / "paper.pdf"
+    src.write_bytes(b"x")
+    session = _RecordingPutSession()
+    _setup_webdav_env(monkeypatch)
+    monkeypatch.setenv("ZOTERO_WEBDAV_TIMEOUT", "300")
+    monkeypatch.setattr("requests.Session", lambda: session)
+
+    webdav.upload_attachment_to_webdav("ABCD1234", src)
+
+    assert session.timeouts == [(10.0, 300.0), (10.0, 300.0)]
+
+
+@skip_on_ci
+def test_upload_explicit_timeout_wins_over_env(tmp_path, monkeypatch):
+    src = tmp_path / "paper.pdf"
+    src.write_bytes(b"x")
+    session = _RecordingPutSession()
+    _setup_webdav_env(monkeypatch)
+    monkeypatch.setenv("ZOTERO_WEBDAV_TIMEOUT", "300")
+    monkeypatch.setattr("requests.Session", lambda: session)
+
+    webdav.upload_attachment_to_webdav("ABCD1234", src, timeout=45.0)
+
+    # Explicit caller arg takes precedence over the env var.
+    assert session.timeouts == [(10.0, 45.0), (10.0, 45.0)]


### PR DESCRIPTION
## Summary

Closes #344.

Exposes the `webdav.upload_attachment_to_webdav` read timeout via a new `ZOTERO_WEBDAV_TIMEOUT` env var. Completes the env-var pattern that `ZOTERO_WEBDAV_URL` / `_USERNAME` / `_PASSWORD` already established. Default unchanged.

Signature change: `timeout: float = 60.0` → `timeout: float | None = None`. `None` triggers the lookup chain (env var → 60.0 fallback). Explicit caller-passed timeout still wins.

## Backwards compatibility

`grep -rn "upload_attachment_to_webdav(" src/ tests/` → only `tools/write.py:2094` calls it, no explicit `timeout=` kwarg. The signature change is a strict no-op for anyone not setting the env var.

## Test plan

- [x] Unit: `.venv/bin/pytest tests/test_webdav.py` — 11/11 pass (8 existing + 3 new).
- [x] Full suite: `uv sync --all-extras && .venv/bin/pytest tests/` — 900 pass, 2 pre-existing `TestPlaceInBibtex` failures unrelated to this change (confirmed reproducing on `upstream/main` without the patch).

Tests added in `tests/test_webdav.py`:
- `test_upload_default_timeout_is_60s` — no env var, no explicit kwarg; mocked Session sees `timeout=(10.0, 60.0)`.
- `test_upload_env_override_respected` — `ZOTERO_WEBDAV_TIMEOUT=300`; Session sees `timeout=(10.0, 300.0)`.
- `test_upload_explicit_timeout_wins_over_env` — caller passes `timeout=45.0` with env var also set; explicit wins.

Env-var pattern mirrors #279's `_get_env_value` reads.