### PR TITLE
fix(ollama): use /api/embed instead of deprecated /api/embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Ollama embeddings now use the current `/api/embed` endpoint** instead of the deprecated `/api/embeddings` route. The whole batch is sent in a single request (`input`) rather than one request per document, and the response's `embeddings` list is parsed accordingly (#349, #360).
+
 ## [0.6.0] - 2026-06-22
 
 ### Added

--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -397,23 +397,35 @@ class OllamaEmbeddingFunction(EmbeddingFunction):
         )
 
     def __call__(self, input: Documents) -> Embeddings:
-        """Generate embeddings using Ollama's local embeddings endpoint."""
+        """Generate embeddings using Ollama's /api/embed endpoint.
+
+        Unlike the deprecated /api/embeddings route (single ``prompt`` -> single
+        ``embedding``), /api/embed accepts a batch via ``input`` and returns a
+        list under ``embeddings``, so the whole batch is sent in one request
+        instead of one request per document.
+        """
         try:
             import requests
         except ImportError:
             raise ImportError("requests package is required for Ollama embeddings")
 
-        embeddings = []
-        endpoint = f"{self.base_url}/api/embeddings"
-        for text in input:
-            response = requests.post(
-                endpoint,
-                json={"model": self.model_name, "prompt": text},
-                timeout=120,
+        texts = list(input)
+        if not texts:
+            return []
+
+        endpoint = f"{self.base_url}/api/embed"
+        response = requests.post(
+            endpoint,
+            json={"model": self.model_name, "input": texts},
+            timeout=120,
+        )
+        response.raise_for_status()
+        data = response.json()
+        embeddings = data.get("embeddings")
+        if embeddings is None:
+            raise ValueError(
+                f"Ollama /api/embed returned no 'embeddings' field: {data}"
             )
-            response.raise_for_status()
-            data = response.json()
-            embeddings.append(data["embedding"])
         return embeddings
 
     def embed_query(self, text: str) -> list[float]:

--- a/tests/test_ollama_embedding.py
+++ b/tests/test_ollama_embedding.py
@@ -1,0 +1,84 @@
+"""Unit tests for ``OllamaEmbeddingFunction``'s HTTP contract.
+
+Ollama deprecated the single-input ``/api/embeddings`` route in favour of
+``/api/embed``, which accepts a batch under ``input`` and returns a list of
+vectors under ``embeddings``. These tests pin that contract without requiring a
+live Ollama server.
+
+Note: ChromaDB's ``EmbeddingFunction`` base wraps ``__call__`` with
+``validate_embeddings(normalize_embeddings(...))``, so the values returned to
+the caller are numpy arrays. Assertions below account for that.
+"""
+
+import pytest
+
+requests = pytest.importorskip("requests")
+# OllamaEmbeddingFunction subclasses chromadb's EmbeddingFunction; numpy ships
+# with chromadb and is used to compare the (normalized) return value.
+pytest.importorskip("chromadb")
+import numpy as np  # noqa: E402
+
+from zotero_mcp.chroma_client import OllamaEmbeddingFunction  # noqa: E402
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_call_uses_api_embed_and_sends_one_batched_request(monkeypatch):
+    calls = []
+
+    def fake_post(url, json=None, timeout=None):
+        calls.append({"url": url, "json": json, "timeout": timeout})
+        # /api/embed returns one vector per input, in order.
+        return _FakeResponse({"embeddings": [[0.1, 0.2], [0.3, 0.4]]})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    ef = OllamaEmbeddingFunction(
+        model_name="nomic-embed-text", base_url="http://localhost:11434"
+    )
+    result = ef(["alpha", "beta"])
+
+    # The whole batch goes out in a single request to the new endpoint, with the
+    # texts under ``input`` (not one ``prompt`` request per document).
+    assert len(calls) == 1, "the whole batch must be sent in a single request"
+    assert calls[0]["url"] == "http://localhost:11434/api/embed"
+    assert calls[0]["json"] == {
+        "model": "nomic-embed-text",
+        "input": ["alpha", "beta"],
+    }
+    assert np.allclose(np.asarray(result, dtype=float), [[0.1, 0.2], [0.3, 0.4]])
+
+
+def test_call_empty_input_issues_no_http_request(monkeypatch):
+    calls = []
+    monkeypatch.setattr(requests, "post", lambda *a, **k: calls.append((a, k)))
+
+    # The guard must short-circuit *before* any HTTP request. (ChromaDB's EF
+    # wrapper may separately reject an empty result; that is orthogonal to the
+    # guard under test and varies by ChromaDB version, so it is not asserted.)
+    try:
+        OllamaEmbeddingFunction()([])
+    except Exception:
+        pass
+
+    assert calls == [], "empty input must not issue an HTTP request"
+
+
+def test_call_raises_when_response_lacks_embeddings(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *a, **k: _FakeResponse({"error": "model not found"}),
+    )
+
+    with pytest.raises(ValueError, match="no 'embeddings' field"):
+        OllamaEmbeddingFunction()(["x"])


### PR DESCRIPTION
## Problem

The Ollama embedding backend added in #349 (`OllamaEmbeddingFunction` in `chroma_client.py`) calls Ollama's **`/api/embeddings`** route. Ollama [deprecated that endpoint](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings) in favour of **`/api/embed`**. On current Ollama builds `/api/embeddings` is still aliased for now, but it is the legacy single-input route and is slated for removal.

The legacy route also forces a request **per document** (`{"prompt": text}` → `{"embedding": [...]}`), so indexing a library issues one HTTP round-trip per chunk.

## Change

Switch `OllamaEmbeddingFunction.__call__` to `/api/embed`:

| | before (`/api/embeddings`) | after (`/api/embed`) |
|---|---|---|
| request key | `prompt` (one string) | `input` (the full batch) |
| requests | one per document | **one per batch** |
| response key | `embedding` | `embeddings` (list) |

- Sends the whole batch in a single request, parsing the `embeddings` list.
- Raises a clear `ValueError` if the response lacks `embeddings` (e.g. model-not-found error payloads), instead of a bare `KeyError`.
- Short-circuits empty input so no pointless empty-batch request is issued (the old per-document loop did zero requests for empty input; the batched form needs an explicit guard).

`embed_query` is unchanged — it passes a one-element list and takes `[0]`, which works the same way.

## Compatibility

`/api/embed` has been available in Ollama since v0.1.45 (mid-2024); any Ollama recent enough to run the embedding models this backend targets (`nomic-embed-text`, `bge-m3`) already supports it. Stored vectors are unaffected — the same model produces the same vectors regardless of endpoint, so no re-index is required for existing Ollama-backed collections.

## Testing

- New `tests/test_ollama_embedding.py` pins the contract with a mocked `requests.post`: correct endpoint, batched `input` payload, single request for a multi-item batch, `embeddings` parsing, and the missing-field error path.
- `pytest tests/test_ollama_embedding.py tests/test_embedding_function_registration.py` → **8 passed**.
- `ruff check` clean on the changed files.
- Verified end-to-end against a local Ollama (`nomic-embed-text`): batched `/api/embed` returns the expected 768-dim vectors, and semantic search over a ~2k-document library returns relevant results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)