### PR TITLE
Land #349: Ollama embedding backend (+ deterministic bibtex test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ### 🧠 AI-Powered Semantic Search
 - **Vector-based similarity search** over your entire research library (requires `[semantic]` extra)
-- **Multiple embedding models**: Default (free, local), OpenAI, and Gemini
+- **Multiple embedding models**: Default (free, local), OpenAI, Gemini, and Ollama
 - **Intelligent results** with similarity scores and contextual matching
 - **Auto-updating database** with configurable sync schedules
 
@@ -152,6 +152,27 @@ zotero-mcp setup --semantic-config-only
 - **Default (all-MiniLM-L6-v2)**: Free, runs locally, good for most use cases
 - **OpenAI**: Better quality, requires API key (`text-embedding-3-small` or `text-embedding-3-large`)
 - **Gemini**: Better quality, requires API key (`gemini-embedding-001`)
+- **Ollama**: Runs locally via Ollama API (requires model name, e.g., 'qwen3-embedding')
+
+**Using Ollama embeddings:**
+
+Install and start Ollama, then pull an embedding model before running `zotero-mcp update-db`:
+
+```bash
+ollama serve
+
+# Small model: fast and lightweight
+ollama pull nomic-embed-text
+
+# Medium model: better multilingual retrieval quality
+ollama pull bge-m3
+```
+
+When prompted by `zotero-mcp setup --semantic-config-only`, choose **Ollama** and use either `nomic-embed-text` or `bge-m3` as the model name. If you change embedding models later, rebuild the index:
+
+```bash
+zotero-mcp update-db --force-rebuild
+```
 
 **Update Frequency Options:**
 - **Manual**: Update only when you run `zotero-mcp update-db`
@@ -306,13 +327,15 @@ zotero-mcp setup --no-local --api-key YOUR_API_KEY --library-id YOUR_LIBRARY_ID
 - `ZOTERO_WEBDAV_PASSWORD`: Optional WebDAV password
 
 **Semantic Search:**
-- `ZOTERO_EMBEDDING_MODEL`: Embedding model to use (default, openai, gemini)
+- `ZOTERO_EMBEDDING_MODEL`: Embedding model to use (default, openai, gemini, ollama)
 - `OPENAI_API_KEY`: Your OpenAI API key (for OpenAI embeddings)
 - `OPENAI_EMBEDDING_MODEL`: OpenAI model name (text-embedding-3-small, text-embedding-3-large)
 - `OPENAI_BASE_URL`: Custom OpenAI endpoint URL (optional, for use with compatible APIs)
 - `GEMINI_API_KEY`: Your Gemini API key (for Gemini embeddings)
 - `GEMINI_EMBEDDING_MODEL`: Gemini model name (gemini-embedding-001)
 - `GEMINI_BASE_URL`: Custom Gemini endpoint URL (optional, for use with compatible APIs)
+- `OLLAMA_EMBEDDING_MODEL`: Ollama embedding model name (qwen3-embedding by default)
+- `OLLAMA_BASE_URL`: Ollama server URL (default: http://localhost:11434)
 - `ZOTERO_DB_PATH`: Custom `zotero.sqlite` path (optional)
 
 ### Command-Line Options

--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -314,6 +314,68 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction):
         return text
 
 
+@register_embedding_function
+class OllamaEmbeddingFunction(EmbeddingFunction):
+    """Custom Ollama embedding function for ChromaDB.
+
+    Uses Ollama's local HTTP API. Registered under the name ``ollama`` so
+    ChromaDB can rebuild persisted collections that were created with this
+    embedding function.
+    """
+
+    # Ollama models vary; use a conservative, char-based fallback budget.
+    max_input_tokens = 8000
+
+    def __init__(self, model_name: str = "qwen3-embedding", base_url: str | None = None):
+        self.model_name = model_name
+        self.base_url = (base_url or os.getenv("OLLAMA_BASE_URL") or "http://localhost:11434").rstrip("/")
+
+    @staticmethod
+    def name() -> str:
+        return "ollama"
+
+    def get_config(self) -> dict[str, Any]:
+        return {"model_name": self.model_name, "base_url": self.base_url}
+
+    @staticmethod
+    def build_from_config(config: dict[str, Any]) -> "OllamaEmbeddingFunction":
+        return OllamaEmbeddingFunction(
+            model_name=config.get("model_name", "qwen3-embedding"),
+            base_url=config.get("base_url"),
+        )
+
+    def __call__(self, input: Documents) -> Embeddings:
+        """Generate embeddings using Ollama's local embeddings endpoint."""
+        try:
+            import requests
+        except ImportError:
+            raise ImportError("requests package is required for Ollama embeddings")
+
+        embeddings = []
+        endpoint = f"{self.base_url}/api/embeddings"
+        for text in input:
+            response = requests.post(
+                endpoint,
+                json={"model": self.model_name, "prompt": text},
+                timeout=120,
+            )
+            response.raise_for_status()
+            data = response.json()
+            embeddings.append(data["embedding"])
+        return embeddings
+
+    def embed_query(self, text: str) -> list[float]:
+        """Embed a query string. No special handling needed for Ollama."""
+        return self.__call__([text])[0]
+
+    def truncate(self, text: str, max_tokens: int) -> str:
+        """Truncate using character-based estimation for local Ollama models."""
+        max_chars = max_tokens * 4
+        if len(text) > max_chars:
+            text = text[:max_chars]
+        return text
+
+
 class ChromaClient:
     """ChromaDB client for Zotero semantic search."""
 
@@ -328,7 +390,7 @@ class ChromaClient:
         Args:
             collection_name: Name of the ChromaDB collection
             persist_directory: Directory to persist the database
-            embedding_model: Model to use for embeddings ('default', 'openai', 'gemini', 'qwen', 'embeddinggemma', or HuggingFace model name)
+            embedding_model: Model to use for embeddings ('default', 'openai', 'gemini', 'ollama', 'qwen', 'embeddinggemma', or HuggingFace model name)
             embedding_config: Configuration for the embedding model
         """
         self.collection_name = collection_name
@@ -422,6 +484,11 @@ class ChromaClient:
             base_url = self.embedding_config.get("base_url")
             return GeminiEmbeddingFunction(model_name=model_name, api_key=api_key, base_url=base_url)
 
+        elif self.embedding_model == "ollama":
+            model_name = self.embedding_config.get("model_name", "qwen3-embedding")
+            base_url = self.embedding_config.get("base_url")
+            return OllamaEmbeddingFunction(model_name=model_name, base_url=base_url)
+
         elif self.embedding_model == "qwen":
             model_name = self.embedding_config.get("model_name", "Qwen/Qwen3-Embedding-0.6B")
             return HuggingFaceEmbeddingFunction(model_name=model_name)
@@ -430,7 +497,7 @@ class ChromaClient:
             model_name = self.embedding_config.get("model_name", "google/embeddinggemma-300m")
             return HuggingFaceEmbeddingFunction(model_name=model_name)
 
-        elif self.embedding_model not in ["default", "openai", "gemini"]:
+        elif self.embedding_model not in ["default", "openai", "gemini", "ollama"]:
             # Treat any other value as a HuggingFace model name
             return HuggingFaceEmbeddingFunction(model_name=self.embedding_model)
 
@@ -545,7 +612,7 @@ class ChromaClient:
             # its embed_query returns chunked results, not a single vector.
             _is_custom_ef = isinstance(
                 self.embedding_function,
-                (OpenAIEmbeddingFunction, GeminiEmbeddingFunction, HuggingFaceEmbeddingFunction),
+                (OpenAIEmbeddingFunction, GeminiEmbeddingFunction, HuggingFaceEmbeddingFunction, OllamaEmbeddingFunction),
             )
             if _is_custom_ef and hasattr(self.embedding_function, 'embed_query') and query_texts:
                 query_embeddings = []
@@ -732,6 +799,16 @@ def create_chroma_client(config_path: str | None = None) -> ChromaClient:
                 ec["base_url"] = env_base
         if ec.get("api_key"):
             config["embedding_config"] = ec
+
+    elif config["embedding_model"] == "ollama":
+        ec = dict(config.get("embedding_config") or {})
+        if not ec.get("model_name"):
+            ec["model_name"] = os.getenv("OLLAMA_EMBEDDING_MODEL", "qwen3-embedding")
+        if not ec.get("base_url"):
+            env_base = os.getenv("OLLAMA_BASE_URL")
+            if env_base:
+                ec["base_url"] = env_base
+        config["embedding_config"] = ec
 
     return ChromaClient(
         collection_name=config["collection_name"],

--- a/src/zotero_mcp/setup_helper.py
+++ b/src/zotero_mcp/setup_helper.py
@@ -171,12 +171,13 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
     print("1. Default (all-MiniLM-L6-v2) - Free, runs locally")
     print("2. OpenAI - Better quality, requires API key")
     print("3. Gemini - Better quality, requires API key")
+    print("4. Ollama - Local embeddings via Ollama API")
 
     while True:
-        choice = input("\nChoose embedding model (1-3): ").strip()
-        if choice in ["1", "2", "3"]:
+        choice = input("\nChoose embedding model (1-4): ").strip()
+        if choice in ["1", "2", "3", "4"]:
             break
-        print("Please enter 1, 2, or 3")
+        print("Please enter 1, 2, 3, or 4")
 
     config = {}
 
@@ -237,6 +238,18 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
             print(f"Using custom Gemini base URL: {base_url}")
         else:
             print("Using default Gemini base URL")
+
+    elif choice == "4":
+        config["embedding_model"] = "ollama"
+        model_name = input("Enter Ollama embedding model name (default: qwen3-embedding): ").strip()
+        config["embedding_config"] = {"model_name": model_name or "qwen3-embedding"}
+
+        base_url = input("Enter Ollama base URL (leave blank for http://localhost:11434): ").strip()
+        if base_url:
+            config["embedding_config"]["base_url"] = base_url
+            print(f"Using custom Ollama base URL: {base_url}")
+        else:
+            print("Using default Ollama base URL: http://localhost:11434")
 
     # Configure update frequency
     print("\n=== Database Update Configuration ===")
@@ -450,6 +463,12 @@ def update_claude_config(config_path, zotero_mcp_path, local=True, api_key=None,
                 env_settings["GEMINI_EMBEDDING_MODEL"] = model
             if base_url := embedding_config.get("base_url"):
                 env_settings["GEMINI_BASE_URL"] = base_url
+
+        elif semantic_config.get("embedding_model") == "ollama":
+            if model := embedding_config.get("model_name"):
+                env_settings["OLLAMA_EMBEDDING_MODEL"] = model
+            if base_url := embedding_config.get("base_url"):
+                env_settings["OLLAMA_BASE_URL"] = base_url
 
     # Add or update zotero config
     config["mcpServers"]["zotero"] = {

--- a/tests/test_embedding_function_registration.py
+++ b/tests/test_embedding_function_registration.py
@@ -40,6 +40,7 @@ from zotero_mcp import chroma_client  # noqa: E402
         ("openai", "OpenAIEmbeddingFunction"),
         ("gemini", "GeminiEmbeddingFunction"),
         ("huggingface", "HuggingFaceEmbeddingFunction"),
+        ("ollama", "OllamaEmbeddingFunction"),
     ],
 )
 def test_custom_embedding_functions_are_registered(name, cls_attr):

--- a/tests/test_place_field_reads.py
+++ b/tests/test_place_field_reads.py
@@ -8,6 +8,8 @@ workflows could not determine whether users had populated place.
 
 import json
 
+import pytest
+
 from zotero_mcp.client import format_item_metadata, generate_bibtex
 from zotero_mcp.tools import connectors as _conn
 
@@ -87,6 +89,16 @@ class TestPlaceInMarkdown:
 
 
 class TestPlaceInBibtex:
+    @pytest.fixture(autouse=True)
+    def _force_fallback_bibtex(self, monkeypatch):
+        # generate_bibtex prefers Better BibTeX when Zotero is running; force the
+        # built-in fallback so these tests are deterministic regardless of whether
+        # a local Zotero instance is up (it is not on CI, but may be locally).
+        monkeypatch.setattr(
+            "zotero_mcp.better_bibtex_client.ZoteroBetterBibTexAPI.is_zotero_running",
+            lambda self: False,
+        )
+
     def test_address_rendered_for_book(self):
         item = _book(publisher="Oxford University Press", place="Oxford")
         output = generate_bibtex(item)


### PR DESCRIPTION
Lands @rafaelcorsi's Ollama embedding backend (#349) on current main. Merged cleanly with no conflicts.

- Adds `OllamaEmbeddingFunction` using the local Ollama API, wired into chroma client creation and the interactive setup, documented for `nomic-embed-text` / `bge-m3`.

Also folds in a small test fix: `TestPlaceInBibtex` now stubs `is_zotero_running` so the bibtex fallback assertions are deterministic on dev machines with Zotero open (they already passed on CI). Full suite: 1041 passed locally.

Original PR: #349.