### PR TITLE
fix(semantic): report correct count in search database status (#362)

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -929,10 +929,27 @@ class _NoEmbeddingFunction(EmbeddingFunction):
     for the default backend, eagerly downloads the ~80MB ONNX MiniLM model.
     Counting rows never embeds anything, so this is never actually called; it
     raises if it ever is, to make misuse loud rather than silently wrong.
+
+    ``name()`` MUST return ``"default"``. ChromaDB >=1.x validates the supplied
+    embedding function against the collection's persisted config in
+    ``validate_embedding_function_conflict_on_get`` and raises a ``ValueError``
+    whenever the supplied ``name()`` differs from the persisted one — *unless*
+    the supplied name is ``"default"``, which short-circuits the check. Without
+    this, opening a collection that was built with any real backend (default,
+    openai, gemini, ...) raises a conflict; ``read_collection_status`` then
+    swallowed that error and reported "0 documents / not initialized" against a
+    fully populated database (issue #362).
     """
+
+    def __init__(self):
+        pass
 
     def __call__(self, input: Documents) -> Embeddings:  # pragma: no cover - never invoked
         raise RuntimeError("embedding is unavailable in status-only mode")
+
+    @staticmethod
+    def name() -> str:
+        return "default"
 
 
 def read_collection_status(config_path: str | None = None) -> dict[str, Any]:

--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -952,7 +952,11 @@ class _NoEmbeddingFunction(EmbeddingFunction):
         return "default"
 
 
-def read_collection_status(config_path: str | None = None) -> dict[str, Any]:
+def read_collection_status(
+    config_path: str | None = None,
+    *,
+    persist_directory: str | None = None,
+) -> dict[str, Any]:
     """Read ChromaDB collection stats WITHOUT loading an embedding model.
 
     The full :class:`ChromaClient` constructor builds the embedding function,
@@ -962,6 +966,9 @@ def read_collection_status(config_path: str | None = None) -> dict[str, Any]:
     configured model name, neither of which requires the model itself. This
     opens the persisted database directly and reads the count, mirroring the
     shape returned by :meth:`ChromaClient.get_collection_info`.
+
+    ``persist_directory`` defaults to ``ChromaClient``'s location
+    (``~/.config/zotero-mcp/chroma_db``); it is parameterised for testing.
     """
     collection_name = "zotero_library"
     embedding_model = "default"
@@ -981,7 +988,8 @@ def read_collection_status(config_path: str | None = None) -> dict[str, Any]:
     if env_model and embedding_model in (None, "default"):
         embedding_model = env_model
 
-    persist_directory = str(Path.home() / ".config" / "zotero-mcp" / "chroma_db")
+    if persist_directory is None:
+        persist_directory = str(Path.home() / ".config" / "zotero-mcp" / "chroma_db")
     base = {
         "name": collection_name,
         "embedding_model": embedding_model,

--- a/tests/test_search_database_status.py
+++ b/tests/test_search_database_status.py
@@ -31,6 +31,9 @@ conflict check for *any* persisted backend. The no-op function is still never
 invoked, because ``count()`` does not embed.
 """
 
+import shutil
+import tempfile
+
 import pytest
 
 # chromadb is an optional extra (``[semantic]``); skip where it isn't installed.
@@ -93,16 +96,19 @@ def test_no_embedding_function_name_is_default():
     assert chroma_client._NoEmbeddingFunction.name() == "default"
 
 
-def test_read_collection_status_reports_populated_count(tmp_path, monkeypatch):
-    # ``read_collection_status`` derives persist_directory from ``Path.home()``.
-    monkeypatch.setattr(chroma_client.Path, "home", lambda: tmp_path)
+def test_read_collection_status_reports_populated_count():
+    # tempfile (not pytest's tmp_path, which is flagged unreliable on CI in
+    # this repo's conftest); persist_directory is passed explicitly.
+    persist_dir = tempfile.mkdtemp(prefix="zotero_mcp_status_362_")
+    try:
+        n = _populate(persist_dir, "zotero_library", n=5)
 
-    persist_dir = tmp_path / ".config" / "zotero-mcp" / "chroma_db"
-    persist_dir.mkdir(parents=True)
-    n = _populate(persist_dir, "zotero_library", n=5)
+        status = chroma_client.read_collection_status(
+            config_path=None, persist_directory=persist_dir
+        )
 
-    status = chroma_client.read_collection_status(config_path=None)
-
-    assert status.get("error") is None, status
-    assert status["initialized"] is True
-    assert status["count"] == n
+        assert status.get("error") is None, status
+        assert status["initialized"] is True
+        assert status["count"] == n
+    finally:
+        shutil.rmtree(persist_dir, ignore_errors=True)

--- a/tests/test_search_database_status.py
+++ b/tests/test_search_database_status.py
@@ -1,0 +1,108 @@
+"""Regression test for issue #362.
+
+``zotero_get_search_database_status`` reported "0 documents / Not initialized"
+against a fully populated database, while the CLI ``db-status`` reported the
+correct count for the *same* database.
+
+Root cause
+----------
+``read_collection_status`` opens the collection with
+``get_collection(name, embedding_function=_NoEmbeddingFunction())`` precisely so
+it does NOT reconstruct (and download) the persisted embedding model — counting
+rows never needs to embed anything. ChromaDB >=1.x, however, validates the
+provided embedding function against the persisted config in
+``validate_embedding_function_conflict_on_get``::
+
+    if (embedding_function.name() != "default"
+            and persisted_ef_config.get("name") is not None
+            and persisted_ef_config.get("name") != embedding_function.name()):
+        raise ValueError("... Embedding function conflict ...")
+
+``_NoEmbeddingFunction`` did not implement ``name()``, so it reported
+``NotImplemented`` — which is ``!= "default"`` and ``!=`` the persisted name —
+tripping the conflict. The broad ``except Exception`` inside
+``read_collection_status`` then swallowed the ``ValueError`` and returned
+``{count: 0, initialized: False}``.
+
+Fix
+---
+``_NoEmbeddingFunction.name()`` returns ``"default"``, which short-circuits the
+conflict check for *any* persisted backend. The no-op function is still never
+invoked, because ``count()`` does not embed.
+"""
+
+import pytest
+
+# chromadb is an optional extra (``[semantic]``); skip where it isn't installed.
+chromadb = pytest.importorskip("chromadb")
+
+from chromadb import Documents, EmbeddingFunction, Embeddings  # noqa: E402
+from chromadb.config import Settings  # noqa: E402
+from chromadb.utils.embedding_functions import (  # noqa: E402
+    register_embedding_function,
+)
+
+from zotero_mcp import chroma_client  # noqa: E402
+
+
+@register_embedding_function
+class _PersistedFakeEF(EmbeddingFunction):
+    """A registered EF whose persisted name is *not* ``"default"``.
+
+    This recreates the embedding-function conflict that a real populated
+    collection produces, without downloading the ~80MB ONNX default model.
+    """
+
+    def __init__(self):
+        pass
+
+    def __call__(self, input: Documents) -> Embeddings:
+        return [[0.1, 0.2, 0.3] for _ in input]
+
+    @staticmethod
+    def name() -> str:
+        return "persisted_fake_362"
+
+    def get_config(self) -> dict:
+        return {}
+
+    @staticmethod
+    def build_from_config(config) -> "_PersistedFakeEF":
+        return _PersistedFakeEF()
+
+
+def _populate(persist_dir, collection_name, n=5):
+    client = chromadb.PersistentClient(
+        path=str(persist_dir),
+        settings=Settings(anonymized_telemetry=False, allow_reset=True),
+    )
+    col = client.get_or_create_collection(
+        name=collection_name, embedding_function=_PersistedFakeEF()
+    )
+    col.add(
+        ids=[str(i) for i in range(n)],
+        documents=[f"doc {i}" for i in range(n)],
+    )
+    return n
+
+
+def test_no_embedding_function_name_is_default():
+    """The fix hinges on this exact value: ``"default"`` is the only name that
+    ChromaDB's conflict check short-circuits on, regardless of the persisted
+    backend (default / openai / gemini / ...)."""
+    assert chroma_client._NoEmbeddingFunction.name() == "default"
+
+
+def test_read_collection_status_reports_populated_count(tmp_path, monkeypatch):
+    # ``read_collection_status`` derives persist_directory from ``Path.home()``.
+    monkeypatch.setattr(chroma_client.Path, "home", lambda: tmp_path)
+
+    persist_dir = tmp_path / ".config" / "zotero-mcp" / "chroma_db"
+    persist_dir.mkdir(parents=True)
+    n = _populate(persist_dir, "zotero_library", n=5)
+
+    status = chroma_client.read_collection_status(config_path=None)
+
+    assert status.get("error") is None, status
+    assert status["initialized"] is True
+    assert status["count"] == n


### PR DESCRIPTION
## Summary

Fixes #362 — `zotero_get_search_database_status` reported **"0 documents / Not initialized"** against a fully populated database, while the CLI `db-status` reported the correct count for the same database.

## Root cause

`read_collection_status` opens the collection with an explicit `_NoEmbeddingFunction` so it does **not** reconstruct (and download) the persisted embedding model — counting rows never needs to embed anything.

ChromaDB ≥1.x, however, validates the supplied embedding function against the collection's persisted config in `validate_embedding_function_conflict_on_get`:

```python
if (embedding_function.name() != "default"
        and persisted_ef_config.get("name") is not None
        and persisted_ef_config.get("name") != embedding_function.name()):
    raise ValueError("... Embedding function conflict ...")
```

`_NoEmbeddingFunction` did not implement `name()`, so it reported `NotImplemented` — which is `!= "default"` and `!=` the persisted name — tripping the conflict:

```
ValueError: Embedding function conflict: new: NotImplemented vs persisted: default
```

The broad `except Exception` inside `read_collection_status` then swallowed the error and returned `{count: 0, initialized: False}`.

The CLI path uses `get_or_create_collection` with the real default embedding function (`name() == "default"`), so it never hit the conflict — which is why the two paths disagreed.

## Fix

`_NoEmbeddingFunction.name()` returns `"default"`, which short-circuits the conflict check for **any** persisted backend (default / openai / gemini / ollama / ...). `count()` never embeds, so the no-op function is still never invoked and no model is downloaded.

## Tests

New `tests/test_search_database_status.py`:
- asserts `_NoEmbeddingFunction.name() == "default"` (the exact property the fix relies on)
- populates a collection with a registered non-`"default"` embedding function and verifies `read_collection_status` reports the correct count and `initialized: True` — without downloading the ONNX model

Both tests fail before the fix (`initialized: False`) and pass after. Adjacent semantic/chroma tests remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
