### PR TITLE
fix(scite): send bare list payload to POST /papers batch endpoint

### DIFF
--- a/src/zotero_mcp/scite_client.py
+++ b/src/zotero_mcp/scite_client.py
@@ -105,7 +105,7 @@ def get_papers_batch(dois: list[str]) -> dict[str, dict]:
     try:
         resp = requests.post(
             f"{_BASE}/papers",
-            json={"dois": dois[:500]},
+            json=dois[:500],
             headers=_HEADERS,
             timeout=_TIMEOUT,
         )

--- a/tests/test_scite_client.py
+++ b/tests/test_scite_client.py
@@ -1,0 +1,61 @@
+"""Tests for the Scite public API client."""
+
+from unittest.mock import MagicMock, patch
+
+from zotero_mcp import scite_client
+
+
+def _ok_response(payload):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = payload
+    return resp
+
+
+def test_get_papers_batch_sends_bare_list_payload():
+    """get_papers_batch must POST a bare JSON list, not {"dois": [...]}.
+
+    The Scite /papers batch endpoint returns HTTP 400 for a dict-wrapped
+    payload, which surfaced upstream as "Could not reach Scite API" from
+    scite_check_retractions. Regression test for
+    https://github.com/54yyyu/zotero-mcp/issues/352
+    """
+    with patch.object(
+        scite_client.requests,
+        "post",
+        return_value=_ok_response({"papers": {"10.1038/x": {"title": "T"}}}),
+    ) as mock_post:
+        result = scite_client.get_papers_batch(["10.1038/x"])
+
+    _, kwargs = mock_post.call_args
+    # Bare list, NOT {"dois": [...]}
+    assert kwargs["json"] == ["10.1038/x"]
+    assert result == {"10.1038/x": {"title": "T"}}
+
+
+def test_get_papers_batch_returns_empty_on_non_200():
+    """A non-200 response yields an empty dict instead of raising."""
+    bad = MagicMock()
+    bad.status_code = 400
+    with patch.object(scite_client.requests, "post", return_value=bad):
+        assert scite_client.get_papers_batch(["10.1038/x"]) == {}
+
+
+def test_get_papers_batch_empty_input_skips_request():
+    """An empty DOI list short-circuits without hitting the network."""
+    with patch.object(scite_client.requests, "post") as mock_post:
+        assert scite_client.get_papers_batch([]) == {}
+    mock_post.assert_not_called()
+
+
+def test_get_tallies_batch_sends_bare_list_payload():
+    """Regression guard: the tallies batch endpoint already uses a bare list."""
+    with patch.object(
+        scite_client.requests,
+        "post",
+        return_value=_ok_response({"tallies": {"10.1038/x": {"total": 1}}}),
+    ) as mock_post:
+        scite_client.get_tallies_batch(["10.1038/x"])
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["json"] == ["10.1038/x"]


### PR DESCRIPTION
## Summary

`scite_check_retractions` (and any tool using `get_papers_batch`) always reports **"Could not reach Scite API"**, even though `api.scite.ai` is reachable and the single-item `scite_enrich_item` works fine.

## Root cause

`get_papers_batch` POSTs `{"dois": [...]}` to `/papers`, but the endpoint expects a **bare JSON array** — the same shape the sibling `/tallies` batch endpoint already uses correctly. The dict payload triggers HTTP 400:

```
{"message":"1 validation error: {'type': 'list_type', 'loc': ('body',), 'msg': 'Input should be a valid list', 'input': {'dois': [...]}}"}
```

The non-200 response makes `get_papers_batch` return `{}`, surfaced upstream as "Could not reach Scite API".

## Fix

```diff
- json={"dois": dois[:500]},
+ json=dois[:500],
```

Single-item `scite_enrich_item` is unaffected (it uses GET `/papers/{doi}`).

## Testing

- Added `tests/test_scite_client.py` (4 tests): bare-list payload for `/papers`, non-200 handling, empty-input short-circuit, and a regression guard for the `/tallies` endpoint.
- All 4 new tests pass.
- Full suite: **900 passed, 3 failed** — the 3 failures are pre-existing and unrelated (`test_pdf_cascade` needs network; `test_place_field_reads` is a bibtexparser version issue). Confirmed by re-running them with this change stashed.

Fixes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)