### PR TITLE
attach via WebDAV only when configured, skip cloud /file upload

### DIFF
--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -805,11 +805,13 @@ def _download_and_attach_pdf(write_zot, item_key, pdf_url, doi, ctx):
                 ctx.info("Downloaded file too small, likely not a real PDF")
                 return None
 
+            suffix = _webdav_first_attach(write_zot, filename, filepath, item_key, ctx)
+            if suffix is not None:
+                return suffix
             attach_result = write_zot.attachment_both(
                 [(filename, filepath)],
                 parentid=item_key,
             )
-            # Must run inside the with-block — temp file disappears on exit.
             return _maybe_upload_to_webdav(attach_result, filepath, ctx)
     except Exception as e:
         ctx.info(f"PDF download/attach failed: {e}")
@@ -854,6 +856,39 @@ def _maybe_upload_to_webdav(attach_result, file_path, ctx):
         _webdav.upload_attachment_to_webdav(
             attachment_key=attachment_key,
             file_path=file_path,
+        )
+        ctx.info(f"WebDAV PUT: {attachment_key}.zip uploaded")
+        return f" (uploaded to WebDAV as {attachment_key}.zip)"
+    except Exception as e:
+        ctx.info(f"WebDAV PUT failed for {attachment_key}: {e}")
+        return (
+            f" (WARNING: WebDAV upload failed — {e}; "
+            f"attachment {attachment_key} exists but has no file bytes on WebDAV)"
+        )
+
+
+def _webdav_first_attach(write_zot, filename, file_path, parent_key, ctx):
+    """Create attachment shell + WebDAV upload when WebDAV is configured; else return None.
+
+    Returns a user-facing suffix or None (caller falls back to attachment_both).
+    """
+    from zotero_mcp import webdav as _webdav
+
+    if not _webdav.is_webdav_configured():
+        return None
+
+    template = write_zot.item_template("attachment", linkmode="imported_file")
+    template["title"] = filename
+    template["filename"] = filename
+    template["parentItem"] = parent_key
+    result = write_zot.create_items([template])
+    if not (isinstance(result, dict) and result.get("success")):
+        return " (WARNING: could not create attachment shell)"
+    attachment_key = next(iter(result["success"].values()))
+
+    try:
+        _webdav.upload_attachment_to_webdav(
+            attachment_key=attachment_key, file_path=file_path
         )
         ctx.info(f"WebDAV PUT: {attachment_key}.zip uploaded")
         return f" (uploaded to WebDAV as {attachment_key}.zip)"

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -805,7 +805,14 @@ def _download_and_attach_pdf(write_zot, item_key, pdf_url, doi, ctx):
                 ctx.info("Downloaded file too small, likely not a real PDF")
                 return None
 
-            suffix = _webdav_first_attach(write_zot, filename, filepath, item_key, ctx)
+            suffix = _webdav_first_attach(
+                write_zot,
+                filename,
+                filepath,
+                item_key,
+                ctx,
+                content_type="application/pdf",
+            )
             if suffix is not None:
                 return suffix
             attach_result = write_zot.attachment_both(
@@ -867,10 +874,36 @@ def _maybe_upload_to_webdav(attach_result, file_path, ctx):
         )
 
 
-def _webdav_first_attach(write_zot, filename, file_path, parent_key, ctx):
+def _guess_content_type(filename):
+    """Guess a Zotero ``contentType`` from a filename's extension.
+
+    Covers the file types ``add_from_file`` accepts (PDF, EPUB, DJVU, plus a
+    few common extras). Returns ``None`` when there is no useful guess so the
+    caller can leave the field unset and let Zotero fall back.
+    """
+    if not filename:
+        return None
+    ext = os.path.splitext(filename)[1].lower().lstrip(".")
+    return {
+        "pdf": "application/pdf",
+        "epub": "application/epub+zip",
+        "djvu": "image/vnd.djvu",
+        "html": "text/html",
+        "txt": "text/plain",
+        "doc": "application/msword",
+        "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "rtf": "application/rtf",
+        "odt": "application/vnd.oasis.opendocument.text",
+    }.get(ext)
+
+
+def _webdav_first_attach(write_zot, filename, file_path, parent_key, ctx, content_type=None):
     """Create attachment shell + WebDAV upload when WebDAV is configured; else return None.
 
     Returns a user-facing suffix or None (caller falls back to attachment_both).
+    ``content_type``, when given, is written to the attachment shell's
+    ``contentType`` field so Zotero renders and opens the file correctly
+    (e.g. ``application/pdf``).
     """
     from zotero_mcp import webdav as _webdav
 
@@ -881,23 +914,40 @@ def _webdav_first_attach(write_zot, filename, file_path, parent_key, ctx):
     template["title"] = filename
     template["filename"] = filename
     template["parentItem"] = parent_key
+    if content_type:
+        template["contentType"] = content_type
     result = write_zot.create_items([template])
     if not (isinstance(result, dict) and result.get("success")):
         return " (WARNING: could not create attachment shell)"
     attachment_key = next(iter(result["success"].values()))
+    # successVersions is keyed in parallel to success; delete_item() needs the
+    # version for its If-Unmodified-Since-Version header. Older pyzotero may
+    # omit the field, so fall back to a fetch.
+    success_versions = result.get("successVersions") or {}
+    attachment_version = next(iter(success_versions.values()), None)
 
     try:
-        _webdav.upload_attachment_to_webdav(
-            attachment_key=attachment_key, file_path=file_path
-        )
+        _webdav.upload_attachment_to_webdav(attachment_key=attachment_key, file_path=file_path)
         ctx.info(f"WebDAV PUT: {attachment_key}.zip uploaded")
         return f" (uploaded to WebDAV as {attachment_key}.zip)"
     except Exception as e:
         ctx.info(f"WebDAV PUT failed for {attachment_key}: {e}")
-        return (
-            f" (WARNING: WebDAV upload failed — {e}; "
-            f"attachment {attachment_key} exists but has no file bytes on WebDAV)"
-        )
+        # A failed PUT leaves the shell with no file bytes — an orphan that
+        # confuses the Zotero UI and breaks sync. Clean it up, and only fall
+        # back to the "no file bytes" warning if the delete itself fails.
+        try:
+            if attachment_version is None:
+                attachment_version = write_zot.item(attachment_key)["version"]
+            write_zot.delete_item({"key": attachment_key, "version": attachment_version})
+            ctx.info(f"Cleaned up orphan attachment shell {attachment_key}")
+            return f" (WARNING: WebDAV upload failed — {e}; attachment shell {attachment_key} was deleted)"
+        except Exception as del_err:
+            ctx.info(f"Cleanup of orphan shell {attachment_key} failed: {del_err}")
+            return (
+                f" (WARNING: WebDAV upload failed — {e}; "
+                f"attachment {attachment_key} exists but has no file bytes on WebDAV "
+                f"and could not be deleted: {del_err})"
+            )
 
 
 def _attach_pdf_linked_url(write_zot, pdf_url, parent_key, ctx):

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -819,13 +819,15 @@ def _download_and_attach_pdf(write_zot, item_key, pdf_url, doi, ctx):
                 [(filename, filepath)],
                 parentid=item_key,
             )
-            return _maybe_upload_to_webdav(attach_result, filepath, ctx)
+            return _maybe_upload_to_webdav(
+                attach_result, filepath, ctx, write_zot=write_zot
+            )
     except Exception as e:
         ctx.info(f"PDF download/attach failed: {e}")
         return None
 
 
-def _maybe_upload_to_webdav(attach_result, file_path, ctx):
+def _maybe_upload_to_webdav(attach_result, file_path, ctx, write_zot=None):
     """Suffix to append to a user-facing 'file attached' message.
 
     PR #279 added WebDAV-aware upload to ``zotero_add_from_file``. The same
@@ -868,10 +870,34 @@ def _maybe_upload_to_webdav(attach_result, file_path, ctx):
         return f" (uploaded to WebDAV as {attachment_key}.zip)"
     except Exception as e:
         ctx.info(f"WebDAV PUT failed for {attachment_key}: {e}")
-        return (
-            f" (WARNING: WebDAV upload failed — {e}; "
-            f"attachment {attachment_key} exists but has no file bytes on WebDAV)"
-        )
+        # A failed PUT leaves the attachment item with no file bytes — an
+        # orphan that confuses the Zotero UI and breaks sync. Clean it up,
+        # and only fall back to the "no file bytes" warning if the delete
+        # itself fails.
+        try:
+            attachment_version = next(
+                (
+                    entry.get("version")
+                    for status in ("success", "unchanged")
+                    for entry in (attach_result.get(status, []) or [])
+                    if isinstance(entry, dict) and entry.get("key") == attachment_key
+                ),
+                None,
+            )
+            if write_zot is not None:
+                if attachment_version is None:
+                    attachment_version = write_zot.item(attachment_key)["version"]
+                write_zot.delete_item({"key": attachment_key, "version": attachment_version})
+                ctx.info(f"Cleaned up orphan attachment {attachment_key}")
+                return f" (WARNING: WebDAV upload failed — {e}; attachment {attachment_key} was deleted)"
+            raise RuntimeError("no writable client available for cleanup")
+        except Exception as del_err:
+            ctx.info(f"Cleanup of orphan attachment {attachment_key} failed: {del_err}")
+            return (
+                f" (WARNING: WebDAV upload failed — {e}; "
+                f"attachment {attachment_key} exists but has no file bytes on WebDAV "
+                f"and could not be deleted: {del_err})"
+            )
 
 
 def _guess_content_type(filename):

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1385,14 +1385,17 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
                     with open(filepath, "wb") as f:
                         for chunk in pdf_resp.iter_content(chunk_size=8192):
                             f.write(chunk)
-                    attach_result = write_zot.attachment_both(
-                        [(filename, filepath)],
-                        parentid=item_key,
+                    webdav_suffix = _helpers._webdav_first_attach(
+                        write_zot, filename, filepath, item_key, ctx
                     )
-                    # Must run inside the with-block — temp file disappears on exit.
-                    webdav_suffix = _helpers._maybe_upload_to_webdav(
-                        attach_result, filepath, ctx
-                    )
+                    if webdav_suffix is None:
+                        attach_result = write_zot.attachment_both(
+                            [(filename, filepath)],
+                            parentid=item_key,
+                        )
+                        webdav_suffix = _helpers._maybe_upload_to_webdav(
+                            attach_result, filepath, ctx
+                        )
                 pdf_status = "PDF attached" + webdav_suffix
             except Exception as e:
                 ctx.info(f"arXiv PDF attachment failed (non-fatal): {e}")
@@ -2647,14 +2650,18 @@ def add_from_file(
                         "zotero_update_search_database._"
                     )
 
-            attach_result = write_zot.attachment_both(
-                [(display_name, file_path)],
-                parentid=parent_key,
+            webdav_suffix = _helpers._webdav_first_attach(
+                write_zot, display_name, file_path, parent_key, ctx
             )
-            attach_info = (
-                f"File attached: {display_name}"
-                + _helpers._maybe_upload_to_webdav(attach_result, file_path, ctx)
-            )
+            if webdav_suffix is None:
+                attach_result = write_zot.attachment_both(
+                    [(display_name, file_path)],
+                    parentid=parent_key,
+                )
+                webdav_suffix = _helpers._maybe_upload_to_webdav(
+                    attach_result, file_path, ctx
+                )
+            attach_info = f"File attached: {display_name}" + webdav_suffix
         except Exception as e:
             attach_info = f"Item created but file attachment failed: {e}"
 

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1399,7 +1399,7 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
                             parentid=item_key,
                         )
                         webdav_suffix = _helpers._maybe_upload_to_webdav(
-                            attach_result, filepath, ctx
+                            attach_result, filepath, ctx, write_zot=write_zot
                         )
                 pdf_status = "PDF attached" + webdav_suffix
             except Exception as e:
@@ -2669,7 +2669,7 @@ def add_from_file(
                     parentid=parent_key,
                 )
                 webdav_suffix = _helpers._maybe_upload_to_webdav(
-                    attach_result, file_path, ctx
+                    attach_result, file_path, ctx, write_zot=write_zot
                 )
             attach_info = f"File attached: {display_name}" + webdav_suffix
         except Exception as e:

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1386,7 +1386,12 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
                         for chunk in pdf_resp.iter_content(chunk_size=8192):
                             f.write(chunk)
                     webdav_suffix = _helpers._webdav_first_attach(
-                        write_zot, filename, filepath, item_key, ctx
+                        write_zot,
+                        filename,
+                        filepath,
+                        item_key,
+                        ctx,
+                        content_type="application/pdf",
                     )
                     if webdav_suffix is None:
                         attach_result = write_zot.attachment_both(
@@ -2651,7 +2656,12 @@ def add_from_file(
                     )
 
             webdav_suffix = _helpers._webdav_first_attach(
-                write_zot, display_name, file_path, parent_key, ctx
+                write_zot,
+                display_name,
+                file_path,
+                parent_key,
+                ctx,
+                content_type=_helpers._guess_content_type(display_name),
             )
             if webdav_suffix is None:
                 attach_result = write_zot.attachment_both(

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -281,3 +281,159 @@ def test_upload_explicit_timeout_wins_over_env(tmp_path, monkeypatch):
 
     # Explicit caller arg takes precedence over the env var.
     assert session.timeouts == [(10.0, 45.0), (10.0, 45.0)]
+
+
+# ---------------------------------------------------------------------------
+# _webdav_first_attach (shell + PUT orchestration)
+# ---------------------------------------------------------------------------
+
+
+class _NoOpCtx:
+    def info(self, *_a, **_kw):
+        return None
+
+    def error(self, *_a, **_kw):
+        return None
+
+    def warning(self, *_a, **_kw):
+        return None
+
+
+class _ShellZotero:
+    """Minimal pyzotero stand-in for the _webdav_first_attach flow.
+
+    Records the template passed to create_items, returns a deterministic
+    attachment key, and tracks delete_item calls so cleanup-on-failure can
+    be asserted.
+    """
+
+    def __init__(self, attachment_key="ATTCHKEY0", attachment_version=42):
+        self._attachment_key = attachment_key
+        self._attachment_version = attachment_version
+        self.created_template = None
+        self.deleted_payloads = []
+        self.delete_fails = False
+
+    def item_template(self, item_type, **kwargs):
+        return {"itemType": item_type, **kwargs}
+
+    def create_items(self, items, **kwargs):
+        self.created_template = items[0]
+        return {
+            "success": {"0": self._attachment_key},
+            # Mirrors pyzotero: successVersions is keyed in parallel to
+            # success and carries the new item version.
+            "successVersions": {"0": self._attachment_version},
+            "failed": {},
+        }
+
+    def delete_item(self, payload, last_modified=None):
+        # Mirror pyzotero's contract: payload is a dict with key/version
+        # (or a list of such dicts). A bare string must be rejected so a
+        # regression of the call site is caught here rather than in prod.
+        if isinstance(payload, str):
+            raise TypeError("delete_item expects a dict with 'key'/'version', got str")
+        if isinstance(payload, list):
+            keys = [p["key"] for p in payload]
+            versions = [p["version"] for p in payload]
+        else:
+            keys = [payload["key"]]
+            versions = [payload["version"]]
+        self.deleted_payloads.append(payload)
+        assert all(v == self._attachment_version for v in versions), f"unexpected version(s): {versions}"
+        if self.delete_fails:
+            raise RuntimeError("delete refused")
+        return keys
+
+
+def _src_pdf(tmp_path):
+    src = tmp_path / "paper.pdf"
+    src.write_bytes(b"%PDF-1.4 webdav shell test")
+    return src
+
+
+@skip_on_ci
+def test_webdav_first_attach_unconfigured_returns_none(tmp_path, monkeypatch):
+    """No WebDAV env -> _webdav_first_attach returns None so the caller falls
+    through to its existing attachment_both flow untouched.
+    """
+    from zotero_mcp.tools import _helpers
+
+    monkeypatch.delenv("ZOTERO_WEBDAV_URL", raising=False)
+    monkeypatch.delenv("ZOTERO_WEBDAV_USERNAME", raising=False)
+    monkeypatch.delenv("ZOTERO_WEBDAV_PASSWORD", raising=False)
+
+    zot = _ShellZotero()
+    src = _src_pdf(tmp_path)
+    result = _helpers._webdav_first_attach(zot, "paper.pdf", src, "PARENT0", _NoOpCtx(), content_type="application/pdf")
+    assert result is None
+    assert zot.created_template is None  # no shell created
+
+
+@skip_on_ci
+def test_webdav_first_attach_configured_creates_shell_and_uploads(tmp_path, monkeypatch):
+    """WebDAV configured -> shell created with contentType, PUT issued with the right key."""
+    from zotero_mcp.tools import _helpers
+
+    _setup_webdav_env(monkeypatch)
+    session = _RecordingPutSession(status_code=201)
+    monkeypatch.setattr("requests.Session", lambda: session)
+
+    zot = _ShellZotero(attachment_key="ATTCHKEY0")
+    src = _src_pdf(tmp_path)
+
+    result = _helpers._webdav_first_attach(zot, "paper.pdf", src, "PARENT0", _NoOpCtx(), content_type="application/pdf")
+
+    # Shell carries title/filename/parentItem and the contentType.
+    assert zot.created_template["title"] == "paper.pdf"
+    assert zot.created_template["filename"] == "paper.pdf"
+    assert zot.created_template["parentItem"] == "PARENT0"
+    assert zot.created_template["contentType"] == "application/pdf"
+
+    # PUT went out under the shell's attachment key.
+    assert session.calls[0][0] == "https://dav.example.com/zotero/ATTCHKEY0.zip"
+    assert session.calls[1][0] == "https://dav.example.com/zotero/ATTCHKEY0.prop"
+
+    assert result == " (uploaded to WebDAV as ATTCHKEY0.zip)"
+    assert zot.deleted_payloads == []  # no cleanup on success
+
+
+@skip_on_ci
+def test_webdav_first_attach_put_failure_deletes_shell_and_warns(tmp_path, monkeypatch):
+    """PUT failure -> shell deleted via delete_item and the suffix warns about it."""
+    from zotero_mcp.tools import _helpers
+
+    _setup_webdav_env(monkeypatch)
+    session = _RecordingPutSession(status_code=500)
+    monkeypatch.setattr("requests.Session", lambda: session)
+
+    zot = _ShellZotero(attachment_key="ATTCHKEY0")
+    src = _src_pdf(tmp_path)
+
+    result = _helpers._webdav_first_attach(zot, "paper.pdf", src, "PARENT0", _NoOpCtx(), content_type="application/pdf")
+
+    # The orphaned shell was deleted so the Zotero UI/sync stays consistent.
+    assert zot.deleted_payloads == [{"key": "ATTCHKEY0", "version": 42}]
+    assert "WARNING" in result
+    assert "ATTCHKEY0" in result
+    assert "was deleted" in result
+
+
+@skip_on_ci
+def test_webdav_first_attach_put_failure_falls_back_to_warning_if_delete_fails(tmp_path, monkeypatch):
+    """If the cleanup delete itself fails, the suffix retains the old 'no file bytes' wording."""
+    from zotero_mcp.tools import _helpers
+
+    _setup_webdav_env(monkeypatch)
+    session = _RecordingPutSession(status_code=500)
+    monkeypatch.setattr("requests.Session", lambda: session)
+
+    zot = _ShellZotero(attachment_key="ATTCHKEY0")
+    zot.delete_fails = True
+    src = _src_pdf(tmp_path)
+
+    result = _helpers._webdav_first_attach(zot, "paper.pdf", src, "PARENT0", _NoOpCtx(), content_type="application/pdf")
+
+    assert zot.deleted_payloads == [{"key": "ATTCHKEY0", "version": 42}]  # delete was attempted
+    assert "WARNING" in result
+    assert "could not be deleted" in result

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -1,6 +1,5 @@
 """Tests for direct WebDAV attachment access."""
 
-import pytest
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from conftest import skip_on_ci
@@ -437,3 +436,132 @@ def test_webdav_first_attach_put_failure_falls_back_to_warning_if_delete_fails(t
     assert zot.deleted_payloads == [{"key": "ATTCHKEY0", "version": 42}]  # delete was attempted
     assert "WARNING" in result
     assert "could not be deleted" in result
+
+
+# ---------------------------------------------------------------------------
+# _maybe_upload_to_webdav (the attachment_both + PUT path)
+# ---------------------------------------------------------------------------
+
+
+class _AttachBothZotero:
+    """Fake client for the _maybe_upload_to_webdav flow.
+
+    attachment_both succeeded (so the key/version are in attach_result),
+    and delete_item is wired exactly like pyzotero so cleanup-on-PUT-failure
+    can be asserted.
+    """
+
+    def __init__(self, attachment_key="ATTCH2", attachment_version=7):
+        self._key = attachment_key
+        self._version = attachment_version
+        self.deleted_payloads = []
+        self.delete_fails = False
+
+    def item(self, key):
+        return {"key": key, "version": self._version}
+
+    def delete_item(self, payload, last_modified=None):
+        if isinstance(payload, str):
+            raise TypeError("delete_item expects a dict with 'key'/'version', got str")
+        if isinstance(payload, list):
+            keys = [p["key"] for p in payload]
+            versions = [p["version"] for p in payload]
+        else:
+            keys = [payload["key"]]
+            versions = [payload["version"]]
+        self.deleted_payloads.append(payload)
+        assert all(v == self._version for v in versions), f"unexpected version(s): {versions}"
+        if self.delete_fails:
+            raise RuntimeError("delete refused")
+        return keys
+
+    def attachment_both(self, *_a, **_kw):
+        return {
+            "success": [{"key": self._key, "version": self._version}],
+            "unchanged": [],
+            "failed": {},
+        }
+
+
+def _attach_result(key="ATTCH2", version=7):
+    return {
+        "success": [{"key": key, "version": version}],
+        "unchanged": [],
+        "failed": {},
+    }
+
+
+@skip_on_ci
+def test_maybe_upload_success_returns_suffix(tmp_path, monkeypatch):
+    """Successful PUT -> short success suffix, no cleanup."""
+    from zotero_mcp.tools import _helpers
+
+    _setup_webdav_env(monkeypatch)
+    session = _RecordingPutSession(status_code=201)
+    monkeypatch.setattr("requests.Session", lambda: session)
+
+    zot = _AttachBothZotero()
+    src = _src_pdf(tmp_path)
+
+    result = _helpers._maybe_upload_to_webdav(_attach_result(), src, _NoOpCtx(), write_zot=zot)
+
+    assert session.calls[0][0] == "https://dav.example.com/zotero/ATTCH2.zip"
+    assert result == " (uploaded to WebDAV as ATTCH2.zip)"
+    assert zot.deleted_payloads == []  # no cleanup on success
+
+
+@skip_on_ci
+def test_maybe_upload_put_failure_deletes_attachment_and_warns(tmp_path, monkeypatch):
+    """PUT failure after attachment_both -> the just-created attachment is deleted."""
+    from zotero_mcp.tools import _helpers
+
+    _setup_webdav_env(monkeypatch)
+    session = _RecordingPutSession(status_code=500)
+    monkeypatch.setattr("requests.Session", lambda: session)
+
+    zot = _AttachBothZotero(attachment_key="ATTCH2", attachment_version=7)
+    src = _src_pdf(tmp_path)
+
+    result = _helpers._maybe_upload_to_webdav(_attach_result("ATTCH2", 7), src, _NoOpCtx(), write_zot=zot)
+
+    assert zot.deleted_payloads == [{"key": "ATTCH2", "version": 7}]
+    assert "WARNING" in result
+    assert "ATTCH2" in result
+    assert "was deleted" in result
+
+
+@skip_on_ci
+def test_maybe_upload_put_failure_falls_back_if_delete_fails(tmp_path, monkeypatch):
+    """If cleanup delete itself fails, suffix keeps the old 'no file bytes' wording."""
+    from zotero_mcp.tools import _helpers
+
+    _setup_webdav_env(monkeypatch)
+    session = _RecordingPutSession(status_code=500)
+    monkeypatch.setattr("requests.Session", lambda: session)
+
+    zot = _AttachBothZotero(attachment_key="ATTCH2", attachment_version=7)
+    zot.delete_fails = True
+    src = _src_pdf(tmp_path)
+
+    result = _helpers._maybe_upload_to_webdav(_attach_result("ATTCH2", 7), src, _NoOpCtx(), write_zot=zot)
+
+    assert zot.deleted_payloads == [{"key": "ATTCH2", "version": 7}]  # delete was attempted
+    assert "WARNING" in result
+    assert "could not be deleted" in result
+
+
+@skip_on_ci
+def test_maybe_upload_no_key_returns_empty(tmp_path, monkeypatch):
+    """When no attachment key can be extracted, no PUT and no cleanup happen."""
+    from zotero_mcp.tools import _helpers
+
+    _setup_webdav_env(monkeypatch)
+    monkeypatch.setattr("requests.Session", lambda: _RecordingPutSession())
+
+    zot = _AttachBothZotero()
+    src = _src_pdf(tmp_path)
+
+    result = _helpers._maybe_upload_to_webdav({"success": [], "unchanged": []}, src, _NoOpCtx())
+
+    assert result == ""
+    assert zot.deleted_payloads == []


### PR DESCRIPTION
Skip Zotero cloud file upload when WebDAV is configured

`attachment_both` creates an attachment item and uploads the file bytes to Zotero Storage in one call. For users with File Syncing set to WebDAV, this is the wrong target. It also fails with HTTP 413 once the free-tier 300 MB quota is full.

This PR adds `_webdav_first_attach`, called before attachment_both at every PDF/file attach site (`zotero_add_by_doi`, `zotero_add_by_url`, `zotero_add_from_file`, `_add_by_arxiv`). When WebDAV is configured it:

1. Creates the attachment shell via create_items (no file upload to cloud)
2. PUTs the bytes directly to WebDAV as <key>.zip + <key>.prop
3. Returns a user-facing suffix so the caller can report success or a warning

When WebDAV is not configured it returns None and the caller falls through to the existing attachment_both + `_maybe_upload_to_webdav` path unchanged.

if the WebDAV PUT fails after the shell is created, the attachment item is left in Zotero with no file bytes. Cleanup on failure is not implemented right now.
