### PR TITLE
Add OpenAI Batch API embedding indexing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ ZOTERO_LIBRARY_TYPE=user
 
 # OpenAI API Key (用于语义搜索功能，可选)
 # OPENAI_API_KEY=your_openai_key_here
+# OpenAI embedding model and optional Batch API indexing are configured via:
+# zotero-mcp setup --semantic-config-only
 
 # Google Gemini API Key (可选)
 # GEMINI_API_KEY=your_gemini_key_here

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ zotero-mcp setup --semantic-config-only
 - **OpenAI**: Better quality, requires API key (`text-embedding-3-small` or `text-embedding-3-large`)
 - **Gemini**: Better quality, requires API key (`gemini-embedding-001`)
 
+When you choose OpenAI, setup also asks whether database updates should use
+OpenAI Batch API. Batch updates are cheaper for large libraries, but they are
+asynchronous: submit the batch, wait for completion, then import the embeddings.
+
 **Update Frequency Options:**
 - **Manual**: Update only when you run `zotero-mcp update-db`
 - **Auto on startup**: Update database every time the server starts
@@ -166,6 +170,16 @@ After setup, initialize your search database:
 ```bash
 # Build the semantic search database (fast, metadata-only)
 zotero-mcp update-db
+
+# Submit OpenAI embeddings through Batch API for this update
+zotero-mcp update-db --openai-batch
+
+# Check and import completed OpenAI Batch API embeddings
+zotero-mcp openai-batch-status
+zotero-mcp openai-batch-import
+
+# Force realtime OpenAI embeddings even if Batch API is enabled in config
+zotero-mcp update-db --no-openai-batch
 
 # Build with full-text extraction (slower, more comprehensive)
 zotero-mcp update-db --fulltext
@@ -310,6 +324,8 @@ zotero-mcp setup --no-local --api-key YOUR_API_KEY --library-id YOUR_LIBRARY_ID
 - `OPENAI_API_KEY`: Your OpenAI API key (for OpenAI embeddings)
 - `OPENAI_EMBEDDING_MODEL`: OpenAI model name (text-embedding-3-small, text-embedding-3-large)
 - `OPENAI_BASE_URL`: Custom OpenAI endpoint URL (optional, for use with compatible APIs)
+- OpenAI Batch API indexing is configured by `zotero-mcp setup` and can be overridden with
+  `zotero-mcp update-db --openai-batch` or `--no-openai-batch`
 - `GEMINI_API_KEY`: Your Gemini API key (for Gemini embeddings)
 - `GEMINI_EMBEDDING_MODEL`: Gemini model name (gemini-embedding-001)
 - `GEMINI_BASE_URL`: Custom Gemini endpoint URL (optional, for use with compatible APIs)
@@ -336,6 +352,10 @@ zotero-mcp update --force                  # Force update even if up to date
 
 # Semantic search database management
 zotero-mcp update-db                       # Update semantic search database (fast, metadata-only)
+zotero-mcp update-db --openai-batch        # Submit OpenAI embeddings through Batch API
+zotero-mcp update-db --no-openai-batch     # Force realtime OpenAI embeddings for this run
+zotero-mcp openai-batch-status             # Check latest OpenAI embedding batch status
+zotero-mcp openai-batch-import             # Import completed OpenAI batch embeddings
 zotero-mcp update-db --fulltext             # Update with full-text extraction (comprehensive but slower)
 zotero-mcp update-db --force-rebuild       # Force complete database rebuild
 zotero-mcp update-db --fulltext --force-rebuild  # Rebuild with full-text extraction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ semantic = [
     # used to register the custom OpenAI/Gemini/HF embedding functions (#315).
     "chromadb>=1.0.0",
     "sentence-transformers>=2.2.0",
-    "openai>=1.0.0",
+    "openai>=1.30.0",
     "google-genai>=0.7.0",
     "tiktoken>=0.7.0",
 ]

--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -6,10 +6,10 @@ for semantic search over Zotero libraries.
 """
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
-import logging
 
 try:
     import chromadb
@@ -513,6 +513,29 @@ class ChromaClient:
             logger.info(f"Upserted {len(documents)} documents to ChromaDB collection")
         except Exception as e:
             logger.error(f"Error upserting documents to ChromaDB: {e}")
+            raise
+
+    def upsert_embeddings(self,
+                         documents: list[str],
+                         metadatas: list[dict[str, Any]],
+                         ids: list[str],
+                         embeddings: list[list[float]]) -> None:
+        """
+        Upsert documents with precomputed embeddings.
+
+        Used by OpenAI Batch API imports so ChromaDB stores the vectors
+        returned asynchronously without calling the realtime embeddings API.
+        """
+        try:
+            self.collection.upsert(
+                documents=documents,
+                metadatas=metadatas,
+                ids=ids,
+                embeddings=embeddings,
+            )
+            logger.info(f"Upserted {len(documents)} precomputed embeddings to ChromaDB collection")
+        except Exception as e:
+            logger.error(f"Error upserting precomputed embeddings to ChromaDB: {e}")
             raise
 
     def search(self,

--- a/src/zotero_mcp/cli.py
+++ b/src/zotero_mcp/cli.py
@@ -145,6 +145,70 @@ def _save_zotero_db_path_to_config(config_path: Path, db_path: str) -> None:
         print(f"Warning: Could not save db_path to config: {e}")
 
 
+def _semantic_config_path(path_arg: str | None) -> Path:
+    return Path(path_arg) if path_arg else Path.home() / ".config" / "zotero-mcp" / "config.json"
+
+
+def _print_update_stats(stats: dict) -> None:
+    label = "OpenAI batch submission" if stats.get("batch_submitted") else "Database update"
+    print(f"\n{label} completed:")
+    print(f"- Total items: {stats.get('total_items', 0)}")
+    print(f"- Processed: {stats.get('processed_items', 0)}")
+    print(f"- Added: {stats.get('added_items', 0)}")
+    print(f"- Updated: {stats.get('updated_items', 0)}")
+    print(f"- Skipped: {stats.get('skipped_items', 0)}")
+    print(f"- Errors: {stats.get('errors', 0)}")
+    print(f"- Duration: {stats.get('duration', 'Unknown')}")
+    if stats.get("batch_submitted"):
+        print(f"- Batch run: {stats.get('batch_run_id')}")
+        print(f"- Manifest: {stats.get('batch_manifest')}")
+        for batch_id in stats.get("batch_ids", []):
+            print(f"- Batch ID: {batch_id}")
+        print("\nNext steps:")
+        print("  zotero-mcp openai-batch-status")
+        print("  zotero-mcp openai-batch-import")
+
+
+def _print_batch_status(status: dict) -> None:
+    print("=== OpenAI Batch Status ===")
+    print(f"Run: {status.get('run_id')}")
+    print(f"Model: {status.get('model')}")
+    print(f"Manifest: {status.get('manifest_path')}")
+    print(f"Force rebuild: {status.get('force_full_rebuild', False)}")
+    for batch in status.get("batches", []):
+        counts = batch.get("request_counts") or {}
+        if not isinstance(counts, dict):
+            counts = {}
+        print()
+        print(f"Batch: {batch.get('batch_id')}")
+        print(f"- Status: {batch.get('status')}")
+        print(f"- Requests: {batch.get('request_count', counts.get('total', 'Unknown'))}")
+        if counts:
+            print(f"- Completed: {counts.get('completed', 0)}")
+            print(f"- Failed: {counts.get('failed', 0)}")
+        print(f"- Imported: {batch.get('imported_at') or 'No'}")
+
+
+def _print_batch_import(stats: dict) -> None:
+    print("=== OpenAI Batch Import ===")
+    print(f"Run: {stats.get('run_id')}")
+    print(f"Manifest: {stats.get('manifest_path')}")
+    print(f"- Batches seen: {stats.get('batches_seen', 0)}")
+    print(f"- Batches imported: {stats.get('batches_imported', 0)}")
+    print(f"- Batches skipped: {stats.get('batches_skipped', 0)}")
+    print(f"- Imported items: {stats.get('imported_items', 0)}")
+    print(f"- Added: {stats.get('added_items', 0)}")
+    print(f"- Updated: {stats.get('updated_items', 0)}")
+    print(f"- Failed rows: {stats.get('failed_items', 0)}")
+    print(f"- Missing rows: {stats.get('missing_items', 0)}")
+    if stats.get("errors"):
+        print("\nWarnings/errors:")
+        for error in stats["errors"][:20]:
+            print(f"- {error}")
+        if len(stats["errors"]) > 20:
+            print(f"- ... {len(stats['errors']) - 20} more")
+
+
 def setup_zotero_environment():
     """Setup Zotero environment for CLI commands."""
     # Load standalone env first so global flags (e.g., ZOTERO_NO_CLAUDE) take effect
@@ -227,6 +291,25 @@ def main():
                                  help="Path to semantic search configuration file")
     update_db_parser.add_argument("--db-path",
                                  help="Path to Zotero database file (zotero.sqlite), overrides config")
+    openai_batch_group = update_db_parser.add_mutually_exclusive_group()
+    openai_batch_group.add_argument("--openai-batch", dest="openai_batch", action="store_true",
+                                   help="Submit OpenAI embeddings through the asynchronous Batch API")
+    openai_batch_group.add_argument("--no-openai-batch", dest="openai_batch", action="store_false",
+                                   help="Use realtime embeddings even if OpenAI Batch API is enabled in config")
+    update_db_parser.set_defaults(openai_batch=None)
+
+    # OpenAI batch lifecycle commands
+    batch_status_parser = subparsers.add_parser("openai-batch-status", help="Show OpenAI Batch API status")
+    batch_status_parser.add_argument("--batch-id", action="append",
+                                     help="Specific OpenAI batch ID to inspect; can be repeated")
+    batch_status_parser.add_argument("--config-path",
+                                     help="Path to semantic search configuration file")
+
+    batch_import_parser = subparsers.add_parser("openai-batch-import", help="Import completed OpenAI batch embeddings")
+    batch_import_parser.add_argument("--batch-id", action="append",
+                                     help="Specific OpenAI batch ID to import; can be repeated")
+    batch_import_parser.add_argument("--config-path",
+                                     help="Path to semantic search configuration file")
 
     # Database status command
     db_status_parser = subparsers.add_parser("db-status", help="Show semantic search database status")
@@ -251,10 +334,10 @@ def main():
                               help="Override auto-detected installation method")
 
     # Version command
-    version_parser = subparsers.add_parser("version", help="Print version information")
+    subparsers.add_parser("version", help="Print version information")
 
     # Setup info command
-    setup_info_parser = subparsers.add_parser("setup-info", help="Show installation path and configuration info for MCP clients")
+    subparsers.add_parser("setup-info", help="Show installation path and configuration info for MCP clients")
 
     args = parser.parse_args()
 
@@ -360,10 +443,12 @@ def main():
                 print(f"  Database path: {collection_info.get('persist_directory', 'Unknown')}")
 
                 update_config = status.get("update_config", {})
+                batch_config = status.get("openai_batch", {})
                 print(f"  Auto update: {update_config.get('auto_update', False)}")
                 print(f"  Update frequency: {update_config.get('update_frequency', 'manual')}")
                 print(f"  Last update: {update_config.get('last_update', 'Never')}")
                 print(f"  Should update: {status.get('should_update', False)}")
+                print(f"  OpenAI Batch API: {'active' if batch_config.get('active') else 'inactive'}")
 
                 if collection_info.get('error'):
                     print(f"  Error: {collection_info['error']}")
@@ -388,11 +473,7 @@ def main():
         from zotero_mcp.semantic_search import create_semantic_search
 
         # Determine config path
-        config_path = args.config_path
-        if not config_path:
-            config_path = Path.home() / ".config" / "zotero-mcp" / "config.json"
-        else:
-            config_path = Path(config_path)
+        config_path = _semantic_config_path(args.config_path)
 
         print(f"Using configuration: {config_path}")
 
@@ -406,6 +487,9 @@ def main():
         try:
             # Create semantic search instance with optional db_path override
             search = create_semantic_search(str(config_path), db_path=db_path)
+            if args.openai_batch is True and search.chroma_client.embedding_model != "openai":
+                print("Error: --openai-batch requires ZOTERO_EMBEDDING_MODEL=openai", file=sys.stderr)
+                sys.exit(1)
 
             print("Starting database update...")
             if args.fulltext:
@@ -422,17 +506,11 @@ def main():
             stats = search.update_database(
                 force_full_rebuild=args.force_rebuild,
                 limit=args.limit,
-                extract_fulltext=args.fulltext
+                extract_fulltext=args.fulltext,
+                use_openai_batch=args.openai_batch,
             )
 
-            print(f"\nDatabase update completed:")
-            print(f"- Total items: {stats.get('total_items', 0)}")
-            print(f"- Processed: {stats.get('processed_items', 0)}")
-            print(f"- Added: {stats.get('added_items', 0)}")
-            print(f"- Updated: {stats.get('updated_items', 0)}")
-            print(f"- Skipped: {stats.get('skipped_items', 0)}")
-            print(f"- Errors: {stats.get('errors', 0)}")
-            print(f"- Duration: {stats.get('duration', 'Unknown')}")
+            _print_update_stats(stats)
 
             if stats.get('error'):
                 print(f"Error: {stats['error']}")
@@ -440,6 +518,34 @@ def main():
 
         except Exception as e:
             print(f"Error updating database: {e}")
+            sys.exit(1)
+
+    elif args.command == "openai-batch-status":
+        setup_zotero_environment()
+
+        from zotero_mcp.semantic_search import create_semantic_search
+
+        config_path = _semantic_config_path(args.config_path)
+        try:
+            search = create_semantic_search(str(config_path))
+            status = search.get_openai_batch_status(batch_ids=args.batch_id)
+            _print_batch_status(status)
+        except Exception as e:
+            print(f"Error getting OpenAI batch status: {e}")
+            sys.exit(1)
+
+    elif args.command == "openai-batch-import":
+        setup_zotero_environment()
+
+        from zotero_mcp.semantic_search import create_semantic_search
+
+        config_path = _semantic_config_path(args.config_path)
+        try:
+            search = create_semantic_search(str(config_path))
+            stats = search.import_openai_batch(batch_ids=args.batch_id)
+            _print_batch_import(stats)
+        except Exception as e:
+            print(f"Error importing OpenAI batch: {e}")
             sys.exit(1)
 
     elif args.command == "db-status":
@@ -471,11 +577,13 @@ def main():
             print(f"Database path: {collection_info.get('persist_directory', 'Unknown')}")
 
             update_config = status.get("update_config", {})
-            print(f"\nUpdate configuration:")
+            batch_config = status.get("openai_batch", {})
+            print("\nUpdate configuration:")
             print(f"- Auto update: {update_config.get('auto_update', False)}")
             print(f"- Frequency: {update_config.get('update_frequency', 'manual')}")
             print(f"- Last update: {update_config.get('last_update', 'Never')}")
             print(f"- Should update: {status.get('should_update', False)}")
+            print(f"- OpenAI Batch API: {'active' if batch_config.get('active') else 'inactive'}")
 
             if collection_info.get('error'):
                 print(f"\nError: {collection_info['error']}")
@@ -488,8 +596,9 @@ def main():
         # Setup Zotero environment variables
         setup_zotero_environment()
 
-        from zotero_mcp.semantic_search import create_semantic_search
         from collections import Counter
+
+        from zotero_mcp.semantic_search import create_semantic_search
 
         # Determine config path
         config_path = args.config_path

--- a/src/zotero_mcp/cli.py
+++ b/src/zotero_mcp/cli.py
@@ -234,10 +234,27 @@ def setup_zotero_environment():
         apply_environment_variables(fallback_env_vars)
 
 
+def _normalize_help_args(argv: list[str]) -> list[str]:
+    """Support `zotero-mcp help [command]` in addition to argparse's `--help`."""
+    if not argv or argv[0] != "help":
+        return argv
+    if len(argv) == 1:
+        return ["--help"]
+    return [*argv[1:], "--help"]
+
+
 def main():
     """Main entry point for the CLI."""
     parser = argparse.ArgumentParser(
-        description="Zotero Model Context Protocol server"
+        description="Zotero Model Context Protocol server",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "OpenAI Batch API indexing:\n"
+            "  zotero-mcp update-db --openai-batch     Submit embeddings asynchronously\n"
+            "  zotero-mcp openai-batch-status          Check submitted batch status\n"
+            "  zotero-mcp openai-batch-import          Import completed embeddings\n"
+            "  zotero-mcp help update-db               Show update-db options\n"
+        ),
     )
 
     # Create subparsers for different commands
@@ -339,7 +356,7 @@ def main():
     # Setup info command
     subparsers.add_parser("setup-info", help="Show installation path and configuration info for MCP clients")
 
-    args = parser.parse_args()
+    args = parser.parse_args(_normalize_help_args(sys.argv[1:]))
 
     # If no command is provided, default to 'serve'
     if not args.command:

--- a/src/zotero_mcp/cli.py
+++ b/src/zotero_mcp/cli.py
@@ -150,12 +150,19 @@ def _semantic_config_path(path_arg: str | None) -> Path:
 
 
 def _print_update_stats(stats: dict) -> None:
-    label = "OpenAI batch submission" if stats.get("batch_submitted") else "Database update"
-    print(f"\n{label} completed:")
+    is_batch = stats.get("batch_mode") or stats.get("batch_submitted")
+    label = "OpenAI batch submission" if is_batch else "Database update"
+    outcome = "failed" if stats.get("error") else "completed"
+    print(f"\n{label} {outcome}:")
     print(f"- Total items: {stats.get('total_items', 0)}")
     print(f"- Processed: {stats.get('processed_items', 0)}")
-    print(f"- Added: {stats.get('added_items', 0)}")
-    print(f"- Updated: {stats.get('updated_items', 0)}")
+    if stats.get("batch_submitted"):
+        print(f"- Submitted: {stats.get('submitted_items', 0)}")
+        print(f"- Estimated new items: {stats.get('estimated_added_items', 0)}")
+        print(f"- Estimated existing items: {stats.get('estimated_updated_items', 0)}")
+    else:
+        print(f"- Added: {stats.get('added_items', 0)}")
+        print(f"- Updated: {stats.get('updated_items', 0)}")
     print(f"- Skipped: {stats.get('skipped_items', 0)}")
     print(f"- Errors: {stats.get('errors', 0)}")
     print(f"- Duration: {stats.get('duration', 'Unknown')}")

--- a/src/zotero_mcp/cli_standalone.py
+++ b/src/zotero_mcp/cli_standalone.py
@@ -19,6 +19,9 @@ import sys
 
 # Reuse environment setup from the original CLI module
 from zotero_mcp.cli import (
+    _print_batch_import,
+    _print_batch_status,
+    _print_update_stats,
     obfuscate_config_for_display,
     setup_zotero_environment,
 )
@@ -363,6 +366,9 @@ def cmd_db(args):
         if db_path:
             _save_zotero_db_path_to_config(config_path, db_path)
         search = create_semantic_search(str(config_path), db_path=db_path)
+        if getattr(args, "openai_batch", None) is True and search.chroma_client.embedding_model != "openai":
+            print("Error: --openai-batch requires ZOTERO_EMBEDDING_MODEL=openai", file=sys.stderr)
+            sys.exit(1)
         fulltext = getattr(args, "fulltext", False)
         if fulltext:
             from zotero_mcp.utils import is_local_mode
@@ -373,24 +379,29 @@ def cmd_db(args):
             force_full_rebuild=args.force_rebuild,
             limit=args.limit,
             extract_fulltext=fulltext,
+            use_openai_batch=getattr(args, "openai_batch", None),
         )
-        print("Database update completed:")
-        print(f"- Total items: {stats.get('total_items', 0)}")
-        print(f"- Processed: {stats.get('processed_items', 0)}")
-        print(f"- Added: {stats.get('added_items', 0)}")
-        print(f"- Updated: {stats.get('updated_items', 0)}")
-        print(f"- Skipped: {stats.get('skipped_items', 0)}")
-        print(f"- Errors: {stats.get('errors', 0)}")
-        print(f"- Duration: {stats.get('duration', 'Unknown')}")
+        _print_update_stats(stats)
         if stats.get("error"):
             print(f"Error: {stats['error']}", file=sys.stderr)
             sys.exit(1)
+
+    elif args.subcommand == "batch-status":
+        search = create_semantic_search(str(config_path))
+        status = search.get_openai_batch_status(batch_ids=getattr(args, "batch_id", None))
+        _print_batch_status(status)
+
+    elif args.subcommand == "batch-import":
+        search = create_semantic_search(str(config_path))
+        stats = search.import_openai_batch(batch_ids=getattr(args, "batch_id", None))
+        _print_batch_import(stats)
 
     elif args.subcommand == "status":
         search = create_semantic_search(str(config_path))
         status = search.get_database_status()
         ci = status.get("collection_info", {})
         uc = status.get("update_config", {})
+        bc = status.get("openai_batch", {})
         print("=== Semantic Search Database Status ===")
         print(f"Collection: {ci.get('name', 'Unknown')}")
         print(f"Document count: {ci.get('count', 0)}")
@@ -401,6 +412,7 @@ def cmd_db(args):
         print(f"- Frequency: {uc.get('update_frequency', 'manual')}")
         print(f"- Last update: {uc.get('last_update', 'Never')}")
         print(f"- Should update: {status.get('should_update', False)}")
+        print(f"- OpenAI Batch API: {'active' if bc.get('active') else 'inactive'}")
         if ci.get("error"):
             print(f"\nError: {ci['error']}")
 
@@ -700,6 +712,16 @@ def build_parser() -> argparse.ArgumentParser:
     dbu.add_argument("--fulltext", action="store_true")
     dbu.add_argument("--config-path")
     dbu.add_argument("--db-path")
+    dbu_batch = dbu.add_mutually_exclusive_group()
+    dbu_batch.add_argument("--openai-batch", dest="openai_batch", action="store_true")
+    dbu_batch.add_argument("--no-openai-batch", dest="openai_batch", action="store_false")
+    dbu.set_defaults(openai_batch=None)
+    dbbs = db_sub.add_parser("batch-status")
+    dbbs.add_argument("--batch-id", action="append")
+    dbbs.add_argument("--config-path")
+    dbbi = db_sub.add_parser("batch-import")
+    dbbi.add_argument("--batch-id", action="append")
+    dbbi.add_argument("--config-path")
     dbs = db_sub.add_parser("status")
     dbs.add_argument("--config-path")
     dbi = db_sub.add_parser("inspect")

--- a/src/zotero_mcp/openai_batch.py
+++ b/src/zotero_mcp/openai_batch.py
@@ -1,0 +1,336 @@
+"""OpenAI Batch API helpers for semantic-search embeddings.
+
+The Batch API is asynchronous, so this module owns the local run manifests that
+tie OpenAI batch IDs back to the document text and metadata needed for ChromaDB.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+OPENAI_BATCH_ENDPOINT = "/v1/embeddings"
+OPENAI_BATCH_COMPLETION_WINDOW = "24h"
+OPENAI_BATCH_MAX_REQUESTS = 50_000
+OPENAI_BATCH_MAX_FILE_BYTES = 200 * 1024 * 1024
+
+
+def _private_chmod(path: Path) -> None:
+    try:
+        os.chmod(path, 0o600 if path.is_file() else 0o700)
+    except OSError:
+        pass
+
+
+def _json_dumps(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+
+
+def _object_attr(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, list | tuple):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if hasattr(value, "model_dump"):
+        return _jsonable(value.model_dump())
+    if hasattr(value, "to_dict"):
+        return _jsonable(value.to_dict())
+    if hasattr(value, "__dict__"):
+        return _jsonable(vars(value))
+    return str(value)
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def get_openai_batch_root(config_path: str | None = None) -> Path:
+    """Return the directory used to store OpenAI batch manifests."""
+    if config_path:
+        root = Path(config_path).expanduser().parent / "openai_batches"
+    else:
+        root = Path.home() / ".config" / "zotero-mcp" / "openai_batches"
+    root.mkdir(parents=True, exist_ok=True)
+    _private_chmod(root)
+    return root
+
+
+def create_openai_client(embedding_config: dict[str, Any] | None = None) -> Any:
+    """Build an OpenAI client from semantic embedding config and environment."""
+    embedding_config = embedding_config or {}
+    api_key = embedding_config.get("api_key") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OpenAI API key is required for Batch API embeddings")
+
+    try:
+        import openai
+    except ImportError as exc:
+        raise ImportError("openai package is required for OpenAI Batch API embeddings") from exc
+
+    client_kwargs: dict[str, Any] = {"api_key": api_key}
+    base_url = embedding_config.get("base_url") or os.getenv("OPENAI_BASE_URL")
+    if base_url:
+        client_kwargs["base_url"] = base_url
+    return openai.OpenAI(**client_kwargs)
+
+
+def build_embedding_request(record: dict[str, Any], model_name: str) -> dict[str, Any]:
+    """Build one JSONL request object for the OpenAI embeddings endpoint."""
+    return {
+        "custom_id": record["id"],
+        "method": "POST",
+        "url": OPENAI_BATCH_ENDPOINT,
+        "body": {
+            "model": model_name,
+            "input": record["document"],
+            "encoding_format": "float",
+        },
+    }
+
+
+def split_embedding_records(
+    records: list[dict[str, Any]],
+    model_name: str,
+    max_requests: int = OPENAI_BATCH_MAX_REQUESTS,
+    max_file_bytes: int = OPENAI_BATCH_MAX_FILE_BYTES,
+) -> list[tuple[list[dict[str, Any]], list[dict[str, Any]]]]:
+    """Split records into JSONL-sized chunks accepted by the Batch API."""
+    chunks: list[tuple[list[dict[str, Any]], list[dict[str, Any]]]] = []
+    current_records: list[dict[str, Any]] = []
+    current_requests: list[dict[str, Any]] = []
+    current_bytes = 0
+
+    for record in records:
+        request = build_embedding_request(record, model_name)
+        line_bytes = len((_json_dumps(request) + "\n").encode("utf-8"))
+        if line_bytes > max_file_bytes:
+            raise ValueError(f"OpenAI batch request for {record['id']} exceeds the 200 MB file limit")
+
+        would_exceed_count = len(current_requests) >= max_requests
+        would_exceed_bytes = current_requests and current_bytes + line_bytes > max_file_bytes
+        if would_exceed_count or would_exceed_bytes:
+            chunks.append((current_records, current_requests))
+            current_records = []
+            current_requests = []
+            current_bytes = 0
+
+        current_records.append(record)
+        current_requests.append(request)
+        current_bytes += line_bytes
+
+    if current_requests:
+        chunks.append((current_records, current_requests))
+
+    return chunks
+
+
+def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(_json_dumps(row) + "\n")
+    _private_chmod(path)
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                rows.append(json.loads(line))
+    return rows
+
+
+def save_manifest(manifest: dict[str, Any]) -> None:
+    manifest_path = Path(manifest["manifest_path"])
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+    _private_chmod(manifest_path)
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as f:
+        manifest = json.load(f)
+    manifest["manifest_path"] = str(path)
+    return manifest
+
+
+def iter_manifests(config_path: str | None = None) -> list[Path]:
+    root = get_openai_batch_root(config_path)
+    return sorted(root.glob("*/manifest.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+
+
+def find_manifest(config_path: str | None = None, batch_id: str | None = None) -> dict[str, Any]:
+    """Find the newest manifest, or the manifest that contains a batch ID."""
+    for path in iter_manifests(config_path):
+        manifest = load_manifest(path)
+        if batch_id is None:
+            return manifest
+        if any(batch.get("batch_id") == batch_id for batch in manifest.get("batches", [])):
+            return manifest
+    if batch_id:
+        raise FileNotFoundError(f"No OpenAI batch manifest found for batch ID {batch_id}")
+    raise FileNotFoundError("No OpenAI batch manifests found")
+
+
+def submit_embedding_batches(
+    records: list[dict[str, Any]],
+    model_name: str,
+    embedding_config: dict[str, Any] | None,
+    config_path: str | None = None,
+    force_full_rebuild: bool = False,
+    target_sync_version: int | None = None,
+    client: Any | None = None,
+) -> dict[str, Any]:
+    """Upload JSONL files and create one or more OpenAI embedding batches."""
+    if not records:
+        raise ValueError("No documents were prepared for OpenAI Batch API submission")
+
+    client = client or create_openai_client(embedding_config)
+    root = get_openai_batch_root(config_path)
+    run_id = f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}-{uuid.uuid4().hex[:8]}"
+    run_dir = root / run_id
+    run_dir.mkdir(parents=True, exist_ok=False)
+    _private_chmod(run_dir)
+
+    manifest: dict[str, Any] = {
+        "version": 1,
+        "run_id": run_id,
+        "created_at": _utc_now(),
+        "endpoint": OPENAI_BATCH_ENDPOINT,
+        "completion_window": OPENAI_BATCH_COMPLETION_WINDOW,
+        "model": model_name,
+        "force_full_rebuild": bool(force_full_rebuild),
+        "target_sync_version": target_sync_version,
+        "manifest_path": str(run_dir / "manifest.json"),
+        "batches": [],
+    }
+
+    chunks = split_embedding_records(records, model_name)
+    for index, (chunk_records, requests) in enumerate(chunks, start=1):
+        stem = f"batch-{index:03d}"
+        input_path = run_dir / f"{stem}-input.jsonl"
+        records_path = run_dir / f"{stem}-records.jsonl"
+        write_jsonl(input_path, requests)
+        write_jsonl(records_path, chunk_records)
+
+        with open(input_path, "rb") as input_file:
+            input_file_obj = client.files.create(file=input_file, purpose="batch")
+        input_file_id = _object_attr(input_file_obj, "id")
+
+        batch_obj = client.batches.create(
+            input_file_id=input_file_id,
+            endpoint=OPENAI_BATCH_ENDPOINT,
+            completion_window=OPENAI_BATCH_COMPLETION_WINDOW,
+            metadata={
+                "zotero_mcp_run_id": run_id,
+                "zotero_mcp_chunk": str(index),
+            },
+        )
+
+        manifest["batches"].append(
+            {
+                "batch_id": _object_attr(batch_obj, "id"),
+                "input_file_id": input_file_id,
+                "status": _object_attr(batch_obj, "status", "validating"),
+                "output_file_id": _object_attr(batch_obj, "output_file_id"),
+                "error_file_id": _object_attr(batch_obj, "error_file_id"),
+                "request_counts": _jsonable(_object_attr(batch_obj, "request_counts")),
+                "input_path": str(input_path),
+                "records_path": str(records_path),
+                "request_count": len(requests),
+                "imported_at": None,
+                "imported_count": 0,
+            }
+        )
+        save_manifest(manifest)
+
+    return manifest
+
+
+def refresh_manifest_status(
+    manifest: dict[str, Any],
+    embedding_config: dict[str, Any] | None,
+    batch_ids: set[str] | None = None,
+    client: Any | None = None,
+) -> dict[str, Any]:
+    """Retrieve current OpenAI status for selected batches and persist it."""
+    client = client or create_openai_client(embedding_config)
+    for batch in manifest.get("batches", []):
+        if batch_ids and batch.get("batch_id") not in batch_ids:
+            continue
+        batch_obj = client.batches.retrieve(batch["batch_id"])
+        batch["status"] = _object_attr(batch_obj, "status", batch.get("status"))
+        batch["output_file_id"] = _object_attr(batch_obj, "output_file_id", batch.get("output_file_id"))
+        batch["error_file_id"] = _object_attr(batch_obj, "error_file_id", batch.get("error_file_id"))
+        batch["request_counts"] = _jsonable(_object_attr(batch_obj, "request_counts", batch.get("request_counts")))
+    save_manifest(manifest)
+    return manifest
+
+
+def content_to_text(content: Any) -> str:
+    text = getattr(content, "text", None)
+    if callable(text):
+        text = text()
+    if isinstance(text, str):
+        return text
+    if hasattr(content, "read"):
+        content = content.read()
+    if isinstance(content, bytes | bytearray):
+        return bytes(content).decode("utf-8")
+    return str(content)
+
+
+def download_file_text(client: Any, file_id: str, output_path: Path) -> str:
+    content = client.files.content(file_id)
+    text = content_to_text(content)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(text)
+    _private_chmod(output_path)
+    return text
+
+
+def parse_embedding_output(text: str) -> tuple[dict[str, list[float]], list[dict[str, Any]]]:
+    """Parse a Batch API output file into embeddings keyed by custom_id."""
+    embeddings: dict[str, list[float]] = {}
+    failures: list[dict[str, Any]] = []
+    for raw_line in text.splitlines():
+        if not raw_line.strip():
+            continue
+        row = json.loads(raw_line)
+        custom_id = row.get("custom_id")
+        response = row.get("response") or {}
+        error = row.get("error")
+        status_code = response.get("status_code")
+        if error or status_code != 200:
+            failures.append({"custom_id": custom_id, "error": error, "status_code": status_code})
+            continue
+        try:
+            embedding = response["body"]["data"][0]["embedding"]
+        except (KeyError, IndexError, TypeError) as exc:
+            failures.append({"custom_id": custom_id, "error": f"Could not parse embedding: {exc}"})
+            continue
+        if custom_id:
+            embeddings[custom_id] = embedding
+    return embeddings, failures
+
+
+def parse_error_output(text: str) -> list[dict[str, Any]]:
+    failures: list[dict[str, Any]] = []
+    for raw_line in text.splitlines():
+        if raw_line.strip():
+            row = json.loads(raw_line)
+            failures.append({"custom_id": row.get("custom_id"), "error": row.get("error")})
+    return failures

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -23,10 +23,11 @@ except Exception:
     _tokenizer = None
 
 
+from . import openai_batch
 from .chroma_client import ChromaClient, create_chroma_client
 from .client import get_zotero_client
 from .local_db import LocalZoteroReader
-from .utils import format_creators, is_local_mode
+from .utils import format_creators, is_local_mode, suppress_stdout
 
 logger = logging.getLogger(__name__)
 
@@ -62,10 +63,6 @@ def _acquire_update_lock(lock_path: Path):
     finally:
         if fd is not None:
             fd.close()
-
-
-from zotero_mcp.utils import suppress_stdout
-
 
 def _truncate_to_tokens(text: str, max_tokens: int = 8000) -> str:
     """Truncate text to fit within embedding model token limit.
@@ -194,6 +191,29 @@ class ZoteroSemanticSearch:
         except Exception as e:
             logger.warning(f"Error loading include_fulltext setting: {e}")
             return True
+
+    def _load_openai_batch_enabled(self) -> bool:
+        """Whether OpenAI Batch API indexing is enabled by semantic config."""
+        if not self.config_path or not os.path.exists(self.config_path):
+            return False
+        try:
+            with open(self.config_path) as f:
+                file_config = json.load(f)
+                value = (
+                    file_config
+                    .get("semantic_search", {})
+                    .get("openai_batch", {})
+                    .get("enabled", False)
+                )
+                return bool(value)
+        except Exception as e:
+            logger.warning(f"Error loading OpenAI batch setting: {e}")
+            return False
+
+    def _resolve_openai_batch_enabled(self, use_openai_batch: bool | None) -> bool:
+        """Resolve CLI override + config default for OpenAI batch indexing."""
+        requested = self._load_openai_batch_enabled() if use_openai_batch is None else use_openai_batch
+        return bool(requested and self.chroma_client.embedding_model == "openai")
 
     def _load_last_sync_version(self) -> int:
         """Last Zotero library version fully indexed into ChromaDB.
@@ -1030,11 +1050,85 @@ class ZoteroSemanticSearch:
 
         return changed_items, current_keys
 
+    def _prepare_index_records(self, items: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, int]]:
+        """Prepare ChromaDB records without embedding or writing them."""
+        stats = {"processed": 0, "skipped": 0, "errors": 0}
+        records: list[dict[str, Any]] = []
+
+        for item in items:
+            try:
+                item_key = item.get("key", "")
+                if not item_key:
+                    stats["skipped"] += 1
+                    continue
+
+                fulltext = item.get("data", {}).get("fulltext", "")
+                structured_text = self._create_document_text(item)
+                if fulltext.strip():
+                    doc_text = (structured_text + "\n\n" + fulltext) if structured_text.strip() else fulltext
+                else:
+                    doc_text = structured_text
+                metadata = self._create_metadata(item)
+
+                if not doc_text.strip():
+                    stats["skipped"] += 1
+                    continue
+
+                doc_text = self.chroma_client.truncate_text(doc_text)
+                records.append({"id": item_key, "document": doc_text, "metadata": metadata})
+                stats["processed"] += 1
+
+            except Exception as e:
+                logger.error(f"Error processing item {item.get('key', 'unknown')}: {e}")
+                stats["errors"] += 1
+
+        return records, stats
+
+    def _submit_openai_batch_index(
+        self,
+        items: list[dict[str, Any]],
+        force_full_rebuild: bool,
+        target_sync_version: int | None,
+        stats: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Prepare records and submit asynchronous OpenAI embedding batches."""
+        records, prepare_stats = self._prepare_index_records(items)
+        stats["processed_items"] += prepare_stats["processed"]
+        stats["skipped_items"] += prepare_stats["skipped"]
+        stats["errors"] += prepare_stats["errors"]
+
+        ids = [record["id"] for record in records]
+        existing_ids = self.chroma_client.get_existing_ids(ids) if ids and not force_full_rebuild else set()
+        stats["updated_items"] += len(existing_ids)
+        stats["added_items"] += len(ids) - len(existing_ids)
+
+        if not records:
+            stats["batch_submitted"] = False
+            stats["batch_error"] = "No documents were prepared for OpenAI Batch API submission"
+            return stats
+
+        model_name = self.chroma_client.embedding_config.get("model_name", "text-embedding-3-small")
+        manifest = openai_batch.submit_embedding_batches(
+            records=records,
+            model_name=model_name,
+            embedding_config=self.chroma_client.embedding_config,
+            config_path=self.config_path,
+            force_full_rebuild=force_full_rebuild,
+            target_sync_version=target_sync_version,
+        )
+        stats["batch_submitted"] = True
+        stats["batch_run_id"] = manifest["run_id"]
+        stats["batch_manifest"] = manifest["manifest_path"]
+        stats["batch_ids"] = [batch["batch_id"] for batch in manifest.get("batches", [])]
+        stats["submitted_items"] = len(records)
+        return stats
+
     def update_database(self,
                        force_full_rebuild: bool = False,
                        limit: int | None = None,
                        extract_fulltext: bool = False,
-                       include_fulltext: bool | None = None) -> dict[str, Any]:
+                       include_fulltext: bool | None = None,
+                       use_openai_batch: bool | None = None) -> dict[str, Any]:
         """
         Update the semantic search database with Zotero items.
 
@@ -1048,6 +1142,8 @@ class ZoteroSemanticSearch:
                 `semantic_search.include_fulltext` config setting (True
                 unless explicitly disabled). Ignored in local mode since
                 `extract_fulltext` provides richer local extraction.
+            use_openai_batch: Override for OpenAI Batch API indexing. None
+                uses `semantic_search.openai_batch.enabled`.
 
         Returns:
             Update statistics
@@ -1094,9 +1190,11 @@ class ZoteroSemanticSearch:
             # Web-API fulltext only applies when not using the local sqlite
             # extractor (extract_fulltext=True takes precedence in local mode)
             include_fulltext_via_api = include_fulltext and not extract_fulltext
+            use_openai_batch = self._resolve_openai_batch_enabled(use_openai_batch)
 
-            # Reset collection if force rebuild
-            if force_full_rebuild:
+            # In batch mode, defer destructive rebuilds until import so the
+            # existing search index remains usable while the batch runs.
+            if force_full_rebuild and not use_openai_batch:
                 logger.info("Force rebuilding database...")
                 self.chroma_client.reset_collection()
 
@@ -1181,6 +1279,34 @@ class ZoteroSemanticSearch:
 
             stats["total_items"] = len(all_items)
             logger.info(f"Found {stats['total_items']} items to process")
+
+            if use_openai_batch:
+                try:
+                    sys.stderr.write(f"\nSubmitting {len(all_items)} items to OpenAI Batch API...\n")
+                    sys.stderr.flush()
+                except Exception:
+                    pass
+                stats = self._submit_openai_batch_index(
+                    all_items,
+                    force_full_rebuild=force_full_rebuild,
+                    target_sync_version=target_sync_version,
+                    stats=stats,
+                )
+                try:
+                    batch_ids = ", ".join(stats.get("batch_ids", []))
+                    sys.stderr.write(
+                        "  Submitted OpenAI embedding batch"
+                        f"{'es' if len(stats.get('batch_ids', [])) != 1 else ''}: {batch_ids}\n"
+                    )
+                    sys.stderr.write("  Run 'zotero-mcp openai-batch-status' to check progress.\n")
+                    sys.stderr.write("  Run 'zotero-mcp openai-batch-import' after the batch completes.\n")
+                except Exception:
+                    pass
+                end_time = datetime.now()
+                stats["duration"] = str(end_time - start_time)
+                stats["end_time"] = end_time.isoformat()
+                return stats
+
             # User-friendly progress reporting
             total = stats['total_items'] = len(all_items)
             try:
@@ -1307,43 +1433,14 @@ class ZoteroSemanticSearch:
         """
         stats = {"processed": 0, "added": 0, "updated": 0, "skipped": 0, "errors": 0}
 
-        documents = []
-        metadatas = []
-        ids = []
+        records, prepare_stats = self._prepare_index_records(items)
+        stats["processed"] += prepare_stats["processed"]
+        stats["skipped"] += prepare_stats["skipped"]
+        stats["errors"] += prepare_stats["errors"]
 
-        for item in items:
-            try:
-                item_key = item.get("key", "")
-                if not item_key:
-                    stats["skipped"] += 1
-                    continue
-
-                # Create document text and metadata
-                # Always include structured fields; append fulltext when available
-                fulltext = item.get("data", {}).get("fulltext", "")
-                structured_text = self._create_document_text(item)
-                if fulltext.strip():
-                    doc_text = (structured_text + "\n\n" + fulltext) if structured_text.strip() else fulltext
-                else:
-                    doc_text = structured_text
-                metadata = self._create_metadata(item)
-
-                if not doc_text.strip():
-                    stats["skipped"] += 1
-                    continue
-
-                # Truncate to fit the configured embedding model's token limit
-                doc_text = self.chroma_client.truncate_text(doc_text)
-
-                documents.append(doc_text)
-                metadatas.append(metadata)
-                ids.append(item_key)
-
-                stats["processed"] += 1
-
-            except Exception as e:
-                logger.error(f"Error processing item {item.get('key', 'unknown')}: {e}")
-                stats["errors"] += 1
+        documents = [record["document"] for record in records]
+        metadatas = [record["metadata"] for record in records]
+        ids = [record["id"] for record in records]
 
         # Add documents to ChromaDB if any
         if documents:
@@ -1375,6 +1472,161 @@ class ZoteroSemanticSearch:
                     raise
 
         return stats
+
+    def get_openai_batch_status(self, batch_ids: list[str] | None = None) -> dict[str, Any]:
+        """Refresh and return OpenAI Batch API status for the latest run or selected batches."""
+        selected_ids = set(batch_ids or [])
+        manifest = openai_batch.find_manifest(
+            config_path=self.config_path,
+            batch_id=next(iter(selected_ids), None),
+        )
+        manifest = openai_batch.refresh_manifest_status(
+            manifest,
+            embedding_config=self.chroma_client.embedding_config,
+            batch_ids=selected_ids or None,
+        )
+        batches = [
+            batch for batch in manifest.get("batches", [])
+            if not selected_ids or batch.get("batch_id") in selected_ids
+        ]
+        missing_ids = selected_ids - {batch.get("batch_id") for batch in batches}
+        if missing_ids:
+            raise FileNotFoundError(f"No OpenAI batch manifest entries found for: {', '.join(sorted(missing_ids))}")
+        return {
+            "run_id": manifest.get("run_id"),
+            "manifest_path": manifest.get("manifest_path"),
+            "model": manifest.get("model"),
+            "force_full_rebuild": manifest.get("force_full_rebuild", False),
+            "batches": batches,
+        }
+
+    def import_openai_batch(self, batch_ids: list[str] | None = None) -> dict[str, Any]:
+        """Import completed OpenAI Batch API embeddings into ChromaDB."""
+        selected_ids = set(batch_ids or [])
+        manifest = openai_batch.find_manifest(
+            config_path=self.config_path,
+            batch_id=next(iter(selected_ids), None),
+        )
+        manifest = openai_batch.refresh_manifest_status(
+            manifest,
+            embedding_config=self.chroma_client.embedding_config,
+            batch_ids=selected_ids or None,
+        )
+
+        all_batches = manifest.get("batches", [])
+        batches = [
+            batch for batch in all_batches
+            if not selected_ids or batch.get("batch_id") in selected_ids
+        ]
+        missing_ids = selected_ids - {batch.get("batch_id") for batch in batches}
+        if missing_ids:
+            raise FileNotFoundError(f"No OpenAI batch manifest entries found for: {', '.join(sorted(missing_ids))}")
+        if not batches:
+            raise ValueError("No matching OpenAI batches found in the local manifest")
+        if manifest.get("force_full_rebuild") and selected_ids and len(batches) != len(all_batches):
+            raise RuntimeError("Force-rebuild OpenAI batch runs must be imported as a complete run")
+        if manifest.get("force_full_rebuild"):
+            incomplete = [
+                batch.get("batch_id")
+                for batch in all_batches
+                if not batch.get("imported_at") and batch.get("status") != "completed"
+            ]
+            if incomplete:
+                raise RuntimeError(
+                    "Force-rebuild OpenAI batch runs can only be imported after all batches complete: "
+                    + ", ".join(incomplete)
+                )
+
+        stats = {
+            "run_id": manifest.get("run_id"),
+            "manifest_path": manifest.get("manifest_path"),
+            "batches_seen": len(batches),
+            "batches_imported": 0,
+            "batches_skipped": 0,
+            "imported_items": 0,
+            "added_items": 0,
+            "updated_items": 0,
+            "failed_items": 0,
+            "missing_items": 0,
+            "errors": [],
+        }
+
+        lock_path = Path.home() / ".config" / "zotero-mcp" / "update.lock"
+        lock_cm = _acquire_update_lock(lock_path)
+        acquired = lock_cm.__enter__()
+        if not acquired:
+            lock_cm.__exit__(None, None, None)
+            raise RuntimeError(f"Another semantic-search update is already running (lock held at {lock_path})")
+
+        try:
+            already_imported = any(batch.get("imported_at") for batch in all_batches)
+            if (
+                manifest.get("force_full_rebuild")
+                and not already_imported
+                and any(not batch.get("imported_at") for batch in batches)
+            ):
+                self.chroma_client.reset_collection()
+
+            client = openai_batch.create_openai_client(self.chroma_client.embedding_config)
+            for batch in batches:
+                if batch.get("imported_at"):
+                    stats["batches_skipped"] += 1
+                    continue
+                if batch.get("status") != "completed":
+                    stats["batches_skipped"] += 1
+                    stats["errors"].append({
+                        "batch_id": batch.get("batch_id"),
+                        "error": f"Batch status is {batch.get('status')}, not completed",
+                    })
+                    continue
+                output_file_id = batch.get("output_file_id")
+                if not output_file_id:
+                    stats["batches_skipped"] += 1
+                    stats["errors"].append({"batch_id": batch.get("batch_id"), "error": "Missing output_file_id"})
+                    continue
+
+                output_path = Path(batch["records_path"]).with_name(Path(batch["records_path"]).stem + "-output.jsonl")
+                if output_path.exists():
+                    output_text = output_path.read_text(encoding="utf-8")
+                else:
+                    output_text = openai_batch.download_file_text(client, output_file_id, output_path)
+                embeddings_by_id, row_failures = openai_batch.parse_embedding_output(output_text)
+
+                if batch.get("error_file_id"):
+                    error_path = Path(batch["records_path"]).with_name(Path(batch["records_path"]).stem + "-errors.jsonl")
+                    error_text = openai_batch.download_file_text(client, batch["error_file_id"], error_path)
+                    row_failures.extend(openai_batch.parse_error_output(error_text))
+
+                records = {record["id"]: record for record in openai_batch.read_jsonl(Path(batch["records_path"]))}
+                ids = [doc_id for doc_id in embeddings_by_id if doc_id in records]
+                missing_ids = [doc_id for doc_id in embeddings_by_id if doc_id not in records]
+                stats["missing_items"] += len(missing_ids)
+                stats["failed_items"] += len(row_failures)
+                stats["errors"].extend(row_failures)
+
+                if ids:
+                    existing_ids = self.chroma_client.get_existing_ids(ids)
+                    self.chroma_client.upsert_embeddings(
+                        documents=[records[doc_id]["document"] for doc_id in ids],
+                        metadatas=[records[doc_id]["metadata"] for doc_id in ids],
+                        ids=ids,
+                        embeddings=[embeddings_by_id[doc_id] for doc_id in ids],
+                    )
+                    stats["imported_items"] += len(ids)
+                    stats["updated_items"] += len(existing_ids)
+                    stats["added_items"] += len(ids) - len(existing_ids)
+
+                batch["imported_at"] = datetime.now().isoformat()
+                batch["imported_count"] = len(ids)
+                stats["batches_imported"] += 1
+
+            openai_batch.save_manifest(manifest)
+            if all(batch.get("imported_at") for batch in all_batches):
+                self.update_config["last_update"] = datetime.now().isoformat()
+                self._save_update_config(last_sync_version=manifest.get("target_sync_version"))
+            return stats
+        finally:
+            lock_cm.__exit__(None, None, None)
 
     def search(self,
                query: str,
@@ -1485,6 +1737,10 @@ class ZoteroSemanticSearch:
         return {
             "collection_info": collection_info,
             "update_config": self.update_config,
+            "openai_batch": {
+                "enabled": self._load_openai_batch_enabled(),
+                "active": self._resolve_openai_batch_enabled(None),
+            },
             "should_update": self.should_update_database(),
             "last_update": self.update_config.get("last_update"),
         }

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -1097,16 +1097,13 @@ class ZoteroSemanticSearch:
         stats["skipped_items"] += prepare_stats["skipped"]
         stats["errors"] += prepare_stats["errors"]
 
-        ids = [record["id"] for record in records]
-        existing_ids = self.chroma_client.get_existing_ids(ids) if ids and not force_full_rebuild else set()
-        stats["updated_items"] += len(existing_ids)
-        stats["added_items"] += len(ids) - len(existing_ids)
-
         if not records:
             stats["batch_submitted"] = False
             stats["batch_error"] = "No documents were prepared for OpenAI Batch API submission"
             return stats
 
+        ids = [record["id"] for record in records]
+        existing_ids = self.chroma_client.get_existing_ids(ids) if ids and not force_full_rebuild else set()
         model_name = self.chroma_client.embedding_config.get("model_name", "text-embedding-3-small")
         manifest = openai_batch.submit_embedding_batches(
             records=records,
@@ -1121,6 +1118,8 @@ class ZoteroSemanticSearch:
         stats["batch_manifest"] = manifest["manifest_path"]
         stats["batch_ids"] = [batch["batch_id"] for batch in manifest.get("batches", [])]
         stats["submitted_items"] = len(records)
+        stats["estimated_updated_items"] = len(existing_ids)
+        stats["estimated_added_items"] = len(ids) - len(existing_ids)
         return stats
 
     def update_database(self,
@@ -1281,6 +1280,7 @@ class ZoteroSemanticSearch:
             logger.info(f"Found {stats['total_items']} items to process")
 
             if use_openai_batch:
+                stats["batch_mode"] = True
                 try:
                     sys.stderr.write(f"\nSubmitting {len(all_items)} items to OpenAI Batch API...\n")
                     sys.stderr.flush()

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -1599,10 +1599,28 @@ class ZoteroSemanticSearch:
 
                 records = {record["id"]: record for record in openai_batch.read_jsonl(Path(batch["records_path"]))}
                 ids = [doc_id for doc_id in embeddings_by_id if doc_id in records]
-                missing_ids = [doc_id for doc_id in embeddings_by_id if doc_id not in records]
-                stats["missing_items"] += len(missing_ids)
+                unexpected_output_ids = [doc_id for doc_id in embeddings_by_id if doc_id not in records]
+                failure_ids = {
+                    failure.get("custom_id")
+                    for failure in row_failures
+                    if failure.get("custom_id")
+                }
+                missing_result_ids = [
+                    doc_id
+                    for doc_id in records
+                    if doc_id not in embeddings_by_id and doc_id not in failure_ids
+                ]
+                missing_errors = [
+                    {"custom_id": doc_id, "error": "Batch output returned an embedding for an unknown record"}
+                    for doc_id in unexpected_output_ids
+                ] + [
+                    {"custom_id": doc_id, "error": "No embedding or error row returned for batch record"}
+                    for doc_id in missing_result_ids
+                ]
+                stats["missing_items"] += len(unexpected_output_ids) + len(missing_result_ids)
                 stats["failed_items"] += len(row_failures)
                 stats["errors"].extend(row_failures)
+                stats["errors"].extend(missing_errors)
 
                 if ids:
                     existing_ids = self.chroma_client.get_existing_ids(ids)

--- a/src/zotero_mcp/setup_helper.py
+++ b/src/zotero_mcp/setup_helper.py
@@ -153,9 +153,12 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
         name = existing_semantic_config.get("embedding_config", {}).get("model_name", "unknown")
         update_freq = existing_semantic_config.get("update_config", {}).get("update_frequency", "unknown")
         db_path = existing_semantic_config.get("zotero_db_path", "auto-detect")
+        openai_batch = existing_semantic_config.get("openai_batch", {}).get("enabled", False)
         print("Found existing semantic search configuration:")
         print(f"  - Embedding model: {model}")
         print(f"  - Embedding model name: {name}")
+        if model == "openai":
+            print(f"  - OpenAI Batch API updates: {'enabled' if openai_batch else 'disabled'}")
         print(f"  - Update frequency: {update_freq}")
         print(f"  - Zotero database path: {db_path}")
         print("You can keep it or change it.")
@@ -217,6 +220,26 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
             print(f"Using custom OpenAI base URL: {base_url}")
         else:
             print("Using default OpenAI base URL")
+
+        existing_openai_batch = existing_semantic_config.get("openai_batch", {}) if existing_semantic_config else {}
+        if existing_semantic_config and existing_semantic_config.get("embedding_model") == "openai":
+            default_batch_enabled = bool(existing_openai_batch.get("enabled", False))
+        else:
+            default_batch_enabled = True
+        default_hint = "Y/n" if default_batch_enabled else "y/N"
+        print("\nOpenAI indexing mode:")
+        print("Batch API lowers costs for database updates, but results are imported later after the batch completes.")
+        print("Realtime API indexes immediately, but uses standard synchronous embedding pricing.")
+        raw = input(f"Use OpenAI Batch API for database updates? [{default_hint}]: ").strip().lower()
+        if raw == "":
+            batch_enabled = default_batch_enabled
+        else:
+            batch_enabled = raw in ["y", "yes"]
+        config["openai_batch"] = {"enabled": batch_enabled}
+        if batch_enabled:
+            print("OpenAI Batch API will be used by default for update-db.")
+        else:
+            print("Realtime OpenAI embeddings will be used by default for update-db.")
 
     elif choice == "3":
         config["embedding_model"] = "gemini"

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+import pytest
+
+from zotero_mcp.cli import main
+
+
+def test_zotero_mcp_help_mentions_openai_batch(capsys):
+    with patch("sys.argv", ["zotero-mcp", "help"]):
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "OpenAI Batch API indexing" in out
+    assert "zotero-mcp update-db --openai-batch" in out
+    assert "openai-batch-status" in out
+    assert "openai-batch-import" in out
+
+
+def test_zotero_mcp_help_update_db_shows_batch_flags(capsys):
+    with patch("sys.argv", ["zotero-mcp", "help", "update-db"]):
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "--openai-batch" in out
+    assert "--no-openai-batch" in out

--- a/tests/test_openai_batch.py
+++ b/tests/test_openai_batch.py
@@ -138,6 +138,13 @@ class FakeChromaClient:
     def __init__(self, embedding_model="openai"):
         self.embedding_model = embedding_model
         self.embedding_config = {"model_name": "text-embedding-3-small", "api_key": "test"}
+        self.embedding_max_tokens = 8000
+
+    def truncate_text(self, text, max_tokens=None):
+        return text
+
+    def get_existing_ids(self, ids):
+        return {"EXISTING"} & set(ids)
 
 
 def test_update_db_batch_flag_resolution_reads_config(tmp_path, monkeypatch):
@@ -161,6 +168,47 @@ def test_update_db_batch_flag_resolution_reads_config(tmp_path, monkeypatch):
         config_path=str(config_path),
     )
     assert non_openai._resolve_openai_batch_enabled(True) is False
+
+
+def test_failed_batch_submit_does_not_report_added_or_updated(monkeypatch):
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: object())
+    search = semantic_search.ZoteroSemanticSearch(chroma_client=FakeChromaClient())
+
+    def fail_submit(**kwargs):
+        raise RuntimeError("missing files.write")
+
+    monkeypatch.setattr(semantic_search.openai_batch, "submit_embedding_batches", fail_submit)
+    stats = {
+        "processed_items": 0,
+        "added_items": 0,
+        "updated_items": 0,
+        "skipped_items": 0,
+        "errors": 0,
+    }
+
+    with pytest.raises(RuntimeError, match="missing files.write"):
+        search._submit_openai_batch_index(
+            [
+                {
+                    "key": "EXISTING",
+                    "data": {
+                        "title": "Existing item",
+                        "itemType": "journalArticle",
+                        "abstractNote": "A",
+                        "creators": [],
+                    },
+                }
+            ],
+            force_full_rebuild=False,
+            target_sync_version=1,
+            stats=stats,
+        )
+
+    assert stats["processed_items"] == 1
+    assert stats["added_items"] == 0
+    assert stats["updated_items"] == 0
+    assert "estimated_added_items" not in stats
+    assert "estimated_updated_items" not in stats
 
 
 def test_chroma_client_upsert_embeddings_passes_precomputed_vectors():

--- a/tests/test_openai_batch.py
+++ b/tests/test_openai_batch.py
@@ -305,3 +305,76 @@ def test_chroma_client_upsert_embeddings_passes_precomputed_vectors():
         "ids": ["ID1"],
         "embeddings": [[0.1, 0.2]],
     }
+
+
+def test_import_openai_batch_reports_records_missing_from_output(tmp_path, monkeypatch):
+    class ImportChromaClient(FakeChromaClient):
+        def __init__(self):
+            super().__init__()
+            self.upserted = None
+
+        def upsert_embeddings(self, documents, metadatas, ids, embeddings):
+            self.upserted = {
+                "documents": list(documents),
+                "metadatas": list(metadatas),
+                "ids": list(ids),
+                "embeddings": list(embeddings),
+            }
+
+    records_path = tmp_path / "batch-001-records.jsonl"
+    openai_batch.write_jsonl(
+        records_path,
+        [
+            {"id": "A", "document": "doc A", "metadata": {"title": "A"}},
+            {"id": "B", "document": "doc B", "metadata": {"title": "B"}},
+        ],
+    )
+    output_path = tmp_path / "batch-001-records-output.jsonl"
+    output_path.write_text(
+        json.dumps({
+            "custom_id": "A",
+            "response": {"status_code": 200, "body": {"data": [{"embedding": [0.1, 0.2]}]}},
+        }) + "\n",
+        encoding="utf-8",
+    )
+    manifest = {
+        "run_id": "run-1",
+        "manifest_path": str(tmp_path / "manifest.json"),
+        "force_full_rebuild": False,
+        "batches": [
+            {
+                "batch_id": "batch-1",
+                "status": "completed",
+                "output_file_id": "file-1",
+                "records_path": str(records_path),
+                "imported_at": None,
+            }
+        ],
+    }
+
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: object())
+    monkeypatch.setattr(semantic_search.openai_batch, "find_manifest", lambda **kwargs: manifest)
+    monkeypatch.setattr(
+        semantic_search.openai_batch,
+        "refresh_manifest_status",
+        lambda manifest, **kwargs: manifest,
+    )
+    monkeypatch.setattr(semantic_search.openai_batch, "create_openai_client", lambda config: object())
+
+    chroma_client = ImportChromaClient()
+    search = semantic_search.ZoteroSemanticSearch(chroma_client=chroma_client)
+
+    stats = search.import_openai_batch()
+
+    assert chroma_client.upserted == {
+        "documents": ["doc A"],
+        "metadatas": [{"title": "A"}],
+        "ids": ["A"],
+        "embeddings": [[0.1, 0.2]],
+    }
+    assert stats["imported_items"] == 1
+    assert stats["missing_items"] == 1
+    assert {
+        "custom_id": "B",
+        "error": "No embedding or error row returned for batch record",
+    } in stats["errors"]

--- a/tests/test_openai_batch.py
+++ b/tests/test_openai_batch.py
@@ -1,0 +1,189 @@
+import builtins
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from zotero_mcp import openai_batch, setup_helper
+
+if sys.version_info >= (3, 14):
+    pytest.skip(
+        "chromadb currently relies on pydantic v1 paths that are incompatible with Python 3.14+",
+        allow_module_level=True,
+    )
+
+pytest.importorskip("chromadb")
+
+from zotero_mcp import semantic_search  # noqa: E402
+from zotero_mcp.chroma_client import ChromaClient  # noqa: E402
+
+
+def test_build_embedding_request_uses_batch_embeddings_shape():
+    record = {"id": "ABC123", "document": "paper text", "metadata": {"title": "A"}}
+
+    request = openai_batch.build_embedding_request(record, "text-embedding-3-small")
+
+    assert request == {
+        "custom_id": "ABC123",
+        "method": "POST",
+        "url": "/v1/embeddings",
+        "body": {
+            "model": "text-embedding-3-small",
+            "input": "paper text",
+            "encoding_format": "float",
+        },
+    }
+
+
+def test_split_embedding_records_respects_request_limit():
+    records = [
+        {"id": f"ID{i}", "document": f"text {i}", "metadata": {}}
+        for i in range(3)
+    ]
+
+    chunks = openai_batch.split_embedding_records(
+        records,
+        "text-embedding-3-small",
+        max_requests=2,
+        max_file_bytes=10_000,
+    )
+
+    assert [len(chunk_records) for chunk_records, _ in chunks] == [2, 1]
+    assert chunks[0][1][0]["custom_id"] == "ID0"
+    assert chunks[1][1][0]["custom_id"] == "ID2"
+
+
+def test_parse_embedding_output_uses_custom_ids_and_keeps_failures():
+    output = "\n".join(
+        [
+            json.dumps({
+                "custom_id": "B",
+                "response": {"status_code": 200, "body": {"data": [{"embedding": [0.2, 0.3]}]}},
+            }),
+            json.dumps({
+                "custom_id": "A",
+                "response": {"status_code": 200, "body": {"data": [{"embedding": [0.1, 0.2]}]}},
+            }),
+            json.dumps({
+                "custom_id": "C",
+                "response": {"status_code": 429, "body": {}},
+                "error": {"message": "rate limited"},
+            }),
+        ]
+    )
+
+    embeddings, failures = openai_batch.parse_embedding_output(output)
+
+    assert embeddings == {"B": [0.2, 0.3], "A": [0.1, 0.2]}
+    assert failures == [{"custom_id": "C", "error": {"message": "rate limited"}, "status_code": 429}]
+
+
+def test_submit_embedding_batches_writes_manifest_and_jsonl(tmp_path):
+    class FakeFiles:
+        def create(self, file, purpose):
+            assert purpose == "batch"
+            assert Path(file.name).read_text(encoding="utf-8")
+            return SimpleNamespace(id="file-1")
+
+    class FakeBatches:
+        def create(self, **kwargs):
+            assert kwargs["endpoint"] == "/v1/embeddings"
+            assert kwargs["completion_window"] == "24h"
+            return SimpleNamespace(
+                id="batch-1",
+                status="validating",
+                output_file_id=None,
+                error_file_id=None,
+                request_counts={"total": 1, "completed": 0, "failed": 0},
+            )
+
+    records = [{"id": "ABC123", "document": "paper text", "metadata": {"title": "A"}}]
+
+    manifest = openai_batch.submit_embedding_batches(
+        records=records,
+        model_name="text-embedding-3-small",
+        embedding_config={"api_key": "test"},
+        config_path=str(tmp_path / "config.json"),
+        client=SimpleNamespace(files=FakeFiles(), batches=FakeBatches()),
+    )
+
+    assert manifest["batches"][0]["batch_id"] == "batch-1"
+    assert Path(manifest["manifest_path"]).exists()
+    input_rows = openai_batch.read_jsonl(Path(manifest["batches"][0]["input_path"]))
+    assert input_rows[0]["url"] == "/v1/embeddings"
+
+
+def test_setup_openai_new_config_defaults_to_batch(monkeypatch):
+    answers = iter([
+        "2",  # OpenAI
+        "1",  # text-embedding-3-small
+        "",  # default base URL
+        "",  # default batch choice: yes for new configs
+        "1",  # manual updates
+        "",  # default PDF max pages
+        "",  # auto-detect DB path
+    ])
+    monkeypatch.setattr(builtins, "input", lambda *args: next(answers))
+    monkeypatch.setattr(setup_helper.getpass, "getpass", lambda *args: "sk-test")
+
+    config = setup_helper.setup_semantic_search()
+
+    assert config["embedding_model"] == "openai"
+    assert config["openai_batch"] == {"enabled": True}
+
+
+class FakeChromaClient:
+    def __init__(self, embedding_model="openai"):
+        self.embedding_model = embedding_model
+        self.embedding_config = {"model_name": "text-embedding-3-small", "api_key": "test"}
+
+
+def test_update_db_batch_flag_resolution_reads_config(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"semantic_search": {"openai_batch": {"enabled": True}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: object())
+    search = semantic_search.ZoteroSemanticSearch(
+        chroma_client=FakeChromaClient(),
+        config_path=str(config_path),
+    )
+
+    assert search._resolve_openai_batch_enabled(None) is True
+    assert search._resolve_openai_batch_enabled(False) is False
+    assert search._resolve_openai_batch_enabled(True) is True
+
+    non_openai = semantic_search.ZoteroSemanticSearch(
+        chroma_client=FakeChromaClient(embedding_model="gemini"),
+        config_path=str(config_path),
+    )
+    assert non_openai._resolve_openai_batch_enabled(True) is False
+
+
+def test_chroma_client_upsert_embeddings_passes_precomputed_vectors():
+    class FakeCollection:
+        def __init__(self):
+            self.kwargs = None
+
+        def upsert(self, **kwargs):
+            self.kwargs = kwargs
+
+    client = ChromaClient.__new__(ChromaClient)
+    client.collection = FakeCollection()
+
+    client.upsert_embeddings(
+        documents=["doc"],
+        metadatas=[{"title": "Title"}],
+        ids=["ID1"],
+        embeddings=[[0.1, 0.2]],
+    )
+
+    assert client.collection.kwargs == {
+        "documents": ["doc"],
+        "metadatas": [{"title": "Title"}],
+        "ids": ["ID1"],
+        "embeddings": [[0.1, 0.2]],
+    }

--- a/tests/test_openai_batch.py
+++ b/tests/test_openai_batch.py
@@ -211,6 +211,76 @@ def test_failed_batch_submit_does_not_report_added_or_updated(monkeypatch):
     assert "estimated_updated_items" not in stats
 
 
+def test_batch_and_realtime_indexing_share_prepared_payload(monkeypatch):
+    class RecordingChromaClient(FakeChromaClient):
+        def __init__(self):
+            super().__init__()
+            self.upserts = []
+
+        def upsert_documents(self, documents, metadatas, ids):
+            self.upserts.append({
+                "documents": list(documents),
+                "metadatas": list(metadatas),
+                "ids": list(ids),
+            })
+
+    item = {
+        "key": "ITEM1",
+        "data": {
+            "itemType": "journalArticle",
+            "title": "Semantic Batch Paper",
+            "abstractNote": "An abstract that should be embedded.",
+            "publicationTitle": "Journal of Tests",
+            "creators": [{"firstName": "Ada", "lastName": "Lovelace", "creatorType": "author"}],
+            "tags": [{"tag": "embeddings"}, {"tag": "batch"}],
+            "fulltext": "Full text must be included in both indexing paths.",
+            "fulltextSource": "zotero_web_api",
+            "date": "2026",
+            "DOI": "10.1234/example",
+        },
+    }
+
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: object())
+
+    realtime_client = RecordingChromaClient()
+    realtime_search = semantic_search.ZoteroSemanticSearch(chroma_client=realtime_client)
+    realtime_search._process_item_batch([item])
+    assert realtime_client.upserts
+
+    captured = {}
+
+    def capture_batch_submit(**kwargs):
+        captured.update(kwargs)
+        return {
+            "run_id": "run-1",
+            "manifest_path": "/tmp/manifest.json",
+            "batches": [{"batch_id": "batch-1"}],
+        }
+
+    monkeypatch.setattr(semantic_search.openai_batch, "submit_embedding_batches", capture_batch_submit)
+    batch_client = RecordingChromaClient()
+    batch_search = semantic_search.ZoteroSemanticSearch(chroma_client=batch_client)
+    batch_search._submit_openai_batch_index(
+        [item],
+        force_full_rebuild=False,
+        target_sync_version=123,
+        stats={
+            "processed_items": 0,
+            "skipped_items": 0,
+            "errors": 0,
+        },
+    )
+
+    realtime_payload = realtime_client.upserts[0]
+    assert captured["records"] == [{
+        "id": realtime_payload["ids"][0],
+        "document": realtime_payload["documents"][0],
+        "metadata": realtime_payload["metadatas"][0],
+    }]
+    assert "Full text must be included" in captured["records"][0]["document"]
+    assert captured["records"][0]["metadata"]["has_fulltext"] is True
+
+
 def test_chroma_client_upsert_embeddings_passes_precomputed_vectors():
     class FakeCollection:
         def __init__(self):


### PR DESCRIPTION
## Summary

Adds an opt-in OpenAI Batch API path for semantic-search database indexing. This lets users submit OpenAI embedding jobs asynchronously, check their status, and import completed embeddings into ChromaDB without re-calling the realtime embeddings endpoint.

## Changes

- Adds OpenAI Batch API submission, status, and import helpers with local manifests under `~/.config/zotero-mcp/openai_batches/`.
- Adds `zotero-mcp update-db --openai-batch` and `--no-openai-batch` overrides, plus `openai-batch-status` and `openai-batch-import` commands.
- Adds OpenAI setup support so new OpenAI semantic-search configs can choose Batch API as the default indexing mode.
- Adds direct ChromaDB upsert of precomputed embeddings returned by Batch API.
- Improves CLI help so `zotero-mcp help` and `zotero-mcp help update-db` surface the batch workflow.
- Keeps query-time semantic search realtime; Batch API only changes document indexing.

## Notes

- Batch mode is OpenAI-only. Default, Gemini, and realtime OpenAI indexing remain supported.
- For force rebuilds, the existing ChromaDB collection is not reset at submission time; rebuild reset is deferred until import, after all batches are completed.
- Restricted OpenAI API keys need Files and Batches permissions because the Batch API uploads JSONL input files before creating a batch.

## Validation

- `uv run --python 3.13 --extra dev ruff check src/zotero_mcp/openai_batch.py src/zotero_mcp/semantic_search.py src/zotero_mcp/chroma_client.py src/zotero_mcp/cli.py src/zotero_mcp/cli_standalone.py src/zotero_mcp/setup_helper.py tests/test_openai_batch.py tests/test_cli_help.py`
- `uv run --python 3.13 --extra dev pytest tests/test_openai_batch.py tests/test_cli_help.py tests/test_semantic_stats.py tests/test_embedding_function_registration.py tests/test_fulltext_web_mode.py`
