### PR TITLE
feat(research): passage retrieval, citation-graph discovery, synthesis, prompts & resources

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -73,10 +73,19 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
         )
 
     def __call__(self, input: Documents) -> Embeddings:
-        """Generate embeddings using OpenAI API."""
+        """Generate embeddings using the OpenAI-compatible API.
+
+        ``encoding_format="float"`` is set explicitly. The OpenAI SDK otherwise
+        negotiates base64 by default, which OpenRouter's Gemini embedding
+        providers (e.g. ``google/gemini-embedding-001``) do not return reliably —
+        the SDK then raises "No embedding data received" intermittently. Forcing
+        float makes every OpenAI-compatible backend, native OpenAI included,
+        respond deterministically.
+        """
         response = self.client.embeddings.create(
             model=self.model_name,
-            input=input
+            input=input,
+            encoding_format="float",
         )
         return [data.embedding for data in response.data]
 
@@ -689,9 +698,20 @@ def create_chroma_client(config_path: str | None = None) -> ChromaClient:
         except Exception as e:
             logger.warning(f"Error loading config from {config_path}: {e}")
 
-    # Load configuration from environment variables
+    # Pick the embedding model. config.json is the richer, authoritative source
+    # (it also carries the matching api_key / base_url / model_name), so it wins
+    # over the ZOTERO_EMBEDDING_MODEL env var whenever it names a concrete model.
+    # The env var only fills the gap when config.json is absent or left at the
+    # "default" placeholder — which is the normal Claude Desktop case.
+    #
+    # This deliberately guards against a stale env value silently downgrading an
+    # explicitly configured provider: Claude Desktop passes its server `env`
+    # block on every launch and can rewrite that file on its own, so a leftover
+    # ZOTERO_EMBEDDING_MODEL=default there would otherwise override a Gemini/
+    # OpenAI config.json and break search with an opaque embedding-dimension
+    # mismatch against the persisted collection.
     env_embedding_model = os.getenv("ZOTERO_EMBEDDING_MODEL")
-    if env_embedding_model:
+    if env_embedding_model and config.get("embedding_model", "default") in (None, "default"):
         config["embedding_model"] = env_embedding_model
 
     # Merge embedding config from environment (config.json wins, env fills gaps).
@@ -738,3 +758,74 @@ def create_chroma_client(config_path: str | None = None) -> ChromaClient:
         embedding_model=config["embedding_model"],
         embedding_config=config["embedding_config"]
     )
+
+
+class _NoEmbeddingFunction(EmbeddingFunction):
+    """Placeholder embedding function used for read-only status reads.
+
+    Passing an explicit embedding function to ``get_collection`` stops ChromaDB
+    from reconstructing the collection's persisted embedding function — which,
+    for the default backend, eagerly downloads the ~80MB ONNX MiniLM model.
+    Counting rows never embeds anything, so this is never actually called; it
+    raises if it ever is, to make misuse loud rather than silently wrong.
+    """
+
+    def __call__(self, input: Documents) -> Embeddings:  # pragma: no cover - never invoked
+        raise RuntimeError("embedding is unavailable in status-only mode")
+
+
+def read_collection_status(config_path: str | None = None) -> dict[str, Any]:
+    """Read ChromaDB collection stats WITHOUT loading an embedding model.
+
+    The full :class:`ChromaClient` constructor builds the embedding function,
+    which for the default backend downloads the ONNX MiniLM model on first use —
+    turning a read-only status check into a multi-minute (or network-blocked,
+    indefinite) hang. Reporting readiness only needs the row count and the
+    configured model name, neither of which requires the model itself. This
+    opens the persisted database directly and reads the count, mirroring the
+    shape returned by :meth:`ChromaClient.get_collection_info`.
+    """
+    collection_name = "zotero_library"
+    embedding_model = "default"
+
+    if config_path and os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                semantic_cfg = json.load(f).get("semantic_search", {})
+            collection_name = semantic_cfg.get("collection_name", collection_name)
+            embedding_model = semantic_cfg.get("embedding_model", embedding_model)
+        except Exception as e:
+            logger.warning(f"Error loading config from {config_path}: {e}")
+
+    # Mirror create_chroma_client's precedence: config.json wins; the env var
+    # only fills in when the file left the model at the "default" placeholder.
+    env_model = os.getenv("ZOTERO_EMBEDDING_MODEL")
+    if env_model and embedding_model in (None, "default"):
+        embedding_model = env_model
+
+    persist_directory = str(Path.home() / ".config" / "zotero-mcp" / "chroma_db")
+    base = {
+        "name": collection_name,
+        "embedding_model": embedding_model,
+        "persist_directory": persist_directory,
+    }
+
+    try:
+        with suppress_stdout():
+            client = chromadb.PersistentClient(
+                path=persist_directory,
+                settings=Settings(anonymized_telemetry=False, allow_reset=True),
+            )
+            try:
+                collection = client.get_collection(
+                    name=collection_name,
+                    embedding_function=_NoEmbeddingFunction(),
+                )
+            except Exception:
+                # Collection does not exist yet — database not initialized.
+                return {**base, "count": 0, "initialized": False}
+            count = collection.count()
+        return {**base, "count": count, "initialized": True}
+    except Exception as e:
+        logger.error(f"Error reading collection status: {e}")
+        return {**base, "count": 0, "error": str(e)}

--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -6,10 +6,10 @@ for semantic search over Zotero libraries.
 """
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
-import logging
 
 try:
     import chromadb
@@ -588,6 +588,20 @@ class ChromaClient:
         except Exception as e:
             logger.error(f"Error deleting documents from ChromaDB: {e}")
             raise
+
+    def delete_item_chunks(self, item_key: str) -> None:
+        """Delete all passage chunks belonging to one item (chunked collections).
+
+        Passage chunks carry ``parent_item_key`` in their metadata; deleting by
+        that key clears every ``<item_key>#<n>`` entry for the item before its
+        chunks are re-upserted, so a document that shrank to fewer passages
+        never leaves orphaned chunks behind. No-op-safe on item-level
+        collections (nothing matches the filter).
+        """
+        try:
+            self.collection.delete(where={"parent_item_key": item_key})
+        except Exception as e:
+            logger.debug(f"delete_item_chunks({item_key}) failed: {e}")
 
     def get_collection_info(self) -> dict[str, Any]:
         """Get information about the collection."""

--- a/src/zotero_mcp/prompts.py
+++ b/src/zotero_mcp/prompts.py
@@ -1,0 +1,136 @@
+"""MCP prompts: reusable research workflows over the Zotero tools.
+
+Importing this module registers each ``@mcp.prompt`` with the FastMCP app (a
+side effect, mirroring the tool modules). Prompts are surfaced by MCP hosts as
+slash-commands/templates the user can invoke; each returns a plain instruction
+string that steers the assistant to chain the Zotero tools in a sensible order.
+
+These are intentionally dependency-free and never touch the Zotero API at
+import time, so they load in any environment.
+"""
+
+from zotero_mcp._app import mcp
+
+
+@mcp.prompt(
+    name="zotero_literature_review",
+    description="Run a structured literature review on a topic using the Zotero library.",
+)
+def literature_review(topic: str, depth: str = "standard") -> str:
+    """Guide a grounded literature review on *topic*.
+
+    Args:
+        topic: The research question or subject to review.
+        depth: 'quick' (library only), 'standard' (library + citation graph),
+            or 'deep' (also flag coverage gaps to fetch).
+    """
+    steps = [
+        f"Conduct a literature review on: **{topic}**.",
+        "",
+        "Work through these steps, citing item keys and quoting matched passages:",
+        f"1. Run `zotero_semantic_search(query='{topic}', limit=12)` to find the most "
+        "relevant papers already in the library. Note each paper's key and the "
+        "matched passage.",
+        "2. Cluster the results into themes. For each theme, name the key papers and "
+        "summarize their contribution in 1-2 sentences with the supporting quote.",
+    ]
+    if depth in ("standard", "deep"):
+        steps.append(
+            "3. For the 2-3 most central papers, call "
+            "`zotero_find_related_papers(identifier=<item key or DOI>, direction='both')` "
+            "to surface seminal references and newer citing work. Flag any strong "
+            "related papers that are NOT yet in the library."
+        )
+    if depth == "deep":
+        steps.append(
+            "4. Run `zotero_library_coverage()` (or scoped to the relevant collection) "
+            "to list on-topic items missing a PDF, and offer to fetch them via "
+            "`zotero_add_by_doi`."
+        )
+    steps += [
+        "",
+        "Finish with: (a) a synthesized narrative of the state of the field, "
+        "(b) open questions / gaps, and (c) a short reading list of the highest-value "
+        "papers (with keys). Ground every claim in a specific item.",
+    ]
+    return "\n".join(steps)
+
+
+@mcp.prompt(
+    name="zotero_synthesize_my_notes",
+    description="Synthesize your own highlights and notes across a topic or collection.",
+)
+def synthesize_my_notes(scope: str) -> str:
+    """Turn the user's annotations into a themed synthesis.
+
+    Args:
+        scope: A collection name/key, a tag, or a topic describing which notes
+            to pull together.
+    """
+    return "\n".join(
+        [
+            f"Synthesize my own reading notes and highlights for: **{scope}**.",
+            "",
+            "1. Call `zotero_synthesize_annotations` (pass `collection_key` or `tag` if "
+            f"'{scope}' names one; otherwise gather library-wide and filter to the topic). "
+            "This returns a per-paper digest of my highlights and notes.",
+            "2. Read the digest and identify cross-cutting THEMES — points multiple "
+            "papers agree on — and TENSIONS — where my highlighted sources disagree.",
+            "3. Produce a synthesis organized by theme, quoting my highlights and "
+            "attributing each to its paper. Surface contradictions explicitly.",
+            "4. End with the 3-5 most important takeaways and any gaps where I have no notes yet.",
+            "",
+            "Use only my actual annotations as evidence; do not invent claims.",
+        ]
+    )
+
+
+@mcp.prompt(
+    name="zotero_find_contradicting_evidence",
+    description="Stress-test a claim by finding supporting and contradicting papers.",
+)
+def find_contradicting_evidence(claim: str) -> str:
+    """Search the library for evidence for and against *claim*."""
+    return "\n".join(
+        [
+            f"Stress-test this claim against my Zotero library: **{claim}**",
+            "",
+            "1. `zotero_semantic_search(query=<the claim>, limit=10)` — find papers directly on this topic.",
+            "2. `zotero_semantic_search` again with an INVERTED / skeptical phrasing of "
+            "the claim (e.g. limitations, null results, criticisms) to surface "
+            "disconfirming work.",
+            "3. Sort the results into SUPPORTS / CONTRADICTS / MIXED, quoting the matched "
+            "passage and citing the item key for each.",
+            "4. Weigh the evidence: note study quality signals where visible (sample, "
+            "method, recency) and state how well-supported the claim is overall.",
+            "",
+            "Be even-handed — actively look for the strongest contradicting evidence, not just confirmation.",
+        ]
+    )
+
+
+@mcp.prompt(
+    name="zotero_expand_from_paper",
+    description="Snowball a reading list outward from one seed paper via its citation graph.",
+)
+def expand_from_paper(identifier: str) -> str:
+    """Grow a reading list outward from a seed paper.
+
+    Args:
+        identifier: A Zotero item key or a DOI for the seed paper.
+    """
+    return "\n".join(
+        [
+            f"Expand my reading list outward from this seed paper: **{identifier}**",
+            "",
+            f"1. `zotero_find_related_papers(identifier='{identifier}', direction='both', "
+            "limit=25)` to get its references (foundational work) and citations "
+            "(follow-ups).",
+            "2. Rank the related papers by relevance to my interests and by citation "
+            "count. Highlight the ones already flagged as NOT in my library.",
+            "3. For the top not-in-library papers, offer to add them with "
+            "`zotero_add_by_doi` (which also tries to attach an open-access PDF).",
+            "4. Summarize how the seed paper sits in its citation neighborhood: what it "
+            "builds on, and how later work extended or challenged it.",
+        ]
+    )

--- a/src/zotero_mcp/resources.py
+++ b/src/zotero_mcp/resources.py
@@ -1,0 +1,95 @@
+"""MCP resources: expose the Zotero library as attachable context.
+
+Importing this module registers each ``@mcp.resource`` with the FastMCP app (a
+side effect, mirroring the tool modules). Resources let an MCP host attach
+library content (a collection listing, a single item, a collection's items) as
+context directly, without the model having to issue a tool call for each.
+
+The Zotero client is reached lazily via module-level attribute access
+(``_client.get_zotero_client()``) so tests can monkeypatch it, and every
+resource holds the shared API lock while talking to Zotero.
+"""
+
+from zotero_mcp import client as _client
+from zotero_mcp import utils as _utils
+from zotero_mcp._app import mcp
+from zotero_mcp.client import with_zotero_api_lock
+from zotero_mcp.tools import _helpers
+
+
+@mcp.resource(
+    "zotero://collections",
+    name="Zotero collections",
+    description="All collections in the active Zotero library (name, key, item count).",
+    mime_type="text/markdown",
+)
+@with_zotero_api_lock
+def collections_resource() -> str:
+    """List every collection in the active library as markdown."""
+    try:
+        zot = _client.get_zotero_client()
+        collections = _helpers._paginate(zot.collections)
+        if not collections:
+            return "# Zotero Collections\n\nNo collections found."
+        lines = ["# Zotero Collections", ""]
+        for c in collections:
+            data = c.get("data", {})
+            name = data.get("name", "Untitled")
+            key = c.get("key", "")
+            parent = data.get("parentCollection")
+            suffix = f" — child of {parent}" if parent else ""
+            lines.append(f"- **{name}** (`{key}`){suffix}")
+        return "\n".join(lines)
+    except Exception as e:
+        return f"# Zotero Collections\n\nError loading collections: {e}"
+
+
+@mcp.resource(
+    "zotero://items/{item_key}",
+    name="Zotero item",
+    description="Full metadata for a single Zotero item by its 8-char key.",
+    mime_type="text/markdown",
+)
+@with_zotero_api_lock
+def item_resource(item_key: str) -> str:
+    """Return one item's metadata as markdown."""
+    try:
+        zot = _client.get_zotero_client()
+        try:
+            item = zot.item(item_key)
+        except Exception:
+            return f"# Item {item_key}\n\nNo item found with key: {item_key}"
+        if not item:
+            return f"# Item {item_key}\n\nNo item found with key: {item_key}"
+        lines = [f"# Item {item_key}", ""]
+        lines.extend(_utils.format_item_result(item))
+        return "\n".join(lines)
+    except Exception as e:
+        return f"# Item {item_key}\n\nError loading item: {e}"
+
+
+@mcp.resource(
+    "zotero://collections/{collection_key}/items",
+    name="Zotero collection items",
+    description="The items contained in a Zotero collection, by collection key.",
+    mime_type="text/markdown",
+)
+@with_zotero_api_lock
+def collection_items_resource(collection_key: str) -> str:
+    """Return the items in a collection as markdown."""
+    try:
+        zot = _client.get_zotero_client()
+        try:
+            coll = zot.collection(collection_key)
+            coll_name = coll.get("data", {}).get("name", collection_key)
+        except Exception:
+            coll_name = collection_key
+        items = _helpers._paginate(zot.collection_items, collection_key, max_items=200, itemType="-attachment")
+        if not items:
+            return f"# Collection: {coll_name}\n\nNo items found in this collection."
+        lines = [f"# Collection: {coll_name} (`{collection_key}`)", ""]
+        for i, item in enumerate(items, 1):
+            lines.extend(_utils.format_item_result(item, index=i))
+        return _helpers._prepend_size_warning("\n".join(lines))
+    except Exception as e:
+        return f"# Collection {collection_key}\n\nError loading collection items: {e}"

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -86,6 +86,66 @@ def _truncate_to_tokens(text: str, max_tokens: int = 8000) -> str:
     return text
 
 
+_DEFAULT_UPDATE_CONFIG = {
+    "auto_update": False,
+    "update_frequency": "manual",
+    "last_update": None,
+    "update_days": 7,
+}
+
+
+def load_update_config(config_path: str | None) -> dict[str, Any]:
+    """Read the semantic-search ``update_config`` block from disk.
+
+    Pure file read with no ChromaDB or embedding-model side effects, so it is
+    safe on the read-only status path. Returns defaults when the file is
+    missing or unreadable.
+    """
+    config = dict(_DEFAULT_UPDATE_CONFIG)
+    if config_path and os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                file_config = json.load(f)
+            config.update(file_config.get("semantic_search", {}).get("update_config", {}))
+        except Exception as e:
+            logger.warning(f"Error loading update config: {e}")
+    return config
+
+
+def should_update(update_config: dict[str, Any]) -> bool:
+    """Decide whether an auto-update is due from ``update_config`` alone.
+
+    Pure function of the config dict (and the wall clock) — no I/O, no model
+    load — so both :class:`ZoteroSemanticSearch` and the status tool can share
+    one source of truth.
+    """
+    if not update_config.get("auto_update", False):
+        return False
+
+    frequency = update_config.get("update_frequency", "manual")
+
+    if frequency == "manual":
+        return False
+    elif frequency == "startup":
+        return True
+    elif frequency == "daily":
+        last_update = update_config.get("last_update")
+        if not last_update:
+            return True
+        return datetime.now() - datetime.fromisoformat(last_update) >= timedelta(days=1)
+    elif frequency.startswith("every_"):
+        try:
+            days = int(frequency.split("_")[1])
+            last_update = update_config.get("last_update")
+            if not last_update:
+                return True
+            return datetime.now() - datetime.fromisoformat(last_update) >= timedelta(days=days)
+        except (ValueError, IndexError):
+            return False
+
+    return False
+
+
 class CrossEncoderReranker:
     """Optional cross-encoder re-ranker for semantic search results."""
 
@@ -158,22 +218,7 @@ class ZoteroSemanticSearch:
 
     def _load_update_config(self) -> dict[str, Any]:
         """Load update configuration from file or use defaults."""
-        config = {
-            "auto_update": False,
-            "update_frequency": "manual",
-            "last_update": None,
-            "update_days": 7
-        }
-
-        if self.config_path and os.path.exists(self.config_path):
-            try:
-                with open(self.config_path) as f:
-                    file_config = json.load(f)
-                    config.update(file_config.get("semantic_search", {}).get("update_config", {}))
-            except Exception as e:
-                logger.warning(f"Error loading update config: {e}")
-
-        return config
+        return load_update_config(self.config_path)
 
     def _load_include_fulltext_setting(self) -> bool:
         """Whether to fetch fulltext via the Zotero web API during indexing.
@@ -371,35 +416,7 @@ class ZoteroSemanticSearch:
 
     def should_update_database(self) -> bool:
         """Check if the database should be updated based on configuration."""
-        if not self.update_config.get("auto_update", False):
-            return False
-
-        frequency = self.update_config.get("update_frequency", "manual")
-
-        if frequency == "manual":
-            return False
-        elif frequency == "startup":
-            return True
-        elif frequency == "daily":
-            last_update = self.update_config.get("last_update")
-            if not last_update:
-                return True
-
-            last_update_date = datetime.fromisoformat(last_update)
-            return datetime.now() - last_update_date >= timedelta(days=1)
-        elif frequency.startswith("every_"):
-            try:
-                days = int(frequency.split("_")[1])
-                last_update = self.update_config.get("last_update")
-                if not last_update:
-                    return True
-
-                last_update_date = datetime.fromisoformat(last_update)
-                return datetime.now() - last_update_date >= timedelta(days=days)
-            except (ValueError, IndexError):
-                return False
-
-        return False
+        return should_update(self.update_config)
 
     def _get_items_from_source(self,
                                limit: int | None = None,

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -10,6 +10,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -17,6 +18,7 @@ from typing import Any
 
 try:
     import tiktoken
+
     _tokenizer = tiktoken.get_encoding("cl100k_base")
 except Exception:
     tiktoken = None
@@ -26,9 +28,43 @@ except Exception:
 from .chroma_client import ChromaClient, create_chroma_client
 from .client import get_zotero_client
 from .local_db import LocalZoteroReader
-from .utils import format_creators, is_local_mode
+from .utils import format_creators, is_local_mode, suppress_stdout
 
 logger = logging.getLogger(__name__)
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Best-effort liveness check for a process id (POSIX ``kill(pid, 0)``)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by another user
+    except Exception:
+        return False
+    return True
+
+
+def read_lock_holder(lock_path: Path) -> tuple[int | None, bool]:
+    """Return ``(holder_pid, alive)`` for the update lock, for diagnostics.
+
+    ``holder_pid`` is None when the file is missing/unparseable. ``alive`` says
+    whether that pid still exists — a held lock whose holder is dead would be a
+    genuinely stale lock (flock releases those automatically on POSIX, so this
+    is purely to make the user-facing "skipped" message precise).
+    """
+    try:
+        raw = lock_path.read_text().strip()
+        pid = int(raw)
+    except Exception:
+        return None, False
+    return pid, _pid_is_alive(pid)
+
+
+def _force_update_requested() -> bool:
+    """Whether the user asked to bypass the cross-process update lock."""
+    return os.getenv("ZOTERO_MCP_FORCE_UPDATE", "").strip().lower() in {"1", "true", "yes"}
 
 
 @contextlib.contextmanager
@@ -40,9 +76,18 @@ def _acquire_update_lock(lock_path: Path):
     MCP server's auto-update in ``server_lifespan`` from racing a manual
     ``zotero-mcp update-db`` invocation on the same ChromaDB collection.
 
+    Setting ``ZOTERO_MCP_FORCE_UPDATE=1`` bypasses the lock entirely — an
+    escape hatch for the rare case where a lock appears stuck (e.g. a crashed
+    holder on a filesystem with quirky flock semantics) and the user knowingly
+    accepts the small double-work risk.
+
     Windows lacks ``fcntl``; on that platform the function degrades to a
     no-op and yields True so behaviour matches pre-lock releases.
     """
+    if _force_update_requested():
+        yield True
+        return
+
     try:
         import fcntl
     except ImportError:
@@ -58,13 +103,18 @@ def _acquire_update_lock(lock_path: Path):
         except BlockingIOError:
             yield False
             return
+        # Record our pid so a concurrent invocation can report the holder.
+        try:
+            fd.seek(0)
+            fd.truncate()
+            fd.write(str(os.getpid()))
+            fd.flush()
+        except Exception:
+            pass
         yield True
     finally:
         if fd is not None:
             fd.close()
-
-
-from zotero_mcp.utils import suppress_stdout
 
 
 def _truncate_to_tokens(text: str, max_tokens: int = 8000) -> str:
@@ -146,11 +196,115 @@ def should_update(update_config: dict[str, Any]) -> bool:
     return False
 
 
+# ---------------------------------------------------------------------------
+# Passage-level chunking (Tier-1 grounded retrieval)
+# ---------------------------------------------------------------------------
+
+# Sentinel separating PDF pages in extracted fulltext, when present. Page-aware
+# extractors may insert a form-feed between pages; the chunker uses it to map a
+# character offset back to a 1-indexed page. Absent it, only char offsets are
+# reported and ``page`` is omitted from passage metadata.
+_PAGE_SEPARATOR = "\f"
+
+
+def split_into_passages(
+    text: str,
+    chunk_size: int = 1500,
+    overlap: int = 200,
+    max_chunks: int = 20,
+) -> list[tuple[str, int, int]]:
+    """Split *text* into overlapping passages on natural boundaries.
+
+    Pure function (no I/O, no model load) so it is unit-testable in isolation.
+    Returns a list of ``(passage_text, char_start, char_end)`` tuples with
+    character offsets into the original string. Each window targets
+    ``chunk_size`` characters but is snapped back to the nearest paragraph or
+    sentence boundary in its second half so passages read as coherent quotes.
+    Consecutive windows overlap by ``overlap`` characters so a relevant span
+    straddling a boundary is still captured whole in one of them. At most
+    ``max_chunks`` passages are produced (a guard against pathologically long
+    documents inflating the index).
+    """
+    text = (text or "").strip()
+    if not text:
+        return []
+    if overlap >= chunk_size:
+        overlap = chunk_size // 4
+
+    passages: list[tuple[str, int, int]] = []
+    start = 0
+    n = len(text)
+    while start < n and len(passages) < max_chunks:
+        end = min(n, start + chunk_size)
+        if end < n:
+            window = text[start:end]
+            for sep in ("\n\n", ". ", ".\n", "\n", " "):
+                idx = window.rfind(sep)
+                if idx != -1 and idx >= int(chunk_size * 0.5):
+                    end = start + idx + len(sep)
+                    break
+        chunk = text[start:end].strip()
+        if chunk:
+            passages.append((chunk, start, min(end, n)))
+        if end >= n:
+            break
+        new_start = end - overlap
+        # Guarantee forward progress even when overlap is large.
+        start = new_start if new_start > start else end
+    return passages
+
+
+def _page_for_offset(text: str, offset: int) -> int | None:
+    """Return the 1-indexed page containing *offset*, or None if unknowable.
+
+    Only meaningful when *text* carries ``_PAGE_SEPARATOR`` form-feed page
+    breaks (page-aware extraction). Returns None otherwise so callers can omit
+    a page field rather than report a misleading one.
+    """
+    if _PAGE_SEPARATOR not in text:
+        return None
+    return text.count(_PAGE_SEPARATOR, 0, max(0, offset)) + 1
+
+
+def best_snippet(query: str, text: str, width: int = 320) -> tuple[str, int]:
+    """Return the ``width``-char window of *text* richest in query terms.
+
+    Used to surface a *grounded* quote — the part of a matched document that
+    actually overlaps the query — instead of a blind head-truncation. Returns
+    ``(snippet, char_start)``. Falls back to the head of the text when no query
+    term appears. Pure and dependency-free (lexical overlap only).
+    """
+    text = text or ""
+    if not text.strip():
+        return "", 0
+    if len(text) <= width:
+        return text.strip(), 0
+    terms = [t for t in re.findall(r"\w+", (query or "").lower()) if len(t) > 2]
+    if not terms:
+        return text[:width].strip(), 0
+    lowered = text.lower()
+    # Score each candidate window anchored at a query-term hit; keep the best.
+    best_start = 0
+    best_score = -1
+    for m in re.finditer(r"\w+", lowered):
+        if m.group(0) not in terms:
+            continue
+        start = max(0, m.start() - width // 3)
+        window = lowered[start : start + width]
+        score = sum(window.count(t) for t in terms)
+        if score > best_score:
+            best_score = score
+            best_start = start
+    snippet = text[best_start : best_start + width].strip()
+    return snippet, best_start
+
+
 class CrossEncoderReranker:
     """Optional cross-encoder re-ranker for semantic search results."""
 
     def __init__(self, model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"):
         from sentence_transformers import CrossEncoder
+
         self.model = CrossEncoder(model_name)
 
     def rerank(self, query: str, documents: list[str], top_k: int) -> list[int]:
@@ -158,19 +312,27 @@ class CrossEncoderReranker:
 
         Returns indices of top_k documents in descending relevance order.
         """
+        return [idx for idx, _ in self.rerank_with_scores(query, documents, top_k)]
+
+    def rerank_with_scores(self, query: str, documents: list[str], top_k: int) -> list[tuple[int, float]]:
+        """Re-rank documents, returning ``(index, score)`` pairs.
+
+        Scores are the raw cross-encoder relevance logits, surfaced so search
+        results can report *why* an item ranked where it did, not just an
+        opaque order.
+        """
         pairs = [[query, doc] for doc in documents]
         scores = self.model.predict(pairs)
-        ranked_indices = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)
-        return ranked_indices[:top_k]
+        ranked = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)
+        return [(i, float(scores[i])) for i in ranked[:top_k]]
 
 
 class ZoteroSemanticSearch:
     """Semantic search interface for Zotero libraries using ChromaDB."""
 
-    def __init__(self,
-                 chroma_client: ChromaClient | None = None,
-                 config_path: str | None = None,
-                 db_path: str | None = None):
+    def __init__(
+        self, chroma_client: ChromaClient | None = None, config_path: str | None = None, db_path: str | None = None
+    ):
         """
         Initialize semantic search.
 
@@ -190,6 +352,37 @@ class ZoteroSemanticSearch:
         # Reranker (lazy-initialized on first search)
         self._reranker: CrossEncoderReranker | None = None
         self._reranker_config = self._load_reranker_config()
+
+        # Passage-level chunking (opt-in; default off preserves item-level
+        # indexing and existing collections byte-for-byte).
+        self._chunking_config = self._load_chunking_config()
+
+    def _load_chunking_config(self) -> dict[str, Any]:
+        """Load passage-chunking configuration from file or use defaults.
+
+        When ``enabled`` is true, each item is indexed as several overlapping
+        passages (id ``<item_key>#<n>``) instead of one item-level vector, so
+        semantic search returns grounded passage quotes and long PDFs are
+        searchable past the single-vector truncation limit. Off by default.
+        """
+        config: dict[str, Any] = {
+            "enabled": False,
+            "chunk_size": 1500,
+            "overlap": 200,
+            "max_chunks_per_item": 20,
+        }
+        if self.config_path and os.path.exists(self.config_path):
+            try:
+                with open(self.config_path) as f:
+                    file_config = json.load(f)
+                    config.update(file_config.get("semantic_search", {}).get("chunking", {}))
+            except Exception as e:
+                logger.warning(f"Error loading chunking config: {e}")
+        return config
+
+    @property
+    def _chunking_enabled(self) -> bool:
+        return bool(self._chunking_config.get("enabled", False))
 
     def _load_reranker_config(self) -> dict[str, Any]:
         """Load reranker configuration from file or use defaults."""
@@ -284,7 +477,7 @@ class ZoteroSemanticSearch:
             full_config["semantic_search"]["last_sync_version"] = int(last_sync_version)
 
         try:
-            with open(self.config_path, 'w') as f:
+            with open(self.config_path, "w") as f:
                 json.dump(full_config, f, indent=2)
         except Exception as e:
             logger.error(f"Error saving update config: {e}")
@@ -336,7 +529,8 @@ class ZoteroSemanticSearch:
         if note := data.get("note"):
             # Clean HTML from notes
             import re
-            note_text = re.sub(r'<[^>]+>', '', note)
+
+            note_text = re.sub(r"<[^>]+>", "", note)
             extra_fields.append(note_text)
 
         # Combine all text fields
@@ -418,13 +612,14 @@ class ZoteroSemanticSearch:
         """Check if the database should be updated based on configuration."""
         return should_update(self.update_config)
 
-    def _get_items_from_source(self,
-                               limit: int | None = None,
-                               extract_fulltext: bool = False,
-                               chroma_client: ChromaClient | None = None,
-                               force_rebuild: bool = False,
-                               include_fulltext_via_api: bool = False,
-                               ) -> list[dict[str, Any]]:
+    def _get_items_from_source(
+        self,
+        limit: int | None = None,
+        extract_fulltext: bool = False,
+        chroma_client: ChromaClient | None = None,
+        force_rebuild: bool = False,
+        include_fulltext_via_api: bool = False,
+    ) -> list[dict[str, Any]]:
         """
         Get items from either local database or API.
 
@@ -455,15 +650,18 @@ class ZoteroSemanticSearch:
                     "Set ZOTERO_LOCAL=true or run 'zotero-mcp setup' to enable local mode."
                 )
             return self._get_items_from_local_db(
-                limit,
-                extract_fulltext=extract_fulltext,
-                chroma_client=chroma_client,
-                force_rebuild=force_rebuild
+                limit, extract_fulltext=extract_fulltext, chroma_client=chroma_client, force_rebuild=force_rebuild
             )
         else:
             return self._get_items_from_api(limit, include_fulltext=include_fulltext_via_api)
 
-    def _get_items_from_local_db(self, limit: int | None = None, extract_fulltext: bool = False, chroma_client: ChromaClient | None = None, force_rebuild: bool = False) -> list[dict[str, Any]]:
+    def _get_items_from_local_db(
+        self,
+        limit: int | None = None,
+        extract_fulltext: bool = False,
+        chroma_client: ChromaClient | None = None,
+        force_rebuild: bool = False,
+    ) -> list[dict[str, Any]]:
         """
         Get items from local Zotero database.
 
@@ -488,17 +686,22 @@ class ZoteroSemanticSearch:
                 if self.config_path and os.path.exists(self.config_path):
                     with open(self.config_path) as _f:
                         _cfg = json.load(_f)
-                        semantic_cfg = _cfg.get('semantic_search', {})
-                        extraction_cfg = semantic_cfg.get('extraction', {})
-                        pdf_max_pages = extraction_cfg.get('pdf_max_pages')
-                        pdf_timeout = extraction_cfg.get('pdf_timeout', 30)
+                        semantic_cfg = _cfg.get("semantic_search", {})
+                        extraction_cfg = semantic_cfg.get("extraction", {})
+                        pdf_max_pages = extraction_cfg.get("pdf_max_pages")
+                        pdf_timeout = extraction_cfg.get("pdf_timeout", 30)
                         # Use config db_path only if no CLI override
                         if not zotero_db_path:
-                            zotero_db_path = semantic_cfg.get('zotero_db_path')
+                            zotero_db_path = semantic_cfg.get("zotero_db_path")
             except Exception:
                 pass
 
-            with suppress_stdout(), LocalZoteroReader(db_path=zotero_db_path, pdf_max_pages=pdf_max_pages, pdf_timeout=pdf_timeout) as reader:
+            with (
+                suppress_stdout(),
+                LocalZoteroReader(
+                    db_path=zotero_db_path, pdf_max_pages=pdf_max_pages, pdf_timeout=pdf_timeout
+                ) as reader,
+            ):
                 # Phase 1: fetch metadata only (fast)
                 sys.stderr.write("Scanning local Zotero database for items...\n")
                 local_items = reader.get_items_with_text(limit=limit, include_fulltext=False)
@@ -546,7 +749,11 @@ class ZoteroSemanticSearch:
                             if not k:
                                 continue
                             best = key_to_best.get(k)
-                            if best is not None and best is not it and getattr(best, "item_type", None) == "journalArticle":
+                            if (
+                                best is not None
+                                and best is not it
+                                and getattr(best, "item_type", None) == "journalArticle"
+                            ):
                                 drop = True
                                 break
                         if drop:
@@ -557,7 +764,9 @@ class ZoteroSemanticSearch:
                 total_to_extract = len(local_items)
                 if total_to_extract != candidate_count:
                     try:
-                        sys.stderr.write(f"After filtering/dedup: {total_to_extract} items to process. Extracting content...\n")
+                        sys.stderr.write(
+                            f"After filtering/dedup: {total_to_extract} items to process. Extracting content...\n"
+                        )
                     except Exception:
                         pass
                 else:
@@ -739,7 +948,9 @@ class ZoteroSemanticSearch:
                             for name in _skipped_pdfs:
                                 sys.stderr.write(f"    - {name}\n")
                         if _skipped_failed:
-                            sys.stderr.write(f"  {len(_skipped_failed)} item(s) skipped (PDF extraction previously failed):\n")
+                            sys.stderr.write(
+                                f"  {len(_skipped_failed)} item(s) skipped (PDF extraction previously failed):\n"
+                            )
                             for name in _skipped_failed[:5]:  # Show first 5
                                 sys.stderr.write(f"    - {name}\n")
                             if len(_skipped_failed) > 5:
@@ -765,19 +976,19 @@ class ZoteroSemanticSearch:
                         "version": 0,  # Local items don't have versions
                         "data": {
                             "key": item.key,
-                            "itemType": getattr(item, 'item_type', None) or "journalArticle",
+                            "itemType": getattr(item, "item_type", None) or "journalArticle",
                             "title": item.title or "",
                             "abstractNote": item.abstract or "",
                             "extra": item.extra or "",
                             # Include fulltext only when extracted
-                            "fulltext": getattr(item, 'fulltext', None) or "" if extract_fulltext else "",
-                            "fulltextSource": getattr(item, 'fulltext_source', None) or "" if extract_fulltext else "",
+                            "fulltext": getattr(item, "fulltext", None) or "" if extract_fulltext else "",
+                            "fulltextSource": getattr(item, "fulltext_source", None) or "" if extract_fulltext else "",
                             # Flag if extraction was attempted but failed (timeout, empty)
-                            "fulltext_attempted": getattr(item, '_fulltext_attempted', False),
+                            "fulltext_attempted": getattr(item, "_fulltext_attempted", False),
                             "dateAdded": item.date_added,
                             "dateModified": item.date_modified,
-                            "creators": self._parse_creators_string(item.creators) if item.creators else []
-                        }
+                            "creators": self._parse_creators_string(item.creators) if item.creators else [],
+                        },
                     }
 
                     # Add notes if available
@@ -808,23 +1019,16 @@ class ZoteroSemanticSearch:
             return []
 
         creators = []
-        for creator in creators_str.split(';'):
+        for creator in creators_str.split(";"):
             creator = creator.strip()
             if not creator:
                 continue
 
-            if ',' in creator:
-                last, first = creator.split(',', 1)
-                creators.append({
-                    "creatorType": "author",
-                    "firstName": first.strip(),
-                    "lastName": last.strip()
-                })
+            if "," in creator:
+                last, first = creator.split(",", 1)
+                creators.append({"creatorType": "author", "firstName": first.strip(), "lastName": last.strip()})
             else:
-                creators.append({
-                    "creatorType": "author",
-                    "name": creator
-                })
+                creators.append({"creatorType": "author", "name": creator})
 
         return creators
 
@@ -845,6 +1049,7 @@ class ZoteroSemanticSearch:
             text (e.g. "web-api:parent", "web-api:attachment:<key>"). Empty
             strings mean no fulltext is available for this item.
         """
+
         def _extract_content(resp: Any) -> str:
             if isinstance(resp, dict):
                 return str(resp.get("content", "") or "")
@@ -917,10 +1122,7 @@ class ZoteroSemanticSearch:
                 data["fulltext_attempted"] = True
             if idx % 25 == 0 or idx == total:
                 try:
-                    sys.stderr.write(
-                        f"\r  Fulltext: {idx}/{total} items checked, "
-                        f"{fetched} with text"
-                    )
+                    sys.stderr.write(f"\r  Fulltext: {idx}/{total} items checked, {fetched} with text")
                     sys.stderr.flush()
                 except Exception:
                     pass
@@ -929,9 +1131,7 @@ class ZoteroSemanticSearch:
         except Exception:
             pass
 
-    def _get_items_from_api(self,
-                            limit: int | None = None,
-                            include_fulltext: bool = False) -> list[dict[str, Any]]:
+    def _get_items_from_api(self, limit: int | None = None, include_fulltext: bool = False) -> list[dict[str, Any]]:
         """
         Get items from Zotero API (original implementation).
 
@@ -975,8 +1175,7 @@ class ZoteroSemanticSearch:
 
             # Filter out attachments and notes by default
             filtered_items = [
-                item for item in items
-                if item.get("data", {}).get("itemType") not in ["attachment", "note"]
+                item for item in items if item.get("data", {}).get("itemType") not in ["attachment", "note"]
             ]
 
             all_items.extend(filtered_items)
@@ -994,10 +1193,9 @@ class ZoteroSemanticSearch:
         logger.info(f"Retrieved {len(all_items)} items from API")
         return all_items
 
-    def _get_changed_items_from_api(self,
-                                    since_version: int,
-                                    include_fulltext: bool = False
-                                    ) -> tuple[list[dict[str, Any]], set[str]]:
+    def _get_changed_items_from_api(
+        self, since_version: int, include_fulltext: bool = False
+    ) -> tuple[list[dict[str, Any]], set[str]]:
         """Fetch only items changed in the Zotero library since a given version.
 
         Uses pyzotero's `item_versions(since=V)` to discover changed top-level
@@ -1047,11 +1245,13 @@ class ZoteroSemanticSearch:
 
         return changed_items, current_keys
 
-    def update_database(self,
-                       force_full_rebuild: bool = False,
-                       limit: int | None = None,
-                       extract_fulltext: bool = False,
-                       include_fulltext: bool | None = None) -> dict[str, Any]:
+    def update_database(
+        self,
+        force_full_rebuild: bool = False,
+        limit: int | None = None,
+        extract_fulltext: bool = False,
+        include_fulltext: bool | None = None,
+    ) -> dict[str, Any]:
         """
         Update the semantic search database with Zotero items.
 
@@ -1082,7 +1282,7 @@ class ZoteroSemanticSearch:
             "deleted_items": 0,
             "errors": 0,
             "start_time": start_time.isoformat(),
-            "duration": None
+            "duration": None,
         }
 
         # Guard against concurrent rebuilds: the MCP server auto-launches
@@ -1094,11 +1294,24 @@ class ZoteroSemanticSearch:
         acquired = lock_cm.__enter__()
         if not acquired:
             lock_cm.__exit__(None, None, None)
-            logger.warning(
-                "Another semantic-search update is already running "
-                "(lock held at %s); skipping this invocation.",
-                lock_path,
-            )
+            holder_pid, holder_alive = read_lock_holder(lock_path)
+            if holder_pid and not holder_alive:
+                logger.warning(
+                    "Update lock at %s is held by dead pid %s (stale). "
+                    "flock should have released it; set ZOTERO_MCP_FORCE_UPDATE=1 "
+                    "to bypass if this persists.",
+                    lock_path,
+                    holder_pid,
+                )
+            else:
+                logger.warning(
+                    "Another semantic-search update is already running "
+                    "(lock held at %s by pid %s); skipping this invocation. "
+                    "This is expected when the MCP server's background sync is "
+                    "active. Set ZOTERO_MCP_FORCE_UPDATE=1 to override.",
+                    lock_path,
+                    holder_pid if holder_pid else "unknown",
+                )
             stats["duration"] = "0:00:00"
             stats["skipped_reason"] = "another_update_in_progress"
             return stats
@@ -1123,10 +1336,7 @@ class ZoteroSemanticSearch:
             # fulltext only), not a test limit, and a known prior sync version.
             last_sync_version = self._load_last_sync_version() if not force_full_rebuild else 0
             use_incremental = (
-                not force_full_rebuild
-                and not extract_fulltext
-                and limit is None
-                and last_sync_version > 0
+                not force_full_rebuild and not extract_fulltext and limit is None and last_sync_version > 0
             )
 
             target_sync_version: int | None = None
@@ -1142,8 +1352,7 @@ class ZoteroSemanticSearch:
                 # No changes since last sync; skip ingest but still touch last_update
                 try:
                     sys.stderr.write(
-                        f"\nLibrary unchanged since last sync (version {last_sync_version}); "
-                        f"no items to reindex.\n"
+                        f"\nLibrary unchanged since last sync (version {last_sync_version}); no items to reindex.\n"
                     )
                 except Exception:
                     pass
@@ -1159,17 +1368,22 @@ class ZoteroSemanticSearch:
                     since_version=last_sync_version,
                     include_fulltext=include_fulltext_via_api,
                 )
-                # Delete collection entries that are no longer present in the library
+                # Delete collection entries that are no longer present in the
+                # library. Map any chunk ids (``<key>#<n>``) back to item keys
+                # so deletion works identically whether or not chunking is on.
                 try:
                     stored_ids = self.chroma_client.get_all_ids()
-                    to_delete = [k for k in (stored_ids - current_library_keys) if k]
-                    if to_delete:
-                        self.chroma_client.delete_documents(to_delete)
-                        stats["deleted_items"] = len(to_delete)
+                    stored_item_keys = {i.split("#", 1)[0] for i in stored_ids}
+                    to_delete_keys = [k for k in (stored_item_keys - current_library_keys) if k]
+                    if to_delete_keys:
+                        if self._chunking_enabled and hasattr(self.chroma_client, "delete_item_chunks"):
+                            for k in to_delete_keys:
+                                self.chroma_client.delete_item_chunks(k)
+                        else:
+                            self.chroma_client.delete_documents(to_delete_keys)
+                        stats["deleted_items"] = len(to_delete_keys)
                         try:
-                            sys.stderr.write(
-                                f"\nDeleted {len(to_delete)} items no longer present in Zotero.\n"
-                            )
+                            sys.stderr.write(f"\nDeleted {len(to_delete_keys)} items no longer present in Zotero.\n")
                         except Exception:
                             pass
                 except Exception as e:
@@ -1199,7 +1413,7 @@ class ZoteroSemanticSearch:
             stats["total_items"] = len(all_items)
             logger.info(f"Found {stats['total_items']} items to process")
             # User-friendly progress reporting
-            total = stats['total_items'] = len(all_items)
+            total = stats["total_items"] = len(all_items)
             try:
                 sys.stderr.write(f"\nIndexing {total} items...\n\n")
                 sys.stderr.flush()
@@ -1213,7 +1427,7 @@ class ZoteroSemanticSearch:
             seen_items = 0
             _failed_docs = []  # Collect failures for end-of-run retry
             for i in range(0, len(all_items), batch_size):
-                batch = all_items[i:i + batch_size]
+                batch = all_items[i : i + batch_size]
 
                 # Show per-item progress within this batch
                 for item in batch:
@@ -1236,7 +1450,9 @@ class ZoteroSemanticSearch:
                 stats["skipped_items"] += batch_stats["skipped"]
                 stats["errors"] += batch_stats["errors"]
 
-                logger.info(f"Processed {seen_items}/{total} items (added: {stats['added_items']}, skipped: {stats['skipped_items']})")
+                logger.info(
+                    f"Processed {seen_items}/{total} items (added: {stats['added_items']}, skipped: {stats['skipped_items']})"
+                )
 
             # Retry any documents that failed during the main run
             if _failed_docs:
@@ -1247,6 +1463,7 @@ class ZoteroSemanticSearch:
                     pass
 
                 import time as _retry_time
+
                 _retry_time.sleep(1)  # Brief pause before retry
 
                 retry_ok = 0
@@ -1324,9 +1541,17 @@ class ZoteroSemanticSearch:
         """
         stats = {"processed": 0, "added": 0, "updated": 0, "skipped": 0, "errors": 0}
 
-        documents = []
-        metadatas = []
-        ids = []
+        chunking = self._chunking_enabled
+        chunk_size = int(self._chunking_config.get("chunk_size", 1500))
+        overlap = int(self._chunking_config.get("overlap", 200))
+        max_chunks = int(self._chunking_config.get("max_chunks_per_item", 20))
+
+        documents: list[str] = []
+        metadatas: list[dict[str, Any]] = []
+        ids: list[str] = []
+        # One entry per *item* successfully prepared (not per chunk) so add/
+        # update accounting stays item-granular regardless of chunking.
+        item_keys_order: list[str] = []
 
         for item in items:
             try:
@@ -1349,13 +1574,35 @@ class ZoteroSemanticSearch:
                     stats["skipped"] += 1
                     continue
 
-                # Truncate to fit the configured embedding model's token limit
-                doc_text = self.chroma_client.truncate_text(doc_text)
+                if chunking:
+                    # Index one vector per overlapping passage so search can
+                    # return a grounded quote and long PDFs stay searchable
+                    # past the single-vector truncation limit.
+                    passages = split_into_passages(doc_text, chunk_size, overlap, max_chunks)
+                    if not passages:
+                        stats["skipped"] += 1
+                        continue
+                    n_chunks = len(passages)
+                    for ci, (chunk_text, c0, c1) in enumerate(passages):
+                        cmeta = dict(metadata)
+                        cmeta["parent_item_key"] = item_key
+                        cmeta["chunk_index"] = ci
+                        cmeta["n_chunks"] = n_chunks
+                        cmeta["char_start"] = c0
+                        cmeta["char_end"] = c1
+                        page = _page_for_offset(doc_text, c0)
+                        if page is not None:
+                            cmeta["page"] = page
+                        documents.append(self.chroma_client.truncate_text(chunk_text))
+                        metadatas.append(cmeta)
+                        ids.append(f"{item_key}#{ci}")
+                else:
+                    # Truncate to fit the configured embedding model's token limit
+                    documents.append(self.chroma_client.truncate_text(doc_text))
+                    metadatas.append(metadata)
+                    ids.append(item_key)
 
-                documents.append(doc_text)
-                metadatas.append(metadata)
-                ids.append(item_key)
-
+                item_keys_order.append(item_key)
                 stats["processed"] += 1
 
             except Exception as e:
@@ -1364,14 +1611,28 @@ class ZoteroSemanticSearch:
 
         # Add documents to ChromaDB if any
         if documents:
-            existing_ids = set()
+            # Which items already existed (drives added-vs-updated). When
+            # chunking, also clear an item's stale passages before re-adding so
+            # a shrinking document never leaves orphaned chunks behind.
+            existing_item_keys: set[str] = set()
             if not force_rebuild:
-                existing_ids = self.chroma_client.get_existing_ids(ids)
+                if chunking:
+                    probe_ids = [f"{k}#0" for k in item_keys_order]
+                    existing_chunk0 = self.chroma_client.get_existing_ids(probe_ids)
+                    existing_item_keys = {cid.split("#", 1)[0] for cid in existing_chunk0}
+                    if hasattr(self.chroma_client, "delete_item_chunks"):
+                        for k in dict.fromkeys(item_keys_order):
+                            try:
+                                self.chroma_client.delete_item_chunks(k)
+                            except Exception as e:
+                                logger.debug(f"delete_item_chunks({k}) failed: {e}")
+                else:
+                    existing_item_keys = self.chroma_client.get_existing_ids(ids)
 
             try:
                 self.chroma_client.upsert_documents(documents, metadatas, ids)
-                for doc_id in ids:
-                    if doc_id in existing_ids:
+                for k in item_keys_order:
+                    if k in existing_item_keys:
                         stats["updated"] += 1
                     else:
                         stats["added"] += 1
@@ -1393,10 +1654,7 @@ class ZoteroSemanticSearch:
 
         return stats
 
-    def search(self,
-               query: str,
-               limit: int = 10,
-               filters: dict[str, Any] | None = None) -> dict[str, Any]:
+    def search(self, query: str, limit: int = 10, filters: dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Perform semantic search over the Zotero library.
 
@@ -1409,37 +1667,42 @@ class ZoteroSemanticSearch:
             Search results with Zotero item details
         """
         try:
-            # Over-fetch candidates when re-ranking is enabled
+            # Over-fetch candidates when re-ranking and/or chunking are on.
             reranker = self._get_reranker()
             fetch_limit = limit
+            if self._chunking_enabled:
+                # Passages are grouped back to items downstream, so fetch
+                # several chunks per desired item to still surface ~limit
+                # distinct papers.
+                fetch_limit = max(fetch_limit, limit * 4)
             if reranker:
                 multiplier = self._reranker_config.get("candidate_multiplier", 3)
-                fetch_limit = limit * multiplier
+                fetch_limit = max(fetch_limit, limit * multiplier)
 
             # Perform semantic search
-            results = self.chroma_client.search(
-                query_texts=[query],
-                n_results=fetch_limit,
-                where=filters
-            )
+            results = self.chroma_client.search(query_texts=[query], n_results=fetch_limit, where=filters)
 
-            # Re-rank results with cross-encoder if enabled
+            # Re-rank results with cross-encoder if enabled. With chunking we
+            # rerank ALL candidates (grouping to `limit` items happens in
+            # enrichment); without chunking we keep the historical top-k=limit.
             if reranker and results.get("documents") and results["documents"][0]:
                 documents = results["documents"][0]
-                ranked_indices = reranker.rerank(query, documents, top_k=limit)
+                top_k = len(documents) if self._chunking_enabled else limit
+                ranked_indices = reranker.rerank(query, documents, top_k=top_k)
                 for key in ["ids", "distances", "documents", "metadatas"]:
                     if results.get(key) and results[key][0]:
                         results[key][0] = [results[key][0][i] for i in ranked_indices]
 
-            # Enrich results with full Zotero item data
-            enriched_results = self._enrich_search_results(results, query)
+            # Enrich results with full Zotero item data, grouping passages back
+            # to their parent items and capping at `limit` distinct papers.
+            enriched_results = self._enrich_search_results(results, query, limit)
 
             return {
                 "query": query,
                 "limit": limit,
                 "filters": filters,
                 "results": enriched_results,
-                "total_found": len(enriched_results)
+                "total_found": len(enriched_results),
             }
 
         except Exception as e:
@@ -1450,12 +1713,23 @@ class ZoteroSemanticSearch:
                 "filters": filters,
                 "results": [],
                 "total_found": 0,
-                "error": str(e)
+                "error": str(e),
             }
 
-    def _enrich_search_results(self, chroma_results: dict[str, Any], query: str) -> list[dict[str, Any]]:
-        """Enrich ChromaDB results with full Zotero item data."""
-        enriched = []
+    def _enrich_search_results(
+        self, chroma_results: dict[str, Any], query: str, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        """Enrich ChromaDB results with full Zotero item data.
+
+        Chunk-aware: when the collection is indexed as passages, ids look like
+        ``<item_key>#<n>``. Results are grouped back to their parent item — the
+        first (best-ranked) passage per item wins — and capped at ``limit``
+        distinct items. For every hit a grounded ``matched_passage`` quote and,
+        when available, the passage's character offset and page are attached so
+        callers can cite precisely. Item-level collections (ids without ``#``)
+        flow through unchanged.
+        """
+        enriched: list[dict[str, Any]] = []
 
         if not chroma_results.get("ids") or not chroma_results["ids"][0]:
             return enriched
@@ -1465,33 +1739,44 @@ class ZoteroSemanticSearch:
         documents = chroma_results.get("documents", [[]])[0]
         metadatas = chroma_results.get("metadatas", [[]])[0]
 
-        for i, item_key in enumerate(ids):
+        seen_items: set[str] = set()
+        for i, raw_id in enumerate(ids):
+            item_key = raw_id.split("#", 1)[0]
+            if item_key in seen_items:
+                continue
+            seen_items.add(item_key)
+
+            distance = distances[i] if i < len(distances) else None
+            document = documents[i] if i < len(documents) else ""
+            meta = metadatas[i] if i < len(metadatas) else {}
+
+            passage, passage_offset = best_snippet(query, document)
+
+            enriched_result: dict[str, Any] = {
+                "item_key": item_key,
+                "similarity_score": (1 - distance) if distance is not None else 0,
+                "matched_text": document,
+                "matched_passage": passage,
+                "metadata": meta if isinstance(meta, dict) else {},
+                "query": query,
+            }
+            # Passage provenance — present only on a chunk-indexed collection.
+            if isinstance(meta, dict):
+                for mk in ("chunk_index", "n_chunks", "char_start", "char_end", "page"):
+                    if mk in meta:
+                        enriched_result[mk] = meta[mk]
+            if "char_start" not in enriched_result and passage_offset:
+                enriched_result["passage_offset"] = passage_offset
+
             try:
-                # Get full item data from Zotero
-                zotero_item = self.zotero_client.item(item_key)
-
-                enriched_result = {
-                    "item_key": item_key,
-                    "similarity_score": 1 - distances[i] if i < len(distances) else 0,
-                    "matched_text": documents[i] if i < len(documents) else "",
-                    "metadata": metadatas[i] if i < len(metadatas) else {},
-                    "zotero_item": zotero_item,
-                    "query": query
-                }
-
-                enriched.append(enriched_result)
-
+                enriched_result["zotero_item"] = self.zotero_client.item(item_key)
             except Exception as e:
                 logger.error(f"Error enriching result for item {item_key}: {e}")
-                # Include basic result even if enrichment fails
-                enriched.append({
-                    "item_key": item_key,
-                    "similarity_score": 1 - distances[i] if i < len(distances) else 0,
-                    "matched_text": documents[i] if i < len(documents) else "",
-                    "metadata": metadatas[i] if i < len(metadatas) else {},
-                    "query": query,
-                    "error": f"Could not fetch full item data: {e}"
-                })
+                enriched_result["error"] = f"Could not fetch full item data: {e}"
+
+            enriched.append(enriched_result)
+            if limit and len(enriched) >= limit:
+                break
 
         return enriched
 

--- a/src/zotero_mcp/setup_helper.py
+++ b/src/zotero_mcp/setup_helper.py
@@ -339,6 +339,30 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
     # behavior. The flag is ignored in local mode (ZOTERO_LOCAL=true uses
     # local sqlite extraction).
     config.setdefault("include_fulltext", True)
+    # Discoverable defaults for the two retrieval-quality knobs (both off so
+    # the base experience is unchanged). Preserve any existing user values.
+    #   reranker: local cross-encoder re-rank of candidates for higher
+    #             precision (needs sentence-transformers; adds a model load).
+    #   chunking: index each item as overlapping passages so search returns
+    #             grounded quotes and long PDFs stay searchable. Enabling it
+    #             requires a one-time `update-db --force-rebuild`.
+    if existing_semantic_config and existing_semantic_config.get("reranker"):
+        config["reranker"] = existing_semantic_config["reranker"]
+    else:
+        config.setdefault("reranker", {
+            "enabled": False,
+            "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+            "candidate_multiplier": 3,
+        })
+    if existing_semantic_config and existing_semantic_config.get("chunking"):
+        config["chunking"] = existing_semantic_config["chunking"]
+    else:
+        config.setdefault("chunking", {
+            "enabled": False,
+            "chunk_size": 1500,
+            "overlap": 200,
+            "max_chunks_per_item": 20,
+        })
     if zotero_db_path:
         config["zotero_db_path"] = zotero_db_path
 

--- a/src/zotero_mcp/tools/__init__.py
+++ b/src/zotero_mcp/tools/__init__.py
@@ -3,9 +3,11 @@
 from zotero_mcp.tools import (  # noqa: F401
     annotations,
     connectors,
+    discovery,
     read_pdf,
     retrieval,
     search,
+    synthesis,
     write,
 )
 
@@ -14,3 +16,9 @@ try:
     from zotero_mcp.tools import scite as scite  # noqa: F401
 except ImportError:
     pass
+
+# Register MCP prompts (research workflows) and resources (library context).
+# Importing these is a side effect that binds their @mcp.prompt / @mcp.resource
+# handlers, exactly like the tool modules above.
+from zotero_mcp import prompts as prompts  # noqa: F401,E402
+from zotero_mcp import resources as resources  # noqa: F401,E402

--- a/src/zotero_mcp/tools/discovery.py
+++ b/src/zotero_mcp/tools/discovery.py
@@ -1,0 +1,376 @@
+"""Discovery tools: find related papers via OpenAlex and assess library coverage."""
+
+import re
+from typing import Literal
+
+import requests
+
+from zotero_mcp import client as _client
+from zotero_mcp import utils as _utils  # noqa: F401  (kept for module-level conventions)
+from zotero_mcp._app import mcp
+from zotero_mcp._context import Context
+from zotero_mcp.client import with_zotero_api_lock
+from zotero_mcp.tools import _helpers
+
+_OPENALEX_BASE = "https://api.openalex.org"
+_MAILTO = "zotero-mcp@users.noreply.github.com"
+_ITEM_KEY_RE = re.compile(r"^[A-Z0-9]{8}$")
+_HTTP_TIMEOUT = 30
+
+
+def _doi_in_library(zot, doi: str) -> bool:
+    """Best-effort membership check: is a paper with this DOI already in Zotero?
+
+    Tolerates any pyzotero error by returning False (treat as "not in library").
+    """
+    if not doi:
+        return False
+    try:
+        zot.add_parameters(q=doi, qmode="everything", itemType="-attachment", limit=5)
+        results = zot.items()
+    except Exception:
+        try:
+            results = zot.items(q=doi, qmode="everything", itemType="-attachment", limit=5)
+        except Exception:
+            return False
+    norm = doi.strip().lower()
+    for item in results or []:
+        item_doi = str(item.get("data", {}).get("DOI", "")).strip().lower()
+        if item_doi and item_doi == norm:
+            return True
+    return False
+
+
+def _short_id(openalex_id: str) -> str:
+    """Reduce a full OpenAlex URL/ID to its bare 'Wxxxx' form."""
+    if not openalex_id:
+        return ""
+    return openalex_id.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _work_summary(work: dict) -> dict:
+    """Extract a compact summary from an OpenAlex work object."""
+    title = work.get("title") or work.get("display_name") or "Untitled"
+    year = work.get("publication_year")
+    doi = _helpers._normalize_doi(work.get("doi")) or ""
+    cited_by = work.get("cited_by_count", 0) or 0
+
+    authors = []
+    for authorship in (work.get("authorships") or [])[:3]:
+        author = authorship.get("author") or {}
+        name = author.get("display_name")
+        if name:
+            authors.append(name)
+    if len(work.get("authorships") or []) > 3:
+        authors.append("et al.")
+
+    return {
+        "title": title,
+        "year": year,
+        "doi": doi,
+        "cited_by": cited_by,
+        "authors": authors,
+    }
+
+
+def _openalex_get(url: str, params: dict | None = None) -> dict | None:
+    """GET an OpenAlex endpoint, returning parsed JSON or None on any failure."""
+    p = {"mailto": _MAILTO}
+    if params:
+        p.update(params)
+    try:
+        resp = requests.get(url, params=p, timeout=_HTTP_TIMEOUT)
+    except Exception:
+        return None
+    if getattr(resp, "status_code", None) != 200:
+        return None
+    try:
+        return resp.json()
+    except Exception:
+        return None
+
+
+def _resolve_doi(identifier: str, zot) -> str | None:
+    """Resolve an identifier (Zotero item key or DOI/URL) to a normalized DOI."""
+    ident = (identifier or "").strip()
+    if not ident:
+        return None
+    if _ITEM_KEY_RE.match(ident):
+        try:
+            item = zot.item(ident)
+        except Exception:
+            return None
+        raw_doi = (item or {}).get("data", {}).get("DOI")
+        return _helpers._normalize_doi(raw_doi)
+    return _helpers._normalize_doi(ident)
+
+
+def _render_related(papers: list[dict], heading: str) -> list[str]:
+    """Render a list of related-paper summaries as markdown lines."""
+    lines = [f"## {heading} ({len(papers)})", ""]
+    if not papers:
+        lines.append("_None found._")
+        lines.append("")
+        return lines
+    for i, p in enumerate(papers, 1):
+        authors = ", ".join(p["authors"]) if p["authors"] else "Unknown authors"
+        year = p["year"] if p["year"] else "n.d."
+        marker = "in library ✓" if p.get("in_library") else "not in library"
+        lines.append(f"{i}. **{p['title']}** ({year})")
+        lines.append(f"   - Authors: {authors}")
+        if p["doi"]:
+            lines.append(f"   - DOI: {p['doi']}")
+        lines.append(f"   - Cited by: {p['cited_by']}")
+        lines.append(f"   - {marker}")
+        lines.append("")
+    return lines
+
+
+@mcp.tool(
+    name="zotero_find_related_papers",
+    description=(
+        "Discover papers related to a known work by following its citation "
+        "graph via OpenAlex (a free scholarly index). Use this to expand a "
+        "literature review: find what a paper CITES (its references) and what "
+        "CITES it (newer follow-up work). Each related paper is flagged as "
+        "already in your Zotero library or not, so you can quickly spot gaps "
+        "to fetch (e.g. via zotero_add_by_doi). "
+        "identifier: either an 8-char Zotero item key (its DOI is looked up) "
+        "or a DOI / DOI-URL directly (e.g. '10.1038/nature12373' or "
+        "'https://doi.org/10.1038/nature12373'). "
+        "direction: 'references' (works this paper cites), 'citations' (works "
+        "citing this paper), or 'both' (default). "
+        "limit: max related papers per direction (default 20, max 50). "
+        "Citations are sorted by citation count (most-cited first); references "
+        "keep their original order. Requires the work to have a resolvable "
+        "DOI present in OpenAlex. "
+        "Example: zotero_find_related_papers(identifier='10.1038/nature12373', "
+        "direction='citations', limit=10)."
+    ),
+)
+@with_zotero_api_lock
+def find_related_papers(
+    identifier: str,
+    direction: Literal["references", "citations", "both"] = "both",
+    limit: int | str | None = 20,
+    *,
+    ctx: Context,
+) -> str:
+    """Find references and/or citing works for a paper via OpenAlex."""
+    try:
+        if direction not in {"references", "citations", "both"}:
+            return "Error: direction must be 'references', 'citations', or 'both'."
+
+        limit = _helpers._normalize_limit(limit, default=20, max_val=50)
+        zot = _client.get_zotero_client()
+
+        ctx.info(f"Resolving identifier to DOI: {identifier}")
+        doi = _resolve_doi(identifier, zot)
+        if not doi:
+            return (
+                f"Could not resolve a DOI for '{identifier}'. Provide a valid "
+                "DOI / DOI-URL, or an 8-char Zotero item key whose item has a "
+                "DOI in its metadata."
+            )
+
+        ctx.info(f"Querying OpenAlex for DOI {doi}")
+        work = _openalex_get(f"{_OPENALEX_BASE}/works/https://doi.org/{doi}")
+        if not work:
+            return f"OpenAlex has no record for DOI '{doi}', or the lookup failed."
+
+        want_refs = direction in {"references", "both"}
+        want_cites = direction in {"citations", "both"}
+
+        references: list[dict] = []
+        citations: list[dict] = []
+
+        if want_refs:
+            ref_ids = [_short_id(r) for r in (work.get("referenced_works") or [])]
+            ref_ids = [r for r in ref_ids if r][:limit]
+            if ref_ids:
+                filter_val = "openalex_id:" + "|".join(ref_ids)
+                data = _openalex_get(
+                    f"{_OPENALEX_BASE}/works",
+                    {"filter": filter_val, "per-page": min(len(ref_ids), 50)},
+                )
+                results = (data or {}).get("results", []) or []
+                # Preserve referenced_works order.
+                by_id = {_short_id(w.get("id")): w for w in results}
+                for rid in ref_ids:
+                    if rid in by_id:
+                        references.append(_work_summary(by_id[rid]))
+
+        if want_cites:
+            cited_by_url = work.get("cited_by_api_url")
+            if cited_by_url:
+                data = _openalex_get(cited_by_url, {"per-page": min(limit, 50)})
+                results = (data or {}).get("results", []) or []
+                citations = [_work_summary(w) for w in results]
+                citations.sort(key=lambda p: p["cited_by"], reverse=True)
+                citations = citations[:limit]
+
+        # Flag library membership for every related paper.
+        for p in references + citations:
+            p["in_library"] = _doi_in_library(zot, p["doi"]) if p["doi"] else False
+
+        src_title = work.get("title") or work.get("display_name") or doi
+        output = [
+            f"# Related Papers for: {src_title}",
+            "",
+            f"Source DOI: {doi}",
+        ]
+        summary_bits = []
+        if want_refs:
+            summary_bits.append(f"{len(references)} references")
+        if want_cites:
+            summary_bits.append(f"{len(citations)} citations")
+        in_lib = sum(1 for p in references + citations if p.get("in_library"))
+        summary_bits.append(f"{in_lib} already in library")
+        output.append("Found " + ", ".join(summary_bits) + ".")
+        output.append("")
+
+        if want_refs:
+            output.extend(_render_related(references, "References (works this paper cites)"))
+        if want_cites:
+            output.extend(_render_related(citations, "Citations (works citing this paper)"))
+
+        return "\n".join(output)
+
+    except Exception as e:
+        ctx.error(f"Error finding related papers: {e}")
+        return f"Error finding related papers: {e}"
+
+
+def _item_has_pdf(zot, item: dict) -> bool:
+    """Return True if the item is/has a PDF attachment.
+
+    A standalone PDF attachment counts directly; otherwise we inspect the
+    item's children for any PDF attachment. Tolerant of children() errors.
+    """
+    data = item.get("data", {})
+    if data.get("itemType") == "attachment" and data.get("contentType") == "application/pdf":
+        return True
+    key = item.get("key") or data.get("key")
+    if not key:
+        return False
+    try:
+        children = zot.children(key)
+    except Exception:
+        return False
+    for child in children or []:
+        cdata = child.get("data", {})
+        if cdata.get("itemType") == "attachment" and cdata.get("contentType") == "application/pdf":
+            return True
+    return False
+
+
+@mcp.tool(
+    name="zotero_library_coverage",
+    description=(
+        "Audit PDF coverage across your Zotero library (or one collection): "
+        "which items have a downloaded PDF attachment and which are missing "
+        "one. Use this to find papers you can still fetch full text for — the "
+        "missing list includes each item's DOI so you can pass it to "
+        "zotero_add_by_doi's open-access download cascade. "
+        "collection_key: optional 8-char key to scope the audit to one "
+        "collection; omit to scan the whole library. "
+        "limit: max top-level items to scan (default 200). "
+        "Attachments, notes, and annotations are skipped as scan targets; an "
+        "item counts as covered if it (or any child) is a PDF attachment. "
+        "Reports total scanned, covered count, missing count, coverage "
+        "percentage, and a capped list (first 50) of missing items with "
+        "title, year, key, and DOI. "
+        "Example: zotero_library_coverage(collection_key='ABCD1234', "
+        "limit=100)."
+    ),
+)
+@with_zotero_api_lock
+def library_coverage(
+    collection_key: str | None = None,
+    limit: int | str | None = 200,
+    *,
+    ctx: Context,
+) -> str:
+    """Report PDF-attachment coverage across the library or a collection."""
+    try:
+        limit = _helpers._normalize_limit(limit, default=200, max_val=2000)
+        zot = _client.get_zotero_client()
+
+        skip_types = {"attachment", "note", "annotation"}
+
+        ctx.info("Scanning library for PDF coverage...")
+        if collection_key:
+            items = _helpers._paginate(
+                zot.collection_items,
+                collection_key,
+                max_items=limit,
+                itemType="-attachment",
+            )
+        else:
+            items = _helpers._paginate(
+                zot.items,
+                max_items=limit,
+                itemType="-attachment",
+            )
+
+        scanned = 0
+        with_pdf = 0
+        missing: list[dict] = []
+
+        for item in items or []:
+            data = item.get("data", {})
+            item_type = data.get("itemType")
+            # A standalone PDF attachment is a valid scan target even though
+            # we excluded attachments at the API level (defensive).
+            is_standalone_pdf = item_type == "attachment" and data.get("contentType") == "application/pdf"
+            if item_type in skip_types and not is_standalone_pdf:
+                continue
+
+            scanned += 1
+            if _item_has_pdf(zot, item):
+                with_pdf += 1
+            else:
+                title = data.get("title") or data.get("filename") or "Untitled"
+                year = str(data.get("date", ""))[:4]
+                missing.append(
+                    {
+                        "title": title,
+                        "year": year,
+                        "key": item.get("key", ""),
+                        "doi": data.get("DOI", ""),
+                    }
+                )
+
+        missing_count = len(missing)
+        pct = (with_pdf / scanned * 100) if scanned else 0.0
+
+        scope = f"collection {collection_key}" if collection_key else "entire library"
+        output = [
+            f"# PDF Coverage Report ({scope})",
+            "",
+            f"- Items scanned: {scanned}",
+            f"- With PDF: {with_pdf}",
+            f"- Missing PDF: {missing_count}",
+            f"- Coverage: {pct:.1f}%",
+            "",
+        ]
+
+        if missing:
+            shown = missing[:50]
+            output.append(f"## Items Missing a PDF (showing {len(shown)} of {missing_count})")
+            output.append("")
+            for i, m in enumerate(shown, 1):
+                year = m["year"] if m["year"] else "n.d."
+                line = f"{i}. **{m['title']}** ({year}) — key: {m['key']}"
+                if m["doi"]:
+                    line += f" — DOI: {m['doi']}"
+                output.append(line)
+            output.append("")
+        else:
+            output.append("All scanned items have a PDF attachment. ✓")
+
+        return "\n".join(output)
+
+    except Exception as e:
+        ctx.error(f"Error computing library coverage: {e}")
+        return f"Error computing library coverage: {e}"

--- a/src/zotero_mcp/tools/search.py
+++ b/src/zotero_mcp/tools/search.py
@@ -881,19 +881,39 @@ def semantic_search(
             similarity_score = result.get("similarity_score", 0)
             zotero_item = result.get("zotero_item", {})
 
+            # Prefer the grounded passage — the window of the document that
+            # actually overlaps the query — over a blind head-truncation, so
+            # the agent gets a citable quote rather than the abstract's opening.
+            passage = result.get("matched_passage") or result.get("matched_text", "")
+            snippet = passage[:400] + "..." if len(passage) > 400 else passage
+
+            # Provenance for citing: page (when the index carries page breaks),
+            # else which passage of how many, else an approximate char offset.
+            loc_bits = []
+            if (page := result.get("page")) is not None:
+                loc_bits.append(f"p. {page}")
+            if (ci := result.get("chunk_index")) is not None and (nc := result.get("n_chunks")):
+                loc_bits.append(f"passage {ci + 1}/{nc}")
+            elif off := result.get("char_start", result.get("passage_offset")):
+                loc_bits.append(f"char ~{off}")
+
             if zotero_item:
-                extra = {"Similarity Score": f"{similarity_score:.3f}"}
-                matched_text = result.get("matched_text", "")
-                if matched_text:
-                    snippet = matched_text[:300] + "..." if len(matched_text) > 300 else matched_text
-                    extra["Matched Content"] = snippet
+                extra = {"Relevance": f"{similarity_score:.3f}"}
+                if loc_bits:
+                    extra["Location"] = ", ".join(loc_bits)
+                if snippet:
+                    extra["Matched Passage"] = snippet
                 # Override key from result since it may differ from item["key"]
                 zotero_item.setdefault("key", result.get("item_key", ""))
                 output.extend(_utils.format_item_result(zotero_item, index=i, extra_fields=extra))
             else:
                 # Fallback if full Zotero item not available
                 output.append(f"## {i}. Item {result.get('item_key', 'Unknown')}")
-                output.append(f"**Similarity Score:** {similarity_score:.3f}")
+                output.append(f"**Relevance:** {similarity_score:.3f}")
+                if loc_bits:
+                    output.append(f"**Location:** {', '.join(loc_bits)}")
+                if snippet:
+                    output.append(f"**Matched Passage:** {snippet}")
                 if error := result.get("error"):
                     output.append(f"**Error:** {error}")
                 output.append("")

--- a/src/zotero_mcp/tools/search.py
+++ b/src/zotero_mcp/tools/search.py
@@ -1013,10 +1013,16 @@ def update_search_database(
         "provider summary."
     )
 )
-@with_zotero_api_lock
 def get_search_database_status(*, ctx: Context) -> str:
     """
     Get semantic search database status.
+
+    Deliberately NOT wrapped in ``@with_zotero_api_lock``: this is a read-only
+    ChromaDB query that never touches the Zotero API, and holding the shared
+    lock here would make a slow status read block every other tool. The read
+    path below also avoids constructing the embedding function, which for the
+    default backend downloads an ONNX model on first use and could otherwise
+    hang this call for minutes.
 
     Args:
         ctx: MCP context
@@ -1027,9 +1033,12 @@ def get_search_database_status(*, ctx: Context) -> str:
     try:
         ctx.info("Getting semantic search database status...")
 
-        # Import semantic search module
+        # Import the lightweight, model-free status readers. These live in the
+        # semantic-search modules so they share the [semantic] extra's import
+        # guard, but neither loads an embedding model or a Zotero client.
         try:
-            from zotero_mcp.semantic_search import create_semantic_search
+            from zotero_mcp.chroma_client import read_collection_status
+            from zotero_mcp.semantic_search import load_update_config, should_update
         except ImportError:
             return (
                 "Semantic search is not available. Install the required packages with:\n"
@@ -1040,33 +1049,31 @@ def get_search_database_status(*, ctx: Context) -> str:
         # Determine config path
         config_path = Path.home() / ".config" / "zotero-mcp" / "config.json"
 
-        # Create semantic search instance
-        search = create_semantic_search(str(config_path))
-
-        # Get status
-        status = search.get_database_status()
+        # Read status without loading any embedding model (fast, no network).
+        collection_info = read_collection_status(str(config_path))
+        update_config = load_update_config(str(config_path))
 
         # Format results
         output = ["# Semantic Search Database Status", ""]
 
-        collection_info = status.get("collection_info", {})
         output.append("## Collection Information")
         output.append(f"**Name:** {collection_info.get('name', 'Unknown')}")
         output.append(f"**Document Count:** {collection_info.get('count', 0)}")
         output.append(f"**Embedding Model:** {collection_info.get('embedding_model', 'Unknown')}")
         output.append(f"**Database Path:** {collection_info.get('persist_directory', 'Unknown')}")
 
+        if collection_info.get("initialized") is False and not collection_info.get("error"):
+            output.append("**Status:** Not initialized — run zotero_update_search_database first.")
         if collection_info.get('error'):
             output.append(f"**Error:** {collection_info['error']}")
 
         output.append("")
 
-        update_config = status.get("update_config", {})
         output.append("## Update Configuration")
         output.append(f"**Auto Update:** {update_config.get('auto_update', False)}")
         output.append(f"**Frequency:** {update_config.get('update_frequency', 'manual')}")
         output.append(f"**Last Update:** {update_config.get('last_update', 'Never')}")
-        output.append(f"**Should Update Now:** {status.get('should_update', False)}")
+        output.append(f"**Should Update Now:** {should_update(update_config)}")
 
         frequency = update_config.get('update_frequency', 'manual')
         if frequency.startswith('every_') and update_config.get('update_days'):

--- a/src/zotero_mcp/tools/synthesis.py
+++ b/src/zotero_mcp/tools/synthesis.py
@@ -1,0 +1,357 @@
+"""Synthesis and export tool functions for the Zotero MCP server.
+
+These tools gather and structure existing library content (annotations,
+notes, citations) so an LLM agent can synthesize literature summaries or
+drop formatted references into a manuscript. They do NOT call an LLM
+themselves; they only collect and format.
+"""
+
+from typing import Literal
+
+from zotero_mcp import client as _client
+from zotero_mcp import utils as _utils
+from zotero_mcp._app import mcp
+from zotero_mcp._context import Context
+from zotero_mcp.client import with_zotero_api_lock
+from zotero_mcp.tools import _helpers
+
+
+def _resolve_paper_title(zot, parent_key: str, cache: dict[str, str]) -> str:
+    """Resolve an annotation/note parent key to its paper title.
+
+    Annotations are children of PDF/EPUB attachments, which are children of
+    the paper (two hops: annotation.parentItem -> attachment ->
+    attachment.parentItem -> paper). Notes are usually direct children of the
+    paper (one hop). This helper tolerates either shape and any missing hop,
+    falling back to the attachment title or the bare key. Results are cached.
+    """
+    if parent_key in cache:
+        return cache[parent_key]
+
+    title = parent_key
+    try:
+        parent = zot.item(parent_key)
+        data = parent.get("data", {}) if parent else {}
+        if data.get("itemType") == "attachment" and data.get("parentItem"):
+            gp_key = data["parentItem"]
+            try:
+                grandparent = zot.item(gp_key)
+                gp_data = grandparent.get("data", {}) if grandparent else {}
+                title = gp_data.get("title") or data.get("title") or parent_key
+            except Exception:
+                title = data.get("title") or parent_key
+        else:
+            title = data.get("title") or parent_key
+    except Exception:
+        title = parent_key
+
+    cache[parent_key] = title
+    return title
+
+
+@mcp.tool(
+    name="zotero_synthesize_annotations",
+    description=(
+        "Collect every highlight, annotation comment, and child note across "
+        "a scope and organize them into a structured, per-paper digest that "
+        "YOU (the agent) can then synthesize into a literature summary. This "
+        "tool does NOT call an LLM — it only gathers and groups the raw "
+        "material, so the synthesis step is yours. "
+        "collection_key: optional 8-character collection key; when given, "
+        "only annotations/notes whose resolved paper is a member of that "
+        "collection are included. When omitted, the whole active library is "
+        "scanned (capped by limit). "
+        "tag: optional tag or list of tags to filter items by (accepts a "
+        "string, a JSON list, or a list). "
+        "limit: cap on annotations/notes scanned (default 200) to keep the "
+        "call tractable. "
+        "Output: markdown grouped by paper — each paper heading followed by "
+        "its highlights (with attached comments) and any note excerpts — "
+        "plus a top summary line counting papers, highlights, and notes. "
+        "Use this before writing a thematic review so you can spot themes "
+        "and contradictions across sources. "
+        "Example: zotero_synthesize_annotations(collection_key='MT53KB66')."
+    ),
+)
+@with_zotero_api_lock
+def synthesize_annotations(
+    collection_key: str | None = None,
+    tag: list[str] | str | None = None,
+    limit: int | str | None = 200,
+    *,
+    ctx: Context,
+) -> str:
+    """Gather annotations and notes into a per-paper digest for synthesis.
+
+    Args:
+        collection_key: Optional collection to restrict the digest to.
+        tag: Optional tag filter (string, JSON list, or list).
+        limit: Maximum annotations/notes to scan.
+        ctx: MCP context.
+
+    Returns:
+        Markdown digest grouped by paper.
+    """
+    try:
+        ctx.info("Gathering annotations and notes for synthesis")
+        zot = _client.get_zotero_client()
+
+        limit = _helpers._normalize_limit(limit, default=200, max_val=5000)
+        tags = _helpers._normalize_tag_filter(tag)
+
+        # Determine the set of allowed paper keys if a collection is scoped.
+        allowed_keys: set[str] | None = None
+        if collection_key:
+            try:
+                coll_items = _helpers._paginate(
+                    zot.collection_items,
+                    collection_key,
+                    itemType="-attachment",
+                )
+                allowed_keys = {it.get("key") for it in coll_items if it.get("key")}
+            except Exception as e:
+                ctx.warning(f"Could not load collection items: {e}")
+                allowed_keys = set()
+
+        anno_params = {"itemType": "annotation"}
+        note_params = {"itemType": "note"}
+        if tags:
+            anno_params["tag"] = tags
+            note_params["tag"] = tags
+
+        try:
+            annotations = _helpers._paginate(zot.items, max_items=limit, **anno_params)
+        except Exception as e:
+            ctx.warning(f"Annotation fetch failed: {e}")
+            annotations = []
+        try:
+            notes = _helpers._paginate(zot.items, max_items=limit, **note_params)
+        except Exception as e:
+            ctx.warning(f"Note fetch failed: {e}")
+            notes = []
+
+        if not annotations and not notes:
+            scope = f" in collection {collection_key}" if collection_key else ""
+            return f"No annotations or notes found{scope}."
+
+        # Group by resolved paper title.
+        title_cache: dict[str, str] = {}
+        papers: dict[str, dict] = {}
+
+        def _bucket(title: str) -> dict:
+            return papers.setdefault(title, {"highlights": [], "notes": []})
+
+        def _in_scope(parent_key: str) -> bool:
+            if allowed_keys is None:
+                return True
+            # Member if the immediate parent, or its grandparent paper, is in scope.
+            if parent_key in allowed_keys:
+                return True
+            try:
+                parent = zot.item(parent_key)
+                data = parent.get("data", {}) if parent else {}
+                gp = data.get("parentItem")
+                if gp and gp in allowed_keys:
+                    return True
+            except Exception:
+                pass
+            return False
+
+        highlight_count = 0
+        for anno in annotations:
+            data = anno.get("data", {})
+            parent_key = data.get("parentItem")
+            text = (data.get("annotationText") or "").strip()
+            comment = (data.get("annotationComment") or "").strip()
+            if not text and not comment:
+                continue
+            if parent_key and not _in_scope(parent_key):
+                continue
+            title = _resolve_paper_title(zot, parent_key, title_cache) if parent_key else "(unknown source)"
+            _bucket(title)["highlights"].append((text, comment))
+            highlight_count += 1
+
+        note_count = 0
+        for note in notes:
+            data = note.get("data", {})
+            parent_key = data.get("parentItem")
+            raw = data.get("note") or ""
+            text = _utils.clean_html(raw).strip()
+            if not text:
+                continue
+            if parent_key and not _in_scope(parent_key):
+                continue
+            title = _resolve_paper_title(zot, parent_key, title_cache) if parent_key else "(standalone note)"
+            if len(text) > 400:
+                text = text[:400] + "..."
+            _bucket(title)["notes"].append(text)
+            note_count += 1
+
+        if not papers:
+            scope = f" in collection {collection_key}" if collection_key else ""
+            return f"No annotations or notes found{scope}."
+
+        output = [
+            "# Annotation & Note Digest",
+            "",
+            (f"**{len(papers)} papers, {highlight_count} highlights, {note_count} notes**"),
+            "",
+        ]
+
+        for title in sorted(papers):
+            bucket = papers[title]
+            output.append(f"## {title}")
+            if bucket["highlights"]:
+                output.append("**Highlights:**")
+                for text, comment in bucket["highlights"]:
+                    line = f"- {text}" if text else "- (comment only)"
+                    if comment:
+                        line += f" — *{comment}*"
+                    output.append(line)
+            if bucket["notes"]:
+                output.append("**Notes:**")
+                for note_text in bucket["notes"]:
+                    output.append(f"- {note_text}")
+            output.append("")
+
+        output.append(
+            "*You can now synthesize themes, agreements, and contradictions across these papers from the digest above.*"
+        )
+
+        result = "\n".join(output)
+        return _helpers._prepend_size_warning(
+            result,
+            "Scope to a collection_key or narrow with tag to reduce size.",
+        )
+
+    except Exception as e:
+        ctx.error(f"Error synthesizing annotations: {str(e)}")
+        return f"Error synthesizing annotations: {str(e)}"
+
+
+def _render_entries(rendered) -> list[str]:
+    """Normalize pyzotero content output into a list of plain-text entries."""
+    if rendered is None:
+        return []
+    if isinstance(rendered, str):
+        return [rendered]
+    entries: list[str] = []
+    for item in rendered:
+        entries.append(item if isinstance(item, str) else str(item))
+    return entries
+
+
+@mcp.tool(
+    name="zotero_export_bibliography",
+    description=(
+        "Render a formatted bibliography or in-text citations for a set of "
+        "Zotero items using Zotero's own CSL citation engine, so you can drop "
+        "references straight into a manuscript. "
+        "item_keys: optional list of 8-character item keys (also accepts a "
+        "JSON list string); takes precedence over collection_key. "
+        "collection_key: optional collection to export instead; if neither is "
+        "given, the active library is exported (capped). "
+        "style: CSL style short name (default 'apa'); e.g. 'modern-language-"
+        "association', 'chicago-note-bibliography', 'ieee'. Ignored for "
+        "bibtex. "
+        "export_format: 'bib' (formatted reference-list entries, default), "
+        "'citation' (in-text citation strings), or 'bibtex' (raw BibTeX for "
+        ".bib files). "
+        "Output: markdown naming the style/format, then the rendered entries "
+        "(a fenced block for bibtex, a numbered list otherwise). "
+        "Requires bibliography rendering support — if the API errors (e.g. "
+        "local read-only mode), the tool suggests web API mode. "
+        "Example: zotero_export_bibliography(item_keys=['RTKZQI8E'], "
+        "style='apa', export_format='bib')."
+    ),
+)
+@with_zotero_api_lock
+def export_bibliography(
+    item_keys: list[str] | str | None = None,
+    collection_key: str | None = None,
+    style: str = "apa",
+    export_format: Literal["bib", "citation", "bibtex"] = "bib",
+    *,
+    ctx: Context,
+) -> str:
+    """Render a formatted bibliography/citations via Zotero's CSL engine.
+
+    Args:
+        item_keys: Optional list of item keys (or JSON/comma string).
+        collection_key: Optional collection to export.
+        style: CSL style short name (default "apa").
+        export_format: "bib", "citation", or "bibtex".
+        ctx: MCP context.
+
+    Returns:
+        Markdown-formatted bibliography or citations.
+    """
+    try:
+        if not isinstance(style, str) or not style.strip():
+            style = "apa"
+        style = style.strip()
+
+        keys: list[str] = []
+        if item_keys is not None:
+            keys = _helpers._normalize_str_list_input(item_keys, "item_keys")
+
+        ctx.info(f"Exporting bibliography (format={export_format}, style={style})")
+        zot = _client.get_zotero_client()
+
+        content = "bibtex" if export_format == "bibtex" else export_format
+
+        try:
+            if keys:
+                fetch_kwargs = {"itemKey": ",".join(keys), "content": content, "limit": 100}
+                if content != "bibtex":
+                    fetch_kwargs["style"] = style
+                rendered = zot.items(**fetch_kwargs)
+            elif collection_key:
+                page_kwargs = {"content": content}
+                if content != "bibtex":
+                    page_kwargs["style"] = style
+                rendered = _helpers._paginate(zot.collection_items, collection_key, max_items=100, **page_kwargs)
+            else:
+                fetch_kwargs = {"content": content, "limit": 100}
+                if content != "bibtex":
+                    fetch_kwargs["style"] = style
+                rendered = zot.items(**fetch_kwargs)
+        except Exception as api_error:
+            ctx.error(f"Bibliography rendering failed: {api_error}")
+            return (
+                f"Error rendering bibliography: {api_error}\n\n"
+                "Bibliography/citation rendering relies on Zotero's web API "
+                "CSL engine. If you are running in local read-only mode, "
+                "configure web API credentials (ZOTERO_API_KEY and "
+                "ZOTERO_LIBRARY_ID) and try again."
+            )
+
+        entries = _render_entries(rendered)
+        if not entries:
+            scope = (
+                f" for collection {collection_key}" if collection_key else (" for the requested items" if keys else "")
+            )
+            return f"No bibliography entries produced{scope}."
+
+        format_label = {
+            "bib": "Bibliography",
+            "citation": "Citations",
+            "bibtex": "BibTeX",
+        }[export_format]
+
+        if export_format == "bibtex":
+            body = "\n\n".join(e.strip() for e in entries if e.strip())
+            return f"# {format_label}\n\n```bibtex\n{body}\n```"
+
+        header = f"# {format_label} ({style})"
+        lines = [header, ""]
+        for i, entry in enumerate(entries, 1):
+            clean = _utils.clean_html(entry).strip()
+            if not clean:
+                continue
+            lines.append(f"{i}. {clean}")
+        return "\n".join(lines)
+
+    except Exception as e:
+        ctx.error(f"Error exporting bibliography: {str(e)}")
+        return f"Error exporting bibliography: {str(e)}"

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,321 @@
+"""Tests for the discovery tools (zotero_find_related_papers, zotero_library_coverage).
+
+Network calls to OpenAlex are stubbed by monkeypatching
+``zotero_mcp.tools.discovery.requests.get``. The Zotero client is stubbed by
+monkeypatching ``zotero_mcp.client.get_zotero_client``.
+"""
+
+from conftest import DummyContext, FakeZotero
+
+from zotero_mcp.tools import discovery
+
+# --- Fake HTTP plumbing ----------------------------------------------------
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+
+    def json(self):
+        return self._payload
+
+
+def _work(work_id, title, year, doi, cited_by, authors=None, **extra):
+    w = {
+        "id": work_id,
+        "title": title,
+        "publication_year": year,
+        "doi": f"https://doi.org/{doi}" if doi else None,
+        "cited_by_count": cited_by,
+        "authorships": [{"author": {"display_name": a}} for a in (authors or [])],
+    }
+    w.update(extra)
+    return w
+
+
+# --- Fake Zotero -----------------------------------------------------------
+
+
+class FakeZoteroDiscovery(FakeZotero):
+    """FakeZotero that supports add_parameters/items for membership checks and
+    children() for coverage."""
+
+    def __init__(self):
+        super().__init__()
+        self._params = {}
+        self._by_doi = {}  # normalized DOI -> list of items returned by items()
+
+    def add_parameters(self, **kwargs):
+        self._params = kwargs
+
+    def items(self, **kwargs):
+        q = (kwargs.get("q") or self._params.get("q") or "").strip().lower()
+        if q and q in self._by_doi:
+            return self._by_doi[q]
+        if q:
+            return []
+        return self._items
+
+
+def _make_zot(monkeypatch):
+    zot = FakeZoteroDiscovery()
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: zot)
+    return zot
+
+
+def _patch_requests(monkeypatch, handler):
+    def fake_get(url, params=None, timeout=None, **kwargs):
+        return handler(url, params or {})
+
+    monkeypatch.setattr(discovery.requests, "get", fake_get)
+
+
+# NOTE: DOIs below use the real `10.NNNN/...` shape because the tool normalizes
+# DOIs via _helpers._normalize_doi, which (correctly) rejects malformed ones.
+
+
+# --- find_related_papers: references --------------------------------------
+
+
+def test_references_direction(monkeypatch):
+    _make_zot(monkeypatch)
+
+    source = {
+        "id": "https://openalex.org/W1",
+        "title": "Source Paper",
+        "display_name": "Source Paper",
+        "referenced_works": [
+            "https://openalex.org/W10",
+            "https://openalex.org/W11",
+        ],
+        "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W1",
+    }
+    ref_results = {
+        "results": [
+            _work("https://openalex.org/W10", "Ref A", 2010, "10.1234/refa", 5, ["Alice A"]),
+            _work("https://openalex.org/W11", "Ref B", 2012, "10.1234/refb", 9, ["Bob B"]),
+        ]
+    }
+
+    def handler(url, params):
+        if url.endswith("/works/https://doi.org/10.1234/x"):
+            return FakeResponse(200, source)
+        if url.endswith("/works") and "openalex_id" in params.get("filter", ""):
+            return FakeResponse(200, ref_results)
+        return FakeResponse(404, {})
+
+    _patch_requests(monkeypatch, handler)
+
+    out = discovery.find_related_papers("10.1234/x", direction="references", ctx=DummyContext())
+    assert "References" in out
+    assert "Ref A" in out
+    assert "Ref B" in out
+    # references keep referenced_works order: Ref A before Ref B
+    assert out.index("Ref A") < out.index("Ref B")
+    assert "Citations" not in out
+
+
+# --- find_related_papers: citations + sorting -----------------------------
+
+
+def test_citations_direction_sorted_by_citation_count(monkeypatch):
+    _make_zot(monkeypatch)
+
+    cited_url = "https://api.openalex.org/works?filter=cites:W1"
+    source = {
+        "id": "https://openalex.org/W1",
+        "title": "Source Paper",
+        "referenced_works": [],
+        "cited_by_api_url": cited_url,
+    }
+    citing_results = {
+        "results": [
+            _work("https://openalex.org/W20", "Citer Low", 2020, "10.1234/low", 3, ["X"]),
+            _work("https://openalex.org/W21", "Citer High", 2021, "10.1234/high", 99, ["Y"]),
+        ]
+    }
+
+    def handler(url, params):
+        if url.endswith("/works/https://doi.org/10.1234/x"):
+            return FakeResponse(200, source)
+        if url == cited_url:
+            return FakeResponse(200, citing_results)
+        return FakeResponse(404, {})
+
+    _patch_requests(monkeypatch, handler)
+
+    out = discovery.find_related_papers("10.1234/x", direction="citations", ctx=DummyContext())
+    assert "Citations" in out
+    assert "References" not in out
+    # Higher citation count first
+    assert out.index("Citer High") < out.index("Citer Low")
+
+
+# --- find_related_papers: library membership flagging ---------------------
+
+
+def test_library_membership_flagging(monkeypatch):
+    zot = _make_zot(monkeypatch)
+    # Mark 10.1234/refa as already in library.
+    zot._by_doi["10.1234/refa"] = [{"key": "INLIB001", "data": {"itemType": "journalArticle", "DOI": "10.1234/refa"}}]
+
+    source = {
+        "id": "https://openalex.org/W1",
+        "title": "Source Paper",
+        "referenced_works": ["https://openalex.org/W10", "https://openalex.org/W11"],
+        "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W1",
+    }
+    ref_results = {
+        "results": [
+            _work("https://openalex.org/W10", "Ref A", 2010, "10.1234/refa", 5, ["Alice"]),
+            _work("https://openalex.org/W11", "Ref B", 2012, "10.1234/refb", 9, ["Bob"]),
+        ]
+    }
+
+    def handler(url, params):
+        if url.endswith("/works/https://doi.org/10.1234/x"):
+            return FakeResponse(200, source)
+        if url.endswith("/works") and "openalex_id" in params.get("filter", ""):
+            return FakeResponse(200, ref_results)
+        return FakeResponse(404, {})
+
+    _patch_requests(monkeypatch, handler)
+
+    out = discovery.find_related_papers("10.1234/x", direction="references", ctx=DummyContext())
+    assert "in library ✓" in out
+    assert "not in library" in out
+    assert "1 already in library" in out
+
+
+# --- find_related_papers: no DOI error path -------------------------------
+
+
+def test_no_doi_error_path(monkeypatch):
+    _make_zot(monkeypatch)
+    # requests.get should never be called, but stub it to a clear failure.
+    _patch_requests(monkeypatch, lambda url, params: FakeResponse(404, {}))
+
+    out = discovery.find_related_papers("not a doi at all", ctx=DummyContext())
+    assert "Could not resolve a DOI" in out
+
+
+def test_item_key_without_doi(monkeypatch):
+    zot = _make_zot(monkeypatch)
+    zot._items = [{"key": "ABCD1234", "data": {"itemType": "journalArticle"}}]
+    _patch_requests(monkeypatch, lambda url, params: FakeResponse(404, {}))
+
+    out = discovery.find_related_papers("ABCD1234", ctx=DummyContext())
+    assert "Could not resolve a DOI" in out
+
+
+def test_item_key_with_doi_resolves(monkeypatch):
+    zot = _make_zot(monkeypatch)
+    zot._items = [{"key": "ABCD1234", "data": {"itemType": "journalArticle", "DOI": "10.1234/x"}}]
+    source = {
+        "id": "https://openalex.org/W1",
+        "title": "Source Paper",
+        "referenced_works": [],
+        "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W1",
+    }
+
+    def handler(url, params):
+        if url.endswith("/works/https://doi.org/10.1234/x"):
+            return FakeResponse(200, source)
+        return FakeResponse(200, {"results": []})
+
+    _patch_requests(monkeypatch, handler)
+
+    out = discovery.find_related_papers("ABCD1234", direction="both", ctx=DummyContext())
+    assert "Related Papers for: Source Paper" in out
+
+
+# --- library_coverage -----------------------------------------------------
+
+
+class FakeZoteroCoverage(FakeZoteroDiscovery):
+    def collection_items(self, key, start=0, limit=100, **kwargs):
+        return self._items[start : start + limit]
+
+    def items(self, start=None, limit=None, **kwargs):
+        if start is not None:
+            return self._items[start : start + (limit or 100)]
+        return super().items(**kwargs)
+
+
+def _make_coverage_zot(monkeypatch):
+    zot = FakeZoteroCoverage()
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: zot)
+    return zot
+
+
+def test_library_coverage_missing_and_present(monkeypatch):
+    zot = _make_coverage_zot(monkeypatch)
+    zot._items = [
+        {
+            "key": "PAP1",
+            "data": {"itemType": "journalArticle", "title": "Has PDF", "date": "2021", "DOI": "10.1234/haspdf"},
+        },
+        {
+            "key": "PAP2",
+            "data": {"itemType": "journalArticle", "title": "No PDF", "date": "2022", "DOI": "10.1234/nopdf"},
+        },
+    ]
+    zot._children = {
+        "PAP1": [{"key": "ATT1", "data": {"itemType": "attachment", "contentType": "application/pdf"}}],
+        "PAP2": [{"key": "NOTE1", "data": {"itemType": "note"}}],
+    }
+
+    out = discovery.library_coverage(ctx=DummyContext())
+    assert "Items scanned: 2" in out
+    assert "With PDF: 1" in out
+    assert "Missing PDF: 1" in out
+    assert "Coverage: 50.0%" in out
+    assert "No PDF" in out
+    assert "10.1234/nopdf" in out
+    # Item that has a PDF should not appear in the missing list.
+    assert "Has PDF" not in out.split("Items Missing")[1] if "Items Missing" in out else True
+
+
+def test_library_coverage_standalone_pdf_counts(monkeypatch):
+    zot = _make_coverage_zot(monkeypatch)
+    zot._items = [
+        {
+            "key": "STAND1",
+            "data": {"itemType": "attachment", "contentType": "application/pdf", "filename": "loose.pdf"},
+        },
+    ]
+    out = discovery.library_coverage(ctx=DummyContext())
+    assert "Items scanned: 1" in out
+    assert "With PDF: 1" in out
+    assert "Coverage: 100.0%" in out
+
+
+def test_library_coverage_scoped_collection(monkeypatch):
+    zot = _make_coverage_zot(monkeypatch)
+    zot._items = [
+        {
+            "key": "PAP2",
+            "data": {"itemType": "journalArticle", "title": "No PDF", "date": "2022", "DOI": "10.1234/nopdf"},
+        },
+    ]
+    zot._children = {"PAP2": []}
+    out = discovery.library_coverage(collection_key="ABCD1234", ctx=DummyContext())
+    assert "collection ABCD1234" in out
+    assert "Missing PDF: 1" in out
+
+
+def test_library_coverage_children_error_tolerated(monkeypatch):
+    zot = _make_coverage_zot(monkeypatch)
+    zot._items = [
+        {"key": "PAP3", "data": {"itemType": "journalArticle", "title": "Boom", "date": "2020"}},
+    ]
+
+    def boom(key, **kwargs):
+        raise RuntimeError("network down")
+
+    zot.children = boom
+    out = discovery.library_coverage(ctx=DummyContext())
+    # Treated as missing, not an error.
+    assert "Missing PDF: 1" in out
+    assert "Boom" in out

--- a/tests/test_passage_chunking.py
+++ b/tests/test_passage_chunking.py
@@ -1,0 +1,281 @@
+"""Tests for passage-level chunked retrieval (Tier-1 grounded search).
+
+Covers the pure splitter, page mapping, the best-snippet extractor, the
+chunk-aware indexing path in `_process_item_batch`, and chunk grouping in
+`_enrich_search_results`. Chunking is opt-in; these tests force it on via a
+config file or by setting `_chunking_config` directly.
+"""
+
+import json
+import sys
+
+import pytest
+
+if sys.version_info >= (3, 14):
+    pytest.skip(
+        "chromadb relies on pydantic v1 paths incompatible with Python 3.14+",
+        allow_module_level=True,
+    )
+
+from zotero_mcp import semantic_search
+from zotero_mcp.semantic_search import (
+    _page_for_offset,
+    best_snippet,
+    split_into_passages,
+)
+
+# ---------------------------------------------------------------------------
+# Pure splitter
+# ---------------------------------------------------------------------------
+
+
+def test_split_empty_returns_nothing():
+    assert split_into_passages("", 100, 20, 10) == []
+    assert split_into_passages("   ", 100, 20, 10) == []
+
+
+def test_split_short_text_single_passage():
+    out = split_into_passages("a short body", chunk_size=100, overlap=20, max_chunks=10)
+    assert len(out) == 1
+    text, start, end = out[0]
+    assert text == "a short body"
+    assert start == 0
+
+
+def test_split_offsets_are_monotonic_and_cover_text():
+    body = ("Sentence one. " * 200).strip()
+    out = split_into_passages(body, chunk_size=200, overlap=40, max_chunks=50)
+    assert len(out) > 1
+    # Offsets strictly advance and each passage is non-empty.
+    prev_start = -1
+    for text, start, end in out:
+        assert text.strip()
+        assert start > prev_start
+        assert end > start
+        prev_start = start
+
+
+def test_split_respects_max_chunks():
+    body = "word " * 5000
+    out = split_into_passages(body, chunk_size=100, overlap=10, max_chunks=7)
+    assert len(out) == 7
+
+
+def test_split_overlap_larger_than_chunk_is_tolerated():
+    body = "x" * 1000
+    out = split_into_passages(body, chunk_size=100, overlap=500, max_chunks=20)
+    # Must still terminate and make progress.
+    assert out
+    assert all(end > start for _, start, end in out)
+
+
+# ---------------------------------------------------------------------------
+# Page mapping
+# ---------------------------------------------------------------------------
+
+
+def test_page_for_offset_without_separators_is_none():
+    assert _page_for_offset("no form feeds here", 5) is None
+
+
+def test_page_for_offset_counts_form_feeds():
+    text = "page one\fpage two\fpage three"
+    assert _page_for_offset(text, 0) == 1
+    assert _page_for_offset(text, text.index("page two")) == 2
+    assert _page_for_offset(text, text.index("page three")) == 3
+
+
+# ---------------------------------------------------------------------------
+# Best-snippet extractor
+# ---------------------------------------------------------------------------
+
+
+def test_best_snippet_short_text_returned_whole():
+    snippet, off = best_snippet("anything", "tiny doc")
+    assert snippet == "tiny doc"
+    assert off == 0
+
+
+def test_best_snippet_centers_on_query_terms():
+    head = "irrelevant filler. " * 40
+    target = "mindfulness based cognitive therapy reduces relapse"
+    text = head + target + " more filler here." * 40
+    snippet, off = best_snippet("mindfulness cognitive therapy", text, width=120)
+    assert "mindfulness" in snippet.lower()
+    assert off > 0  # not the head of the document
+
+
+def test_best_snippet_no_terms_falls_back_to_head():
+    text = "alpha beta gamma delta " * 50
+    snippet, off = best_snippet("zzz", text, width=80)
+    assert off == 0
+    assert snippet.startswith("alpha")
+
+
+# ---------------------------------------------------------------------------
+# Chunk-aware indexing
+# ---------------------------------------------------------------------------
+
+
+class ChunkingFakeChroma:
+    """Chroma stub that records upserts and supports chunk bookkeeping."""
+
+    def __init__(self, existing=None):
+        self.upserted_ids = []
+        self.upserted_docs = []
+        self.upserted_metas = []
+        self.deleted_parents = []
+        self.embedding_max_tokens = 8000
+        self._existing = set(existing or [])
+
+    def get_existing_ids(self, ids):
+        return self._existing & set(ids)
+
+    def delete_item_chunks(self, item_key):
+        self.deleted_parents.append(item_key)
+
+    def upsert_documents(self, documents, metadatas, ids):
+        self.upserted_docs.extend(documents)
+        self.upserted_metas.extend(metadatas)
+        self.upserted_ids.extend(ids)
+
+    def truncate_text(self, text, max_tokens=None):
+        return text
+
+
+def _chunking_search(monkeypatch, config=None, existing=None):
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: object())
+    s = semantic_search.ZoteroSemanticSearch(chroma_client=ChunkingFakeChroma(existing))
+    s._chunking_config = {
+        "enabled": True,
+        "chunk_size": 120,
+        "overlap": 20,
+        "max_chunks_per_item": 10,
+    }
+    if config:
+        s._chunking_config.update(config)
+    return s
+
+
+def _long_item(key="ITEM0001"):
+    body = "Mindfulness reduces relapse. " * 60
+    return {
+        "key": key,
+        "data": {
+            "title": "Mindfulness Paper",
+            "itemType": "journalArticle",
+            "abstractNote": "An abstract.",
+            "creators": [],
+            "fulltext": body,
+        },
+    }
+
+
+def test_chunking_emits_multiple_passage_ids(monkeypatch):
+    s = _chunking_search(monkeypatch)
+    stats = s._process_item_batch([_long_item("ITEM0001")], force_rebuild=True)
+
+    # One *item* processed, but many chunk ids upserted.
+    assert stats["processed"] == 1
+    assert len(s.chroma_client.upserted_ids) > 1
+    assert all(cid.startswith("ITEM0001#") for cid in s.chroma_client.upserted_ids)
+    # Each chunk carries passage provenance in its metadata.
+    meta0 = s.chroma_client.upserted_metas[0]
+    assert meta0["parent_item_key"] == "ITEM0001"
+    assert meta0["chunk_index"] == 0
+    assert meta0["n_chunks"] == len(s.chroma_client.upserted_ids)
+    assert "char_start" in meta0 and "char_end" in meta0
+
+
+def test_chunking_added_vs_updated_is_item_granular(monkeypatch):
+    # Pretend the item already exists (its chunk #0 is present).
+    s = _chunking_search(monkeypatch, existing={"ITEM0001#0"})
+    stats = s._process_item_batch([_long_item("ITEM0001")], force_rebuild=False)
+    assert stats["updated"] == 1
+    assert stats["added"] == 0
+    # Stale chunks for the re-indexed item were cleared first.
+    assert "ITEM0001" in s.chroma_client.deleted_parents
+
+
+def test_default_path_still_item_level(monkeypatch):
+    # No chunking config -> ids are bare item keys (regression guard).
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: object())
+    s = semantic_search.ZoteroSemanticSearch(chroma_client=ChunkingFakeChroma())
+    stats = s._process_item_batch([_long_item("ITEM0001")], force_rebuild=True)
+    assert stats["processed"] == 1
+    assert s.chroma_client.upserted_ids == ["ITEM0001"]
+
+
+def test_chunking_config_loaded_from_file(monkeypatch, tmp_path):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"semantic_search": {"chunking": {"enabled": True, "chunk_size": 256}}}))
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: object())
+    monkeypatch.setattr(semantic_search, "create_chroma_client", lambda _p: ChunkingFakeChroma())
+    s = semantic_search.ZoteroSemanticSearch(config_path=str(cfg))
+    assert s._chunking_enabled is True
+    assert s._chunking_config["chunk_size"] == 256
+
+
+# ---------------------------------------------------------------------------
+# Chunk grouping in enrichment
+# ---------------------------------------------------------------------------
+
+
+class _ZotItemStub:
+    def item(self, key):
+        return {"key": key, "data": {"title": f"Title {key}"}}
+
+
+def test_enrich_groups_chunks_back_to_items(monkeypatch):
+    s = _chunking_search(monkeypatch)
+    s.zotero_client = _ZotItemStub()
+
+    chroma_results = {
+        "ids": [["PAP1#3", "PAP1#0", "PAP2#1"]],
+        "distances": [[0.10, 0.20, 0.30]],
+        "documents": [
+            [
+                "mindfulness relapse passage from paper one chunk three",
+                "intro passage from paper one chunk zero",
+                "unrelated passage from paper two",
+            ]
+        ],
+        "metadatas": [
+            [
+                {
+                    "parent_item_key": "PAP1",
+                    "chunk_index": 3,
+                    "n_chunks": 5,
+                    "char_start": 900,
+                    "char_end": 1020,
+                    "page": 4,
+                },
+                {"parent_item_key": "PAP1", "chunk_index": 0, "n_chunks": 5, "char_start": 0, "char_end": 120},
+                {"parent_item_key": "PAP2", "chunk_index": 1, "n_chunks": 2, "char_start": 100, "char_end": 220},
+            ]
+        ],
+    }
+
+    enriched = s._enrich_search_results(chroma_results, "mindfulness relapse", limit=10)
+
+    # Two distinct items, PAP1 represented by its best (first) passage.
+    assert [r["item_key"] for r in enriched] == ["PAP1", "PAP2"]
+    best = enriched[0]
+    assert best["chunk_index"] == 3
+    assert best["page"] == 4
+    assert best["char_start"] == 900
+    assert best["matched_passage"]
+    assert best["zotero_item"]["data"]["title"] == "Title PAP1"
+
+
+def test_enrich_caps_at_limit(monkeypatch):
+    s = _chunking_search(monkeypatch)
+    s.zotero_client = _ZotItemStub()
+    chroma_results = {
+        "ids": [["A#0", "B#0", "C#0", "D#0"]],
+        "distances": [[0.1, 0.2, 0.3, 0.4]],
+        "documents": [["a", "b", "c", "d"]],
+        "metadatas": [[{"parent_item_key": x} for x in ("A", "B", "C", "D")]],
+    }
+    enriched = s._enrich_search_results(chroma_results, "q", limit=2)
+    assert [r["item_key"] for r in enriched] == ["A", "B"]

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -1,0 +1,205 @@
+"""Tests for the synthesis tool module (digest + bibliography export)."""
+
+from conftest import DummyContext, FakeZotero
+
+import zotero_mcp.client as zotero_client
+from zotero_mcp.tools import synthesis
+
+# ---------------------------------------------------------------------------
+# synthesize_annotations
+# ---------------------------------------------------------------------------
+
+
+class _DigestZotero(FakeZotero):
+    """FakeZotero returning annotation/note fixtures and resolvable parents."""
+
+    def __init__(self):
+        super().__init__()
+        # parent metadata items (papers) and the attachment between them.
+        self._title_map = {
+            "PAPER001": "Attention Is All You Need",
+            "PAPER002": "Deep Residual Learning",
+            "ATTACH01": {"itemType": "attachment", "parentItem": "PAPER001", "title": "Full Text PDF"},
+            "ATTACH02": {"itemType": "attachment", "parentItem": "PAPER002", "title": "Full Text PDF"},
+        }
+
+    def item(self, item_key):
+        entry = self._title_map.get(item_key)
+        if isinstance(entry, dict):
+            return {"key": item_key, "data": entry}
+        if isinstance(entry, str):
+            return {"key": item_key, "data": {"itemType": "journalArticle", "title": entry}}
+        return {"key": item_key, "data": {"title": f"Item {item_key}"}}
+
+    def items(self, **kwargs):
+        item_type = kwargs.get("itemType")
+        if item_type == "annotation":
+            return [
+                {
+                    "key": "ANN1",
+                    "data": {
+                        "itemType": "annotation",
+                        "annotationText": "Self-attention scales to long sequences",
+                        "annotationComment": "key claim",
+                        "parentItem": "ATTACH01",
+                    },
+                },
+                {
+                    "key": "ANN2",
+                    "data": {
+                        "itemType": "annotation",
+                        "annotationText": "Residual connections ease optimization",
+                        "annotationComment": "",
+                        "parentItem": "ATTACH02",
+                    },
+                },
+            ]
+        if item_type == "note":
+            return [
+                {
+                    "key": "NOTE1",
+                    "data": {
+                        "itemType": "note",
+                        "note": "<p>Transformers remove recurrence entirely.</p>",
+                        "parentItem": "PAPER001",
+                    },
+                },
+            ]
+        return []
+
+
+def test_synthesize_annotations_groups_by_paper(monkeypatch):
+    fake = _DigestZotero()
+    monkeypatch.setattr(zotero_client, "get_zotero_client", lambda: fake)
+
+    out = synthesis.synthesize_annotations(ctx=DummyContext())
+
+    # Grouped under resolved paper titles, not raw keys.
+    assert "## Attention Is All You Need" in out
+    assert "## Deep Residual Learning" in out
+    # Highlight text surfaced.
+    assert "Self-attention scales to long sequences" in out
+    assert "Residual connections ease optimization" in out
+    # Comment surfaced for the first annotation.
+    assert "key claim" in out
+    # Note excerpt (HTML stripped) surfaced under its paper.
+    assert "Transformers remove recurrence entirely." in out
+    # Summary line counts.
+    assert "2 papers" in out
+    assert "2 highlights" in out
+    assert "1 notes" in out
+
+
+def test_synthesize_annotations_empty(monkeypatch):
+    fake = FakeZotero()  # items() returns [] for every itemType
+    monkeypatch.setattr(zotero_client, "get_zotero_client", lambda: fake)
+
+    out = synthesis.synthesize_annotations(ctx=DummyContext())
+    assert "No annotations or notes found" in out
+
+
+# ---------------------------------------------------------------------------
+# export_bibliography
+# ---------------------------------------------------------------------------
+
+
+class _BibZotero(FakeZotero):
+    """FakeZotero honoring a content= kwarg for CSL/bibtex rendering."""
+
+    def __init__(self):
+        super().__init__()
+        self.last_kwargs = None
+
+    def _render(self, content, style):
+        if content == "bibtex":
+            return "@article{smith2020, title={Title}, author={Smith, J.}}"
+        # bib / citation -> list of HTML snippets
+        if content == "citation":
+            return ['<span class="citation">(Smith, 2020)</span>']
+        return ['<div class="csl-entry">Smith, J. (2020). Title. Journal.</div>']
+
+    def items(self, **kwargs):
+        self.last_kwargs = kwargs
+        content = kwargs.get("content")
+        if content:
+            return self._render(content, kwargs.get("style"))
+        return self._items
+
+    def collection_items(self, key, **kwargs):
+        self.last_kwargs = kwargs
+        content = kwargs.get("content")
+        if content:
+            return self._render(content, kwargs.get("style"))
+        return super().collection_items(key, **kwargs)
+
+
+def test_export_bibliography_bib_strips_html(monkeypatch):
+    fake = _BibZotero()
+    monkeypatch.setattr(zotero_client, "get_zotero_client", lambda: fake)
+
+    out = synthesis.export_bibliography(item_keys=["ABCD1234"], ctx=DummyContext())
+
+    assert "Smith, J. (2020). Title. Journal." in out
+    # HTML wrapper stripped.
+    assert "csl-entry" not in out
+    assert "Bibliography" in out
+    # style passed through to the API.
+    assert fake.last_kwargs.get("style") == "apa"
+    assert fake.last_kwargs.get("content") == "bib"
+
+
+def test_export_bibliography_style_passthrough(monkeypatch):
+    fake = _BibZotero()
+    monkeypatch.setattr(zotero_client, "get_zotero_client", lambda: fake)
+
+    out = synthesis.export_bibliography(
+        item_keys=["ABCD1234"],
+        style="ieee",
+        export_format="citation",
+        ctx=DummyContext(),
+    )
+
+    assert fake.last_kwargs.get("style") == "ieee"
+    assert fake.last_kwargs.get("content") == "citation"
+    assert "(Smith, 2020)" in out
+    assert "ieee" in out
+
+
+def test_export_bibliography_bibtex_fenced(monkeypatch):
+    fake = _BibZotero()
+    monkeypatch.setattr(zotero_client, "get_zotero_client", lambda: fake)
+
+    out = synthesis.export_bibliography(
+        item_keys=["ABCD1234"],
+        export_format="bibtex",
+        ctx=DummyContext(),
+    )
+
+    assert "@article{smith2020" in out
+    assert "```bibtex" in out
+    # bibtex ignores style (not passed to the API).
+    assert "style" not in fake.last_kwargs
+
+
+def test_export_bibliography_collection(monkeypatch):
+    fake = _BibZotero()
+    monkeypatch.setattr(zotero_client, "get_zotero_client", lambda: fake)
+
+    out = synthesis.export_bibliography(
+        collection_key="COLL1234",
+        export_format="bib",
+        ctx=DummyContext(),
+    )
+    assert "Smith, J. (2020). Title. Journal." in out
+    assert fake.last_kwargs.get("content") == "bib"
+
+
+def test_export_bibliography_api_error(monkeypatch):
+    class _ErrZot(FakeZotero):
+        def items(self, **kwargs):
+            raise RuntimeError("bib not supported in local mode")
+
+    monkeypatch.setattr(zotero_client, "get_zotero_client", lambda: _ErrZot())
+
+    out = synthesis.export_bibliography(item_keys=["ABCD1234"], ctx=DummyContext())
+    assert "web API" in out.lower() or "ZOTERO_API_KEY" in out

--- a/tests/test_update_lock_reliability.py
+++ b/tests/test_update_lock_reliability.py
@@ -1,0 +1,71 @@
+"""Tests for update-lock diagnostics and the cross-encoder score API."""
+
+import os
+import sys
+
+import pytest
+
+if sys.version_info >= (3, 14):
+    pytest.skip(
+        "chromadb relies on pydantic v1 paths incompatible with Python 3.14+",
+        allow_module_level=True,
+    )
+
+from zotero_mcp import semantic_search
+
+
+def test_read_lock_holder_missing_file(tmp_path):
+    pid, alive = semantic_search.read_lock_holder(tmp_path / "nope.lock")
+    assert pid is None
+    assert alive is False
+
+
+def test_read_lock_holder_live_pid(tmp_path):
+    lock = tmp_path / "update.lock"
+    lock.write_text(str(os.getpid()))
+    pid, alive = semantic_search.read_lock_holder(lock)
+    assert pid == os.getpid()
+    assert alive is True
+
+
+def test_read_lock_holder_dead_pid(tmp_path):
+    lock = tmp_path / "update.lock"
+    # A pid that is essentially certain not to exist.
+    lock.write_text("999999")
+    pid, alive = semantic_search.read_lock_holder(lock)
+    assert pid == 999999
+    assert alive is False
+
+
+def test_force_update_env_bypasses_lock(tmp_path, monkeypatch):
+    lock = tmp_path / "update.lock"
+    monkeypatch.setenv("ZOTERO_MCP_FORCE_UPDATE", "1")
+    with semantic_search._acquire_update_lock(lock) as acquired:
+        assert acquired is True
+
+
+def test_acquire_lock_writes_pid(tmp_path, monkeypatch):
+    lock = tmp_path / "update.lock"
+    monkeypatch.delenv("ZOTERO_MCP_FORCE_UPDATE", raising=False)
+    with semantic_search._acquire_update_lock(lock) as acquired:
+        assert acquired is True
+        # While held, the file records our pid (POSIX/flock platforms).
+        if lock.exists() and lock.read_text().strip():
+            assert lock.read_text().strip() == str(os.getpid())
+
+
+def test_rerank_with_scores_orders_and_scores(monkeypatch):
+    rr = semantic_search.CrossEncoderReranker.__new__(semantic_search.CrossEncoderReranker)
+
+    class _Model:
+        def predict(self, pairs):
+            # Higher score for the doc containing "match".
+            return [9.0 if "match" in d else 1.0 for _, d in pairs]
+
+    rr.model = _Model()
+    ranked = rr.rerank_with_scores("q", ["no", "the match here", "no"], top_k=2)
+    assert ranked[0][0] == 1  # index of the matching doc first
+    assert ranked[0][1] == 9.0
+    assert len(ranked) == 2
+    # rerank() delegates to rerank_with_scores and returns indices only.
+    assert rr.rerank("q", ["no", "the match here", "no"], top_k=1) == [1]


### PR DESCRIPTION
## Summary

An agent-driven-research feature set on top of the semantic-search foundation. Everything is **opt-in or additive** — with the new config flags off, indexing and search behave exactly as before.

> Builds on #348 (the first commit here is that PR's reliability work). If #348 merges first, this rebases to just the feature commit; otherwise this can supersede it.

### Passage-level grounded retrieval
New opt-in `semantic_search.chunking` config. When enabled, each item is indexed as overlapping passages (ids `<item_key>#<n>`, with `parent_item_key`/`chunk_index`/`char_start`/`char_end`/`page` metadata), so semantic search returns a **grounded, citable quote** (`best_snippet`) with provenance, and long PDFs stay searchable past the single-vector truncation limit. Default-off keeps item-level ids and `_process_item_batch` byte-for-byte identical. Id handling (incremental deletion, add/update accounting, `delete_item_chunks`, search grouping) is chunk-aware but treats a bare id as its own item, so existing item-level collections are unaffected. `split_into_passages` / `best_snippet` / `_page_for_offset` are pure and unit-tested.

### Discovery (`tools/discovery.py`)
- `zotero_find_related_papers` — walks the OpenAlex citation graph (references + citing works), ranks them, flags each as already-in-library or a gap.
- `zotero_library_coverage` — audits which items lack a PDF, with DOIs ready for the OA download cascade.

### Synthesis (`tools/synthesis.py`)
- `zotero_synthesize_annotations` — per-paper digest of highlights + notes for an LLM to synthesize.
- `zotero_export_bibliography` — CSL-rendered bibliography/citations/BibTeX via Zotero's own engine.

### MCP prompts & resources
- `prompts.py`: literature-review, synthesize-my-notes, find-contradicting-evidence, expand-from-paper.
- `resources.py`: `zotero://collections`, `zotero://items/{item_key}`, `zotero://collections/{collection_key}/items`.
- Registered via side-effect import in `tools/__init__.py`.

### Reliability
- `CrossEncoderReranker.rerank_with_scores` surfaces raw relevance logits; reranker/chunking written as documented default-off stubs by `setup`.
- `update.lock` hardening: records holder pid, `read_lock_holder()` reports staleness, `ZOTERO_MCP_FORCE_UPDATE=1` bypasses a stuck lock.

## Enabling chunking
Set `semantic_search.chunking.enabled: true` in `config.json` and run `zotero-mcp update-db --force-rebuild` once. New tool descriptions stay within the `test_description_tokens` 450-token cap.

## Tests
Adds `test_passage_chunking`, `test_discovery`, `test_synthesis`, `test_update_lock_reliability`. Full suite: **936 passed**. The 2 failing `test_place_field_reads::TestPlaceInBibtex` tests are pre-existing on `main` (bibtex address rendering) and untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)