### PR TITLE
fix(semantic): cache reranker across requests to avoid MCP timeouts (#283)

### DIFF
--- a/src/zotero_mcp/cli.py
+++ b/src/zotero_mcp/cli.py
@@ -149,6 +149,30 @@ def _semantic_config_path(path_arg: str | None) -> Path:
     return Path(path_arg) if path_arg else Path.home() / ".config" / "zotero-mcp" / "config.json"
 
 
+def _warmup_reranker_in_background() -> None:
+    """Preload the reranker (if enabled) off the request path — see issue #283.
+
+    Runs in a daemon thread so server startup is never delayed and a failed or
+    slow model load can never crash the server. No-op when the optional
+    ``[semantic]`` extra isn't installed or the reranker is disabled.
+    """
+    import threading
+
+    def _run() -> None:
+        try:
+            from zotero_mcp.semantic_search import warmup_reranker
+        except Exception:
+            return  # semantic extra not installed
+        try:
+            config_path = str(_semantic_config_path(None))
+            if warmup_reranker(config_path):
+                print("Reranker warmed up.", file=sys.stderr)
+        except Exception:
+            pass  # best-effort: never let warmup break serving
+
+    threading.Thread(target=_run, daemon=True, name="zmcp-reranker-warmup").start()
+
+
 def _print_update_stats(stats: dict) -> None:
     is_batch = stats.get("batch_mode") or stats.get("batch_submitted")
     label = "OpenAI batch submission" if is_batch else "Database update"
@@ -773,6 +797,11 @@ def main():
         transport = getattr(args, "transport", "stdio")
         # Ensure environment is initialized (Claude config or standalone config)
         setup_zotero_environment()
+        # If the reranker is enabled, warm it up in the background so the first
+        # semantic search doesn't pay the ~tens-of-seconds model load inside the
+        # request path and time out (issue #283). Daemon thread: never blocks
+        # startup, never crashes the server if loading fails.
+        _warmup_reranker_in_background()
         if transport == "stdio":
             mcp.run(transport="stdio")
         elif transport == "streamable-http":

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import sys
+import threading
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -161,6 +162,50 @@ def load_update_config(config_path: str | None) -> dict[str, Any]:
         except Exception as e:
             logger.warning(f"Error loading update config: {e}")
     return config
+
+
+_DEFAULT_RERANKER_CONFIG: dict[str, Any] = {
+    "enabled": False,
+    "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+    "candidate_multiplier": 3,
+}
+
+
+def load_reranker_config(config_path: str | None) -> dict[str, Any]:
+    """Read the semantic-search ``reranker`` block from disk.
+
+    Pure file read with no model load, so the server can consult it (e.g. to
+    decide whether to warm up) without paying the cross-encoder cost.
+    """
+    config = dict(_DEFAULT_RERANKER_CONFIG)
+    if config_path and os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                file_config = json.load(f)
+            config.update(file_config.get("semantic_search", {}).get("reranker", {}))
+        except Exception as e:
+            logger.warning(f"Error loading reranker config: {e}")
+    return config
+
+
+def warmup_reranker(config_path: str | None = None) -> bool:
+    """Preload the configured reranker into the process-wide cache.
+
+    Lets the server pay the cross-encoder load cost once at startup (off the
+    request path) so the first real ``zotero_semantic_search`` is fast too
+    (issue #283). Returns ``True`` if a model was warmed, ``False`` if the
+    reranker is disabled. Never raises — a failed warmup must not crash startup.
+    """
+    cfg = load_reranker_config(config_path)
+    if not cfg.get("enabled", False):
+        return False
+    model = cfg.get("model", _DEFAULT_RERANKER_CONFIG["model"])
+    try:
+        get_cached_reranker(model)
+        return True
+    except Exception as e:
+        logger.warning(f"Reranker warmup failed for '{model}': {e}")
+        return False
 
 
 def should_update(update_config: dict[str, Any]) -> bool:
@@ -328,6 +373,33 @@ class CrossEncoderReranker:
         return [(i, float(scores[i])) for i in ranked[:top_k]]
 
 
+# Process-wide reranker cache (issue #283).
+#
+# The MCP search path builds a fresh ``ZoteroSemanticSearch`` per request, so a
+# reranker held on the instance (``self._reranker``) was reloaded from disk on
+# *every* call — the cross-encoder load dominates at ~tens of seconds and blew
+# past client timeouts. The weights are immutable for a given ``model_name``, so
+# caching the loaded reranker at module scope keeps it warm across requests and
+# instances. The lock prevents two concurrent first-calls from double-loading.
+_RERANKER_CACHE: dict[str, CrossEncoderReranker] = {}
+_RERANKER_CACHE_LOCK = threading.Lock()
+
+
+def get_cached_reranker(model_name: str) -> CrossEncoderReranker:
+    """Return a process-wide cached reranker, loading it once per ``model_name``."""
+    cached = _RERANKER_CACHE.get(model_name)
+    if cached is not None:
+        return cached
+    with _RERANKER_CACHE_LOCK:
+        # Re-check under the lock: another thread may have loaded it while we
+        # waited, and the model load is far too expensive to repeat.
+        cached = _RERANKER_CACHE.get(model_name)
+        if cached is None:
+            cached = CrossEncoderReranker(model_name=model_name)
+            _RERANKER_CACHE[model_name] = cached
+        return cached
+
+
 class ZoteroSemanticSearch:
     """Semantic search interface for Zotero libraries using ChromaDB."""
 
@@ -390,27 +462,20 @@ class ZoteroSemanticSearch:
 
     def _load_reranker_config(self) -> dict[str, Any]:
         """Load reranker configuration from file or use defaults."""
-        config: dict[str, Any] = {
-            "enabled": False,
-            "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
-            "candidate_multiplier": 3,
-        }
-        if self.config_path and os.path.exists(self.config_path):
-            try:
-                with open(self.config_path) as f:
-                    file_config = json.load(f)
-                    config.update(file_config.get("semantic_search", {}).get("reranker", {}))
-            except Exception as e:
-                logger.warning(f"Error loading reranker config: {e}")
-        return config
+        return load_reranker_config(self.config_path)
 
     def _get_reranker(self) -> CrossEncoderReranker | None:
-        """Get the reranker instance, lazily initializing if enabled."""
+        """Get the reranker, reusing the process-wide cache if enabled.
+
+        Each MCP request builds a new ``ZoteroSemanticSearch``, so the model is
+        fetched from :func:`get_cached_reranker` (loaded once per process) rather
+        than reloaded per instance (issue #283).
+        """
         if not self._reranker_config.get("enabled", False):
             return None
         if self._reranker is None:
-            model = self._reranker_config.get("model", "cross-encoder/ms-marco-MiniLM-L-6-v2")
-            self._reranker = CrossEncoderReranker(model_name=model)
+            model = self._reranker_config.get("model", _DEFAULT_RERANKER_CONFIG["model"])
+            self._reranker = get_cached_reranker(model)
         return self._reranker
 
     def _load_update_config(self) -> dict[str, Any]:

--- a/tests/test_reranker_cache.py
+++ b/tests/test_reranker_cache.py
@@ -80,7 +80,7 @@ def test_get_reranker_returns_none_when_disabled():
     assert _FakeReranker.load_count == 0  # disabled never loads
 
 
-def test_warmup_reranker_populates_cache(tmp_path, monkeypatch):
+def test_warmup_reranker_populates_cache(monkeypatch):
     monkeypatch.setattr(semantic_search.os.path, "exists", lambda p: False)
     # Disabled config -> no warmup, no load.
     assert semantic_search.warmup_reranker(config_path=None) is False

--- a/tests/test_reranker_cache.py
+++ b/tests/test_reranker_cache.py
@@ -1,0 +1,99 @@
+"""Regression tests for issue #283.
+
+With the reranker enabled, every ``zotero_semantic_search`` MCP call constructs
+a fresh ``ZoteroSemanticSearch`` (``create_semantic_search`` is called per
+request). The cross-encoder was held on that throwaway instance
+(``self._reranker``), so the ~30s model load happened on *every* request and
+blew past the client's timeout.
+
+Fix: cache the loaded reranker at module scope, keyed by model name, so it is
+loaded once per process and reused across instances. ``warmup_reranker`` lets
+the server populate that cache at startup so the first real search is fast too.
+
+These tests use a fake reranker class (patched over ``CrossEncoderReranker``) to
+assert the *caching behaviour* without loading the real ~30s model.
+"""
+
+import pytest
+
+from zotero_mcp import semantic_search
+
+
+class _FakeReranker:
+    """Counts how many times a reranker is actually constructed (= model load)."""
+
+    load_count = 0
+
+    def __init__(self, model_name="cross-encoder/ms-marco-MiniLM-L-6-v2"):
+        type(self).load_count += 1
+        self.model_name = model_name
+
+
+class _FakeChromaClient:
+    embedding_max_tokens = 8000
+
+    def search(self, *a, **k):
+        return {"ids": [[]], "documents": [[]], "distances": [[]], "metadatas": [[]]}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(monkeypatch):
+    """Each test gets a clean cache and a fresh, fake, non-loading reranker."""
+    semantic_search._RERANKER_CACHE.clear()
+    _FakeReranker.load_count = 0
+    monkeypatch.setattr(semantic_search, "CrossEncoderReranker", _FakeReranker)
+    monkeypatch.setattr(semantic_search, "get_zotero_client", lambda: object())
+    yield
+    semantic_search._RERANKER_CACHE.clear()
+
+
+def test_get_cached_reranker_loads_once_per_model():
+    r1 = semantic_search.get_cached_reranker("model-a")
+    r2 = semantic_search.get_cached_reranker("model-a")
+    assert r1 is r2
+    assert _FakeReranker.load_count == 1  # second call hits the cache
+
+    r3 = semantic_search.get_cached_reranker("model-b")
+    assert r3 is not r1
+    assert _FakeReranker.load_count == 2  # distinct model loads separately
+
+
+def test_reranker_shared_across_instances():
+    """The core #283 fix: two separate ZoteroSemanticSearch instances (as the
+    per-request MCP path creates) must reuse one loaded model."""
+    s1 = semantic_search.ZoteroSemanticSearch(chroma_client=_FakeChromaClient())
+    s2 = semantic_search.ZoteroSemanticSearch(chroma_client=_FakeChromaClient())
+    s1._reranker_config = {"enabled": True, "model": "shared-model"}
+    s2._reranker_config = {"enabled": True, "model": "shared-model"}
+
+    r1 = s1._get_reranker()
+    r2 = s2._get_reranker()
+
+    assert r1 is r2
+    assert _FakeReranker.load_count == 1  # loaded once despite two instances
+
+
+def test_get_reranker_returns_none_when_disabled():
+    s = semantic_search.ZoteroSemanticSearch(chroma_client=_FakeChromaClient())
+    s._reranker_config = {"enabled": False, "model": "shared-model"}
+    assert s._get_reranker() is None
+    assert _FakeReranker.load_count == 0  # disabled never loads
+
+
+def test_warmup_reranker_populates_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(semantic_search.os.path, "exists", lambda p: False)
+    # Disabled config -> no warmup, no load.
+    assert semantic_search.warmup_reranker(config_path=None) is False
+    assert _FakeReranker.load_count == 0
+
+    # Enabled config -> warms the cache exactly once.
+    monkeypatch.setattr(
+        semantic_search,
+        "load_reranker_config",
+        lambda cp: {"enabled": True, "model": "warm-model"},
+    )
+    assert semantic_search.warmup_reranker(config_path=None) is True
+    assert _FakeReranker.load_count == 1
+    # The warmed instance is what a later search would get.
+    assert semantic_search.get_cached_reranker("warm-model") is not None
+    assert _FakeReranker.load_count == 1  # already warm -> no extra load


### PR DESCRIPTION
## Summary

Fixes #283 — with the reranker enabled, `zotero_semantic_search` repeatedly blew past the MCP client timeout (the reporter saw >120s with the reranker on vs <1s with it off, and ~34s/query on the direct Python path).

## Root cause

Every `zotero_semantic_search` call builds a **fresh** `ZoteroSemanticSearch` — `create_semantic_search(...)` is invoked per request (`tools/search.py:858`, also `:278`, `:985`). The cross-encoder was held on that throwaway instance (`self._reranker`), and lazily loaded in `_get_reranker`:

```python
if self._reranker is None:                       # always True on a new instance
    self._reranker = CrossEncoderReranker(model_name=model)   # ← loads ~tens of seconds
```

So the instance-level memoization never paid off: each request was a new instance that performed exactly one search, reloading the model from disk every time. The cross-encoder **load** (not inference — that's sub-second on ~30 candidates) is the dominant cost, and it ran on *every* call → timeout. The non-reranker path stays fast because it does no such per-request model load.

This is unchanged in the current `v0.6.0` release: there is no process-level reranker cache anywhere on `main`.

## Fix

**Tier 1 — process-wide reranker cache.** Load the cross-encoder once per `model_name` in a module-level cache; `_get_reranker` fetches from it, so the model stays warm across requests and instances. The weights are immutable for a given model name, so caching is safe. A `threading.Lock` (double-checked) prevents two concurrent first-calls from double-loading.

```python
_RERANKER_CACHE: dict[str, CrossEncoderReranker] = {}
_RERANKER_CACHE_LOCK = threading.Lock()

def get_cached_reranker(model_name: str) -> CrossEncoderReranker:
    cached = _RERANKER_CACHE.get(model_name)
    if cached is not None:
        return cached
    with _RERANKER_CACHE_LOCK:
        cached = _RERANKER_CACHE.get(model_name)
        if cached is None:
            cached = CrossEncoderReranker(model_name=model_name)
            _RERANKER_CACHE[model_name] = cached
        return cached
```

**Tier 2 — startup warmup.** `warmup_reranker()` / `load_reranker_config()` populate that cache at server start from a daemon thread (wired in the `serve` command), so the first real search is fast too. It never blocks startup, never crashes the server on failure, and is a no-op when the reranker is disabled or the `[semantic]` extra isn't installed.

Also dedupes the reranker defaults into `_DEFAULT_RERANKER_CONFIG`. **Default model unchanged** (`cross-encoder/ms-marco-MiniLM-L-6-v2`).

### Effect

```
before: N requests → N model loads (~30s each) → timeout
after:  one warmup at startup → every request is a cache hit (sub-second)
```

## Tests

New `tests/test_reranker_cache.py` (uses a fake reranker patched over `CrossEncoderReranker`, so it asserts the caching behaviour without loading the real ~30s model):
- `get_cached_reranker` loads once per model name; distinct models load separately
- **two separate `ZoteroSemanticSearch` instances reuse one loaded model** (the core fix)
- disabled reranker never loads; `warmup_reranker` populates the cache exactly once

All four fail before the fix and pass after. Adjacent semantic/CLI tests remain green.

## Notes for reviewers

- Warmup currently triggers automatically when `reranker.enabled = true`. Happy to gate it behind a config flag or expose an explicit `zotero_warmup_reranker` tool instead if preferred.
- The issue's larger suggestions (`rerank_mode`, per-request inference timeout + graceful fallback, timing logs) are intentionally left for a follow-up PR to keep this one focused on the timeout root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
