### PR TITLE
fix(semantic-search): reliable OpenRouter/Gemini embeddings, non-blocking status, config-authoritative model

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -73,10 +73,19 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
         )
 
     def __call__(self, input: Documents) -> Embeddings:
-        """Generate embeddings using OpenAI API."""
+        """Generate embeddings using the OpenAI-compatible API.
+
+        ``encoding_format="float"`` is set explicitly. The OpenAI SDK otherwise
+        negotiates base64 by default, which OpenRouter's Gemini embedding
+        providers (e.g. ``google/gemini-embedding-001``) do not return reliably —
+        the SDK then raises "No embedding data received" intermittently. Forcing
+        float makes every OpenAI-compatible backend, native OpenAI included,
+        respond deterministically.
+        """
         response = self.client.embeddings.create(
             model=self.model_name,
-            input=input
+            input=input,
+            encoding_format="float",
         )
         return [data.embedding for data in response.data]
 
@@ -689,9 +698,20 @@ def create_chroma_client(config_path: str | None = None) -> ChromaClient:
         except Exception as e:
             logger.warning(f"Error loading config from {config_path}: {e}")
 
-    # Load configuration from environment variables
+    # Pick the embedding model. config.json is the richer, authoritative source
+    # (it also carries the matching api_key / base_url / model_name), so it wins
+    # over the ZOTERO_EMBEDDING_MODEL env var whenever it names a concrete model.
+    # The env var only fills the gap when config.json is absent or left at the
+    # "default" placeholder — which is the normal Claude Desktop case.
+    #
+    # This deliberately guards against a stale env value silently downgrading an
+    # explicitly configured provider: Claude Desktop passes its server `env`
+    # block on every launch and can rewrite that file on its own, so a leftover
+    # ZOTERO_EMBEDDING_MODEL=default there would otherwise override a Gemini/
+    # OpenAI config.json and break search with an opaque embedding-dimension
+    # mismatch against the persisted collection.
     env_embedding_model = os.getenv("ZOTERO_EMBEDDING_MODEL")
-    if env_embedding_model:
+    if env_embedding_model and config.get("embedding_model", "default") in (None, "default"):
         config["embedding_model"] = env_embedding_model
 
     # Merge embedding config from environment (config.json wins, env fills gaps).
@@ -738,3 +758,74 @@ def create_chroma_client(config_path: str | None = None) -> ChromaClient:
         embedding_model=config["embedding_model"],
         embedding_config=config["embedding_config"]
     )
+
+
+class _NoEmbeddingFunction(EmbeddingFunction):
+    """Placeholder embedding function used for read-only status reads.
+
+    Passing an explicit embedding function to ``get_collection`` stops ChromaDB
+    from reconstructing the collection's persisted embedding function — which,
+    for the default backend, eagerly downloads the ~80MB ONNX MiniLM model.
+    Counting rows never embeds anything, so this is never actually called; it
+    raises if it ever is, to make misuse loud rather than silently wrong.
+    """
+
+    def __call__(self, input: Documents) -> Embeddings:  # pragma: no cover - never invoked
+        raise RuntimeError("embedding is unavailable in status-only mode")
+
+
+def read_collection_status(config_path: str | None = None) -> dict[str, Any]:
+    """Read ChromaDB collection stats WITHOUT loading an embedding model.
+
+    The full :class:`ChromaClient` constructor builds the embedding function,
+    which for the default backend downloads the ONNX MiniLM model on first use —
+    turning a read-only status check into a multi-minute (or network-blocked,
+    indefinite) hang. Reporting readiness only needs the row count and the
+    configured model name, neither of which requires the model itself. This
+    opens the persisted database directly and reads the count, mirroring the
+    shape returned by :meth:`ChromaClient.get_collection_info`.
+    """
+    collection_name = "zotero_library"
+    embedding_model = "default"
+
+    if config_path and os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                semantic_cfg = json.load(f).get("semantic_search", {})
+            collection_name = semantic_cfg.get("collection_name", collection_name)
+            embedding_model = semantic_cfg.get("embedding_model", embedding_model)
+        except Exception as e:
+            logger.warning(f"Error loading config from {config_path}: {e}")
+
+    # Mirror create_chroma_client's precedence: config.json wins; the env var
+    # only fills in when the file left the model at the "default" placeholder.
+    env_model = os.getenv("ZOTERO_EMBEDDING_MODEL")
+    if env_model and embedding_model in (None, "default"):
+        embedding_model = env_model
+
+    persist_directory = str(Path.home() / ".config" / "zotero-mcp" / "chroma_db")
+    base = {
+        "name": collection_name,
+        "embedding_model": embedding_model,
+        "persist_directory": persist_directory,
+    }
+
+    try:
+        with suppress_stdout():
+            client = chromadb.PersistentClient(
+                path=persist_directory,
+                settings=Settings(anonymized_telemetry=False, allow_reset=True),
+            )
+            try:
+                collection = client.get_collection(
+                    name=collection_name,
+                    embedding_function=_NoEmbeddingFunction(),
+                )
+            except Exception:
+                # Collection does not exist yet — database not initialized.
+                return {**base, "count": 0, "initialized": False}
+            count = collection.count()
+        return {**base, "count": count, "initialized": True}
+    except Exception as e:
+        logger.error(f"Error reading collection status: {e}")
+        return {**base, "count": 0, "error": str(e)}

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -86,6 +86,66 @@ def _truncate_to_tokens(text: str, max_tokens: int = 8000) -> str:
     return text
 
 
+_DEFAULT_UPDATE_CONFIG = {
+    "auto_update": False,
+    "update_frequency": "manual",
+    "last_update": None,
+    "update_days": 7,
+}
+
+
+def load_update_config(config_path: str | None) -> dict[str, Any]:
+    """Read the semantic-search ``update_config`` block from disk.
+
+    Pure file read with no ChromaDB or embedding-model side effects, so it is
+    safe on the read-only status path. Returns defaults when the file is
+    missing or unreadable.
+    """
+    config = dict(_DEFAULT_UPDATE_CONFIG)
+    if config_path and os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                file_config = json.load(f)
+            config.update(file_config.get("semantic_search", {}).get("update_config", {}))
+        except Exception as e:
+            logger.warning(f"Error loading update config: {e}")
+    return config
+
+
+def should_update(update_config: dict[str, Any]) -> bool:
+    """Decide whether an auto-update is due from ``update_config`` alone.
+
+    Pure function of the config dict (and the wall clock) — no I/O, no model
+    load — so both :class:`ZoteroSemanticSearch` and the status tool can share
+    one source of truth.
+    """
+    if not update_config.get("auto_update", False):
+        return False
+
+    frequency = update_config.get("update_frequency", "manual")
+
+    if frequency == "manual":
+        return False
+    elif frequency == "startup":
+        return True
+    elif frequency == "daily":
+        last_update = update_config.get("last_update")
+        if not last_update:
+            return True
+        return datetime.now() - datetime.fromisoformat(last_update) >= timedelta(days=1)
+    elif frequency.startswith("every_"):
+        try:
+            days = int(frequency.split("_")[1])
+            last_update = update_config.get("last_update")
+            if not last_update:
+                return True
+            return datetime.now() - datetime.fromisoformat(last_update) >= timedelta(days=days)
+        except (ValueError, IndexError):
+            return False
+
+    return False
+
+
 class CrossEncoderReranker:
     """Optional cross-encoder re-ranker for semantic search results."""
 
@@ -158,22 +218,7 @@ class ZoteroSemanticSearch:
 
     def _load_update_config(self) -> dict[str, Any]:
         """Load update configuration from file or use defaults."""
-        config = {
-            "auto_update": False,
-            "update_frequency": "manual",
-            "last_update": None,
-            "update_days": 7
-        }
-
-        if self.config_path and os.path.exists(self.config_path):
-            try:
-                with open(self.config_path) as f:
-                    file_config = json.load(f)
-                    config.update(file_config.get("semantic_search", {}).get("update_config", {}))
-            except Exception as e:
-                logger.warning(f"Error loading update config: {e}")
-
-        return config
+        return load_update_config(self.config_path)
 
     def _load_include_fulltext_setting(self) -> bool:
         """Whether to fetch fulltext via the Zotero web API during indexing.
@@ -371,35 +416,7 @@ class ZoteroSemanticSearch:
 
     def should_update_database(self) -> bool:
         """Check if the database should be updated based on configuration."""
-        if not self.update_config.get("auto_update", False):
-            return False
-
-        frequency = self.update_config.get("update_frequency", "manual")
-
-        if frequency == "manual":
-            return False
-        elif frequency == "startup":
-            return True
-        elif frequency == "daily":
-            last_update = self.update_config.get("last_update")
-            if not last_update:
-                return True
-
-            last_update_date = datetime.fromisoformat(last_update)
-            return datetime.now() - last_update_date >= timedelta(days=1)
-        elif frequency.startswith("every_"):
-            try:
-                days = int(frequency.split("_")[1])
-                last_update = self.update_config.get("last_update")
-                if not last_update:
-                    return True
-
-                last_update_date = datetime.fromisoformat(last_update)
-                return datetime.now() - last_update_date >= timedelta(days=days)
-            except (ValueError, IndexError):
-                return False
-
-        return False
+        return should_update(self.update_config)
 
     def _get_items_from_source(self,
                                limit: int | None = None,

--- a/src/zotero_mcp/tools/search.py
+++ b/src/zotero_mcp/tools/search.py
@@ -1013,10 +1013,16 @@ def update_search_database(
         "provider summary."
     )
 )
-@with_zotero_api_lock
 def get_search_database_status(*, ctx: Context) -> str:
     """
     Get semantic search database status.
+
+    Deliberately NOT wrapped in ``@with_zotero_api_lock``: this is a read-only
+    ChromaDB query that never touches the Zotero API, and holding the shared
+    lock here would make a slow status read block every other tool. The read
+    path below also avoids constructing the embedding function, which for the
+    default backend downloads an ONNX model on first use and could otherwise
+    hang this call for minutes.
 
     Args:
         ctx: MCP context
@@ -1027,9 +1033,12 @@ def get_search_database_status(*, ctx: Context) -> str:
     try:
         ctx.info("Getting semantic search database status...")
 
-        # Import semantic search module
+        # Import the lightweight, model-free status readers. These live in the
+        # semantic-search modules so they share the [semantic] extra's import
+        # guard, but neither loads an embedding model or a Zotero client.
         try:
-            from zotero_mcp.semantic_search import create_semantic_search
+            from zotero_mcp.chroma_client import read_collection_status
+            from zotero_mcp.semantic_search import load_update_config, should_update
         except ImportError:
             return (
                 "Semantic search is not available. Install the required packages with:\n"
@@ -1040,33 +1049,31 @@ def get_search_database_status(*, ctx: Context) -> str:
         # Determine config path
         config_path = Path.home() / ".config" / "zotero-mcp" / "config.json"
 
-        # Create semantic search instance
-        search = create_semantic_search(str(config_path))
-
-        # Get status
-        status = search.get_database_status()
+        # Read status without loading any embedding model (fast, no network).
+        collection_info = read_collection_status(str(config_path))
+        update_config = load_update_config(str(config_path))
 
         # Format results
         output = ["# Semantic Search Database Status", ""]
 
-        collection_info = status.get("collection_info", {})
         output.append("## Collection Information")
         output.append(f"**Name:** {collection_info.get('name', 'Unknown')}")
         output.append(f"**Document Count:** {collection_info.get('count', 0)}")
         output.append(f"**Embedding Model:** {collection_info.get('embedding_model', 'Unknown')}")
         output.append(f"**Database Path:** {collection_info.get('persist_directory', 'Unknown')}")
 
+        if collection_info.get("initialized") is False and not collection_info.get("error"):
+            output.append("**Status:** Not initialized — run zotero_update_search_database first.")
         if collection_info.get('error'):
             output.append(f"**Error:** {collection_info['error']}")
 
         output.append("")
 
-        update_config = status.get("update_config", {})
         output.append("## Update Configuration")
         output.append(f"**Auto Update:** {update_config.get('auto_update', False)}")
         output.append(f"**Frequency:** {update_config.get('update_frequency', 'manual')}")
         output.append(f"**Last Update:** {update_config.get('last_update', 'Never')}")
-        output.append(f"**Should Update Now:** {status.get('should_update', False)}")
+        output.append(f"**Should Update Now:** {should_update(update_config)}")
 
         frequency = update_config.get('update_frequency', 'manual')
         if frequency.startswith('every_') and update_config.get('update_days'):


### PR DESCRIPTION
## Summary

Three related robustness fixes for semantic search, surfaced while setting up **Gemini embeddings via OpenRouter** (an OpenAI-compatible gateway). Each is independent; happy to split into separate PRs if you'd prefer.

### 1. Deterministic embeddings via `encoding_format="float"`
The `openai` SDK negotiates **base64** by default. OpenRouter's Gemini embedding providers (`google/gemini-embedding-001`, `google/gemini-embedding-2`) don't return that reliably, so the SDK raises `ValueError: No embedding data received` — intermittently for `-001` (~1 in 3 calls) and *every* time for `-2`. The raw HTTP endpoint returns valid 3072-dim vectors, so it's purely the encoding negotiation.

Setting `encoding_format="float"` explicitly in `OpenAIEmbeddingFunction.__call__` fixes it: **8/8 → 100% reliable** in testing, including batches. Harmless for native OpenAI (returns float, just slightly larger over the wire) and makes behavior deterministic across any OpenAI-compatible backend.

### 2. `db-status` / `zotero_get_search_database_status` no longer loads a model or holds the API lock
The status tool went through `create_semantic_search()`, which constructs the embedding function. For the **default** backend that downloads the ~80MB ONNX MiniLM model on first use — turning a read-only row count into a multi-minute (or network-blocked, indefinite) hang. Worse, the tool held the shared `@with_zotero_api_lock`, so a slow status read wedged every other Zotero tool until the client timed out.

This adds `read_collection_status()` — a lightweight reader that opens the persisted collection and reads `.count()` **without** building any embedding function (uses a no-op EF so ChromaDB doesn't reconstruct the persisted one) — plus module-level `load_update_config()` / `should_update()` helpers (pure config, no I/O). The tool now uses these and **drops the API lock** (it never touches the Zotero API).

### 3. `config.json` is authoritative over a stale `ZOTERO_EMBEDDING_MODEL` env var
`create_chroma_client` let the env var unconditionally override `config.json`'s model. Claude Desktop passes its server `env` block on every launch (and can rewrite that file itself), so a leftover `ZOTERO_EMBEDDING_MODEL=default` there silently downgraded an explicitly configured Gemini/OpenAI setup back to the local model — which then failed every query with an opaque `Collection expecting embedding with dimension of 3072, got 384`.

The env var now only fills the gap when `config.json` leaves the model at the `"default"` placeholder (the normal Claude Desktop case), so the env path still works while an explicit config wins. This is consistent with the existing "config.json wins, env fills gaps" rule already applied to `embedding_config`.

## Testing
- Full suite: **897 passed**; the only failures are pre-existing `test_place_field_reads` cases unrelated to these changes (present on a clean tree).
- Manually verified end-to-end against a real library: rebuilt a 447-doc / 3072-dim index on `google/gemini-embedding-001` via OpenRouter with 0 errors, and confirmed semantic queries return relevant results — including under a simulated stale `ZOTERO_EMBEDDING_MODEL=default` env (fix #3).

## Notes
- No new dependencies. No public API changes.
- Behavior change worth calling out: fix #3 changes env-vs-file precedence for `ZOTERO_EMBEDDING_MODEL`. Only affects setups that set a non-default model in `config.json` *and* a different one via the env var — previously the env won, now the file does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)