### PR TITLE
fix: route read_pdf_pages through download_attachment_file (WebDAV support)

### DIFF
--- a/src/zotero_mcp/tools/read_pdf.py
+++ b/src/zotero_mcp/tools/read_pdf.py
@@ -60,7 +60,8 @@ def _get_pdf_path(item_key: str, ctx: Context) -> tuple[str, str] | None:
     except Exception:
         pass
 
-    # Fallback: download via API to a named temp file
+    # Fallback: resolve via the multi-source downloader (local -> WebDAV ->
+    # Zotero cloud) so WebDAV-backed attachments work, not just cloud storage.
     attachment = _client.get_attachment_details(zot, item)
     if not attachment:
         return None
@@ -73,16 +74,23 @@ def _get_pdf_path(item_key: str, ctx: Context) -> tuple[str, str] | None:
             return None
 
     tmpdir = tempfile.mkdtemp(prefix="zotero_pdf_")
-    file_path = os.path.join(tmpdir, filename)
+    probe = os.path.join(tmpdir, os.path.basename(filename))
     try:
-        zot.dump(attachment.key, filename=os.path.basename(file_path), path=tmpdir)
-        if os.path.exists(file_path) and os.path.getsize(file_path) > 0:
-            return file_path, attachment.title
+        download = _client.download_attachment_file(
+            attachment.key,
+            tmpdir,
+            os.path.basename(filename),
+            local_client=_client.get_local_zotero_client(),
+            web_client=None if _utils.is_local_mode() else zot,
+        )
     except Exception:
-        _cleanup_path(file_path)
+        _cleanup_path(probe)
         raise
 
-    _cleanup_path(file_path)
+    if download.path and download.path.exists() and download.path.stat().st_size > 0:
+        return str(download.path), attachment.title
+
+    _cleanup_path(probe)
     return None
 
 


### PR DESCRIPTION
## Summary

`zotero_read_pdf_pages` fails for libraries whose attachment files are stored via **WebDAV**, even though every other read path in the server already supports WebDAV.

## Problem

`_get_pdf_path` in `src/zotero_mcp/tools/read_pdf.py` downloads the attachment with `zot.dump()` directly. `zot.dump()` only retrieves files from Zotero's **own cloud storage**. For WebDAV-backed libraries, `https://api.zotero.org/.../items/<key>/file` returns **404** — the Zotero servers hold only the attachment metadata + md5, not the file bytes — so `read_pdf_pages` fails even though the file is available over WebDAV.

This is inconsistent with `get_item_fulltext`, which already routes through `client.download_attachment_file()` and therefore works with WebDAV-backed attachments.

## Fix

Route `_get_pdf_path` through `client.download_attachment_file()`, which resolves **local → WebDAV → Zotero cloud** (the same resolver `get_item_fulltext` uses in `tools/retrieval.py`).

- No behavior change for Zotero cloud-storage users — the cloud path still runs, just last in the chain.
- WebDAV-backed attachments (with `ZOTERO_WEBDAV_URL` / `ZOTERO_WEBDAV_USERNAME` / `ZOTERO_WEBDAV_PASSWORD` configured) now resolve.

The diff is small and localized to the fallback block; the PDF-type guard and temp-dir cleanup are preserved.

## Testing

Verified manually against a WebDAV (Koofr) library: several items that returned `404 … /file` via `zot.dump()` now download and parse correctly through the live `read_pdf_pages` tool (e.g. an 8-page PDF returned full page-1 text). The module compiles and the helpers it calls (`download_attachment_file`, `get_local_zotero_client`) exist on `main`.