### PR TITLE
Embedding sub-batching + rate-limit throttle (ports #261 engine; supersedes #307)

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -41,10 +41,23 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
 
     max_input_tokens = 8000  # text-embedding-3-* limit is 8191
 
-    def __init__(self, model_name: str = "text-embedding-3-small", api_key: str | None = None, base_url: str | None = None):
+    # Per-request input-list cap. OpenAI allows up to 2048 items but many
+    # OpenAI-compatible providers are stricter (SiliconFlow is 64 for
+    # /v1/embeddings, Mistral is 512, etc.). Defaulting to 64 keeps the code
+    # portable; real OpenAI users can raise embedding_config.request_batch_size.
+    DEFAULT_REQUEST_BATCH_SIZE = 64
+
+    def __init__(self, model_name: str = "text-embedding-3-small", api_key: str | None = None,
+                 base_url: str | None = None, request_batch_size: int | None = None,
+                 rate_limit_rps: float | None = None):
+        import threading
         self.model_name = model_name
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         self.base_url = base_url or os.getenv("OPENAI_BASE_URL")
+        self.request_batch_size = int(request_batch_size) if request_batch_size else self.DEFAULT_REQUEST_BATCH_SIZE
+        self.rate_limit_rps: float | None = float(rate_limit_rps) if rate_limit_rps else None
+        self._rate_lock = threading.Lock()
+        self._last_request_ts: float = 0.0
         if not self.api_key:
             raise ValueError("OpenAI API key is required")
 
@@ -62,7 +75,12 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
         return "openai"
 
     def get_config(self) -> dict[str, Any]:
-        return {"model_name": self.model_name, "base_url": self.base_url}
+        return {
+            "model_name": self.model_name,
+            "base_url": self.base_url,
+            "request_batch_size": self.request_batch_size,
+            "rate_limit_rps": self.rate_limit_rps,
+        }
 
     @staticmethod
     def build_from_config(config: dict[str, Any]) -> "OpenAIEmbeddingFunction":
@@ -70,7 +88,26 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
             model_name=config.get("model_name", "text-embedding-3-small"),
             api_key=config.get("api_key"),
             base_url=config.get("base_url"),
+            request_batch_size=config.get("request_batch_size"),
+            rate_limit_rps=config.get("rate_limit_rps"),
         )
+
+    def _wait_for_rate_limit(self) -> None:
+        """Sleep as needed so successive embedding requests stay under
+        ``rate_limit_rps``. Applied per HTTP request (including each sub-batch)
+        so rate-limited providers see a steady cadence regardless of how many
+        inputs the caller passed. The lock keeps parallel threads honest.
+        """
+        rps = self.rate_limit_rps
+        if not rps or rps <= 0:
+            return
+        import time
+        with self._rate_lock:
+            min_interval = 1.0 / rps
+            wait = min_interval - (time.monotonic() - self._last_request_ts)
+            if wait > 0:
+                time.sleep(wait)
+            self._last_request_ts = time.monotonic()
 
     def __call__(self, input: Documents) -> Embeddings:
         """Generate embeddings using the OpenAI-compatible API.
@@ -82,12 +119,18 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
         float makes every OpenAI-compatible backend, native OpenAI included,
         respond deterministically.
         """
-        response = self.client.embeddings.create(
-            model=self.model_name,
-            input=input,
-            encoding_format="float",
-        )
-        return [data.embedding for data in response.data]
+        batch_size = self.request_batch_size or self.DEFAULT_REQUEST_BATCH_SIZE
+        vecs: Embeddings = []
+        for i in range(0, len(input), batch_size):
+            sub = input[i:i + batch_size]
+            self._wait_for_rate_limit()
+            response = self.client.embeddings.create(
+                model=self.model_name,
+                input=sub,
+                encoding_format="float",
+            )
+            vecs.extend(data.embedding for data in response.data)
+        return vecs
 
     def embed_query(self, text: str) -> list[float]:
         """Embed a query string. No special handling needed for OpenAI."""
@@ -423,7 +466,11 @@ class ChromaClient:
             model_name = self.embedding_config.get("model_name", "text-embedding-3-small")
             api_key = self.embedding_config.get("api_key")
             base_url = self.embedding_config.get("base_url")
-            return OpenAIEmbeddingFunction(model_name=model_name, api_key=api_key, base_url=base_url)
+            return OpenAIEmbeddingFunction(
+                model_name=model_name, api_key=api_key, base_url=base_url,
+                request_batch_size=self.embedding_config.get("request_batch_size"),
+                rate_limit_rps=self.embedding_config.get("rate_limit_rps"),
+            )
 
         elif self.embedding_model == "gemini":
             model_name = self.embedding_config.get("model_name", "gemini-embedding-001")

--- a/tests/test_embedding_function_registration.py
+++ b/tests/test_embedding_function_registration.py
@@ -70,4 +70,10 @@ def test_openai_build_from_config_handles_persisted_config(monkeypatch):
     ef = known_embedding_functions["openai"].build_from_config(persisted)
 
     assert isinstance(ef, chroma_client.OpenAIEmbeddingFunction)
-    assert ef.get_config() == persisted
+    # Configs persisted before request_batch_size/rate_limit_rps existed must
+    # still rebuild, falling back to defaults for the new fields.
+    cfg = ef.get_config()
+    assert cfg["model_name"] == "text-embedding-3-small"
+    assert cfg["base_url"] is None
+    assert cfg["request_batch_size"] == chroma_client.OpenAIEmbeddingFunction.DEFAULT_REQUEST_BATCH_SIZE
+    assert cfg["rate_limit_rps"] is None

--- a/tests/test_openai_embedding_batching.py
+++ b/tests/test_openai_embedding_batching.py
@@ -1,0 +1,84 @@
+"""OpenAI embedding sub-batching + per-request rate limiting.
+
+Ported from the engine work in #261 (credit @SipengXie2024), combined with the
+encoding_format="float" fix from #348. Constructs the embedding function via
+__new__ so the tests don't require the optional `openai` package (CI does not
+install it).
+"""
+
+import threading
+
+from zotero_mcp.chroma_client import OpenAIEmbeddingFunction
+
+
+def _make(batch_size=64, rps=None):
+    """Build an OpenAIEmbeddingFunction with a fake client, bypassing __init__."""
+    ef = OpenAIEmbeddingFunction.__new__(OpenAIEmbeddingFunction)
+    ef.model_name = "text-embedding-3-small"
+    ef.base_url = None
+    ef.request_batch_size = batch_size
+    ef.rate_limit_rps = rps
+    ef._rate_lock = threading.Lock()
+    ef._last_request_ts = 0.0
+
+    calls = []
+
+    class _Resp:
+        def __init__(self, items):
+            # Echo each input back as a 1-d vector so order is verifiable.
+            self.data = [type("D", (), {"embedding": [float(x)]}) for x in items]
+
+    class _Embeddings:
+        @staticmethod
+        def create(model, input, encoding_format):
+            calls.append({"input": list(input), "encoding_format": encoding_format})
+            return _Resp(input)
+
+    class _Client:
+        embeddings = _Embeddings()
+
+    ef.client = _Client()
+    return ef, calls
+
+
+def test_subbatches_large_input_preserving_order():
+    ef, calls = _make(batch_size=2)
+    out = ef([0, 1, 2, 3, 4])
+    # 5 inputs at batch_size 2 -> three POSTs of sizes 2, 2, 1
+    assert [len(c["input"]) for c in calls] == [2, 2, 1]
+    # concatenated output matches input order
+    assert out == [[0.0], [1.0], [2.0], [3.0], [4.0]]
+
+
+def test_single_request_when_under_cap():
+    ef, calls = _make(batch_size=64)
+    ef([0, 1, 2])
+    assert len(calls) == 1
+    assert len(calls[0]["input"]) == 3
+
+
+def test_encoding_format_is_float_on_every_request():
+    ef, calls = _make(batch_size=2)
+    ef([0, 1, 2, 3])
+    assert calls and all(c["encoding_format"] == "float" for c in calls)
+
+
+def test_rate_limit_noop_when_unset():
+    ef, _ = _make(rps=None)
+    # Should return immediately and not raise.
+    ef._wait_for_rate_limit()
+
+
+def test_rate_limit_records_timestamp_when_set():
+    ef, _ = _make(rps=1000.0)
+    assert ef._last_request_ts == 0.0
+    ef._wait_for_rate_limit()
+    assert ef._last_request_ts > 0.0
+
+
+def test_get_config_roundtrips_new_fields():
+    ef, _ = _make(batch_size=128, rps=5.0)
+    cfg = ef.get_config()
+    assert cfg["request_batch_size"] == 128
+    assert cfg["rate_limit_rps"] == 5.0
+    assert cfg["model_name"] == "text-embedding-3-small"


### PR DESCRIPTION
Ports the portable engine value from #261 (@SipengXie2024) onto current main, and supersedes the throttle request in #307 (@hendryman).

## What this adds
- `OpenAIEmbeddingFunction` splits large input lists into `request_batch_size` slices (default 64, configurable via `embedding_config.request_batch_size`). This keeps it portable across stricter OpenAI-compatible providers (SiliconFlow caps `/v1/embeddings` at 64, etc.).
- Optional `embedding_config.rate_limit_rps` paces requests, applied at every HTTP request including each sub-batch, with a lock so parallel threads stay honest.
- Keeps #348's `encoding_format="float"`.

## What this deliberately does NOT port from #261
- Its passage chunking: superseded by #350's canonical `#`-id + page-provenance schema.
- Its incremental-sync / gap-fill: already on main.
- Its annotation exclusion: main embeds annotation text on purpose, so that's a separate design decision, not folded in here.

## Compatibility + tests
- Configs persisted before these fields existed still rebuild (defaults apply); covered by the existing registration test.
- New `tests/test_openai_embedding_batching.py` (sub-batch sizing, order preservation, encoding_format, rate-limit). 1038 passed locally.

Credit: @SipengXie2024 (#261), @hendryman (#307).