### PR TITLE
Unify zotero_db_path resolution

### DIFF
--- a/src/zotero_mcp/cli.py
+++ b/src/zotero_mcp/cli.py
@@ -122,12 +122,8 @@ def _save_zotero_db_path_to_config(config_path: Path, db_path: str) -> None:
             except Exception:
                 pass
 
-        # Ensure semantic_search section exists
-        if "semantic_search" not in full_config:
-            full_config["semantic_search"] = {}
-
-        # Save the db_path
-        full_config["semantic_search"]["zotero_db_path"] = db_path
+        # Save the db_path at the top level
+        full_config["zotero_db_path"] = db_path
 
         # Write back to file
         with open(config_path, 'w') as f:

--- a/src/zotero_mcp/config.py
+++ b/src/zotero_mcp/config.py
@@ -1,0 +1,124 @@
+"""Typed configuration for zotero-mcp.
+
+The server configuration lives at ``~/.config/zotero-mcp/config.json``.
+This module defines stdlib dataclasses for every section and a single
+loader that deserializes the JSON file into a typed ``ZoteroMcpConfig``
+instance (using pydantic's ``TypeAdapter`` for validation / defaults).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pydantic import TypeAdapter, ValidationError
+
+ZOTERO_MCP_CONFIG_PATH = Path.home() / ".config" / "zotero-mcp" / "config.json"
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Semantic-search sub-sections
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExtractionConfig:
+    pdf_max_pages: int | None = None
+    fulltext_display_max_pages: int | None = None
+
+
+@dataclass
+class UpdateConfig:
+    auto_update: bool = False
+    update_frequency: str = "manual"
+    update_days: int | None = None
+    last_update: str | None = None
+
+
+@dataclass
+class OpenAIBatchConfig:
+    enabled: bool = False
+
+
+@dataclass
+class RerankerConfig:
+    enabled: bool = False
+    model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+    candidate_multiplier: int = 3
+
+
+@dataclass
+class ChunkingConfig:
+    enabled: bool = False
+    chunk_size: int = 1500
+    overlap: int = 200
+    max_chunks_per_item: int = 20
+
+
+@dataclass
+class SemanticSearchConfig:
+    embedding_model: str = "default"
+    embedding_config: dict[str, Any] = field(default_factory=dict)
+    openai_batch: OpenAIBatchConfig = field(default_factory=OpenAIBatchConfig)
+    update_config: UpdateConfig = field(default_factory=UpdateConfig)
+    zotero_db_path: str | None = None
+    extraction: ExtractionConfig = field(default_factory=ExtractionConfig)
+    include_fulltext: bool = True
+    reranker: RerankerConfig = field(default_factory=RerankerConfig)
+    chunking: ChunkingConfig = field(default_factory=ChunkingConfig)
+    last_sync_version: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Top-level config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ZoteroMcpConfig:
+    client_env: dict[str, str] = field(default_factory=dict)
+    semantic_search: SemanticSearchConfig = field(
+        default_factory=SemanticSearchConfig,
+    )
+
+
+_config_adapter: TypeAdapter[ZoteroMcpConfig] = TypeAdapter(ZoteroMcpConfig)
+
+
+def _strip_nulls(obj: Any) -> Any:
+    """Recursively remove keys with ``None`` values from nested dicts.
+
+    This lets users write ``"extraction": null`` in their config without
+    causing a validation error — the key is treated as absent and the
+    dataclass default fills in.
+    """
+    if isinstance(obj, dict):
+        return {k: _strip_nulls(v) for k, v in obj.items() if v is not None}
+    return obj
+
+
+def load_config() -> ZoteroMcpConfig:
+    """Load and validate ``~/.config/zotero-mcp/config.json``.
+
+    Returns a ``ZoteroMcpConfig`` with defaults filled in for any
+    missing keys. A missing file, parse error, or validation error
+    yields the default (all-empty) config so callers never need to
+    guard against ``None``.
+    """
+    raw: dict[str, Any] = {}
+    if ZOTERO_MCP_CONFIG_PATH.exists():
+        try:
+            with open(ZOTERO_MCP_CONFIG_PATH, encoding="utf-8") as f:
+                raw = json.load(f) or {}
+        except (json.JSONDecodeError, OSError):
+            pass
+    try:
+        return _config_adapter.validate_python(_strip_nulls(raw))
+    except ValidationError:
+        logger.warning("Invalid zotero-mcp config, falling back to defaults")
+        return ZoteroMcpConfig()

--- a/src/zotero_mcp/config.py
+++ b/src/zotero_mcp/config.py
@@ -81,10 +81,21 @@ class SemanticSearchConfig:
 
 @dataclass
 class ZoteroMcpConfig:
+    zotero_db_path: str | None = None
     client_env: dict[str, str] = field(default_factory=dict)
     semantic_search: SemanticSearchConfig = field(
         default_factory=SemanticSearchConfig,
     )
+
+    def resolve_zotero_db_path(self) -> str | None:
+        """Return the Zotero database path with correct precedence.
+
+        Checks top-level ``zotero_db_path`` first, then falls back to
+        ``semantic_search.zotero_db_path`` for backward compatibility.
+        Returns ``None`` when neither is set, letting
+        ``LocalZoteroReader._find_zotero_db()`` auto-detect.
+        """
+        return self.zotero_db_path or self.semantic_search.zotero_db_path
 
 
 _config_adapter: TypeAdapter[ZoteroMcpConfig] = TypeAdapter(ZoteroMcpConfig)
@@ -93,9 +104,8 @@ _config_adapter: TypeAdapter[ZoteroMcpConfig] = TypeAdapter(ZoteroMcpConfig)
 def _strip_nulls(obj: Any) -> Any:
     """Recursively remove keys with ``None`` values from nested dicts.
 
-    This lets users write ``"extraction": null`` in their config without
-    causing a validation error — the key is treated as absent and the
-    dataclass default fills in.
+    Allows ``"extraction": null`` in config without causing a validation
+    error — the key is treated as absent and the dataclass default fills in.
     """
     if isinstance(obj, dict):
         return {k: _strip_nulls(v) for k, v in obj.items() if v is not None}
@@ -105,7 +115,7 @@ def _strip_nulls(obj: Any) -> Any:
 def load_config() -> ZoteroMcpConfig:
     """Load and validate ``~/.config/zotero-mcp/config.json``.
 
-    Returns a ``ZoteroMcpConfig`` with defaults filled in for any
+    Return a ``ZoteroMcpConfig`` with defaults filled in for any
     missing keys. A missing file, parse error, or validation error
     yields the default (all-empty) config so callers never need to
     guard against ``None``.

--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .config import load_config
 from .utils import _normalize_for_search, is_local_mode
 
 logger = logging.getLogger(__name__)
@@ -936,7 +937,7 @@ def get_local_zotero_reader() -> LocalZoteroReader | None:
         return None
 
     try:
-        return LocalZoteroReader()
+        return LocalZoteroReader(db_path=load_config().resolve_zotero_db_path())
     except FileNotFoundError:
         return None
 

--- a/src/zotero_mcp/setup_helper.py
+++ b/src/zotero_mcp/setup_helper.py
@@ -143,7 +143,11 @@ def find_claude_config(verbose: bool = False):
         print(f"Claude Desktop config not found. Using default path: {default_path}")
     return default_path
 
-def setup_semantic_search(existing_semantic_config: dict | None = None, semantic_config_only_arg: bool = False) -> dict:
+def setup_semantic_search(
+    existing_semantic_config: dict | None = None,
+    semantic_config_only_arg: bool = False,
+    existing_db_path: str | None = None,
+) -> tuple[dict, str | None]:
     """Interactive setup for semantic search configuration."""
     print("\n=== Semantic Search Configuration ===")
 
@@ -152,7 +156,7 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
         model = existing_semantic_config.get("embedding_model", "unknown")
         name = existing_semantic_config.get("embedding_config", {}).get("model_name", "unknown")
         update_freq = existing_semantic_config.get("update_config", {}).get("update_frequency", "unknown")
-        db_path = existing_semantic_config.get("zotero_db_path", "auto-detect")
+        db_path = existing_db_path or existing_semantic_config.get("zotero_db_path") or "auto-detect"
         openai_batch = existing_semantic_config.get("openai_batch", {}).get("enabled", False)
         print("Found existing semantic search configuration:")
         print(f"  - Embedding model: {model}")
@@ -165,7 +169,7 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
         print("If you change to a new configuration, a database rebuild is advised.")
         print("Would you like to keep your existing configuration? (y/n): ", end="")
         if input().strip().lower() in ['y', 'yes']:
-            return existing_semantic_config
+            return existing_semantic_config, existing_db_path
 
     print("Configure embedding models for semantic search over your Zotero library.")
 
@@ -348,7 +352,7 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
     print("\n=== Zotero Database Path ===")
     print("By default, zotero-mcp auto-detects the Zotero database location.")
     print("If Zotero is installed in a custom location, you can specify the path here.")
-    default_db_path = existing_semantic_config.get("zotero_db_path", "") if existing_semantic_config else ""
+    default_db_path = existing_db_path or (existing_semantic_config.get("zotero_db_path", "") if existing_semantic_config else "")
     db_path_hint = default_db_path if default_db_path else "auto-detect"
     raw_db_path = input(f"Zotero database path [{db_path_hint}]: ").strip()
 
@@ -399,13 +403,14 @@ def setup_semantic_search(existing_semantic_config: dict | None = None, semantic
             "overlap": 200,
             "max_chunks_per_item": 20,
         })
-    if zotero_db_path:
-        config["zotero_db_path"] = zotero_db_path
-
-    return config
+    return config, zotero_db_path
 
 
-def save_semantic_search_config(config: dict, semantic_config_path: Path) -> bool:
+def save_semantic_search_config(
+    config: dict,
+    semantic_config_path: Path,
+    zotero_db_path: str | None = None,
+) -> bool:
     """Save semantic search configuration to file."""
     try:
         # Ensure config directory exists
@@ -424,6 +429,10 @@ def save_semantic_search_config(config: dict, semantic_config_path: Path) -> boo
         # Add semantic search config
         full_semantic_config["semantic_search"] = config
 
+        # Store zotero_db_path at the top level (not under semantic_search)
+        if zotero_db_path:
+            full_semantic_config["zotero_db_path"] = zotero_db_path
+
         # Write config
         with open(semantic_config_path, 'w') as f:
             json.dump(full_semantic_config, f, indent=2)
@@ -435,6 +444,17 @@ def save_semantic_search_config(config: dict, semantic_config_path: Path) -> boo
     except Exception as e:
         print(f"Error saving semantic search config: {e}")
         return False
+
+def load_top_level_db_path(config_path: Path) -> str | None:
+    """Load the top-level ``zotero_db_path`` from the config file."""
+    if not config_path.exists():
+        return None
+    try:
+        with open(config_path) as f:
+            return json.load(f).get("zotero_db_path")
+    except Exception:
+        return None
+
 
 def load_semantic_search_config(semantic_config_path: Path) -> dict:
     """Load existing semantic search configuration."""
@@ -613,16 +633,17 @@ def main(cli_args=None):
     semantic_config_dir = Path.home() / ".config" / "zotero-mcp"
     semantic_config_path = semantic_config_dir / "config.json"
     existing_semantic_config = load_semantic_search_config(semantic_config_path)
+    existing_db_path = load_top_level_db_path(semantic_config_path)
     semantic_config_changed = False
 
     # Handle semantic search only configuration
     if args.semantic_config_only:
         print("Configuring semantic search only...")
-        new_semantic_config = setup_semantic_search(existing_semantic_config)
+        new_semantic_config, zotero_db_path = setup_semantic_search(existing_semantic_config, existing_db_path=existing_db_path)
         semantic_config_changed = existing_semantic_config != new_semantic_config
         # only save if semantic config changed
         if semantic_config_changed:
-            if save_semantic_search_config(new_semantic_config, semantic_config_path):
+            if save_semantic_search_config(new_semantic_config, semantic_config_path, zotero_db_path):
                 print("\nSemantic search configuration complete!")
                 print(f"Configuration saved to: {semantic_config_path}")
                 print("\nTo initialize the database, run: zotero-mcp update-db")
@@ -683,11 +704,11 @@ def main(cli_args=None):
             print("\nWould you like to configure semantic search? (y/n): ", end="")
         # Either way:
         if input().strip().lower() in ['y', 'yes']:
-            new_semantic_config = setup_semantic_search(existing_semantic_config)
+            new_semantic_config, zotero_db_path = setup_semantic_search(existing_semantic_config, existing_db_path=existing_db_path)
             if existing_semantic_config != new_semantic_config:
                 semantic_config_changed = True
                 existing_semantic_config = new_semantic_config  # Update the config to use
-                save_semantic_search_config(existing_semantic_config, semantic_config_path)
+                save_semantic_search_config(existing_semantic_config, semantic_config_path, zotero_db_path)
 
     print("\nSetup with the following settings:")
     print(f"  Local API: {use_local}")

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -6,35 +6,12 @@ import re
 import socket
 import tempfile
 from ipaddress import ip_address
-from pathlib import Path
 from urllib.parse import urljoin, urlparse
 
 import requests
 
 from zotero_mcp import client as _client
 from zotero_mcp import utils as _utils
-
-# ---------------------------------------------------------------------------
-# Config file
-# ---------------------------------------------------------------------------
-
-ZOTERO_MCP_CONFIG_PATH = Path.home() / ".config" / "zotero-mcp" / "config.json"
-
-
-def _load_zotero_mcp_config() -> dict:
-    """Return the parsed ``~/.config/zotero-mcp/config.json``, or ``{}``.
-
-    Missing file or parse errors yield an empty dict so callers can use
-    ``.get(...)`` chains without guarding.
-    """
-    if not ZOTERO_MCP_CONFIG_PATH.exists():
-        return {}
-    try:
-        with open(ZOTERO_MCP_CONFIG_PATH, encoding="utf-8") as f:
-            return json.load(f) or {}
-    except (json.JSONDecodeError, OSError):
-        return {}
-
 
 # ---------------------------------------------------------------------------
 # Pagination helper

--- a/src/zotero_mcp/tools/read_pdf.py
+++ b/src/zotero_mcp/tools/read_pdf.py
@@ -1,15 +1,14 @@
 """Tool for reading specific page ranges from PDF attachments."""
 
-import json
 import os
 import tempfile
-from pathlib import Path
 
 from fastmcp import Context
 
 from zotero_mcp import client as _client
 from zotero_mcp import utils as _utils
 from zotero_mcp._app import mcp
+from zotero_mcp.config import load_config
 from zotero_mcp.tools import _helpers
 
 
@@ -40,16 +39,7 @@ def _get_pdf_path(item_key: str, ctx: Context) -> tuple[str, str] | None:
         from zotero_mcp.local_db import LocalZoteroReader
 
         if _utils.is_local_mode():
-            config_path = Path.home() / ".config" / "zotero-mcp" / "config.json"
-            zotero_db_path = None
-            if config_path.exists():
-                try:
-                    with open(config_path, encoding="utf-8") as _f:
-                        _cfg = json.load(_f)
-                        zotero_db_path = _cfg.get("semantic_search", {}).get("zotero_db_path")
-                except Exception:
-                    pass
-            with LocalZoteroReader(db_path=zotero_db_path) as reader:
+            with LocalZoteroReader(db_path=load_config().resolve_zotero_db_path()) as reader:
                 local_item = reader.get_item_by_key(item_key)
                 if local_item:
                     for att_key, path, ctype in reader._iter_parent_attachments(local_item.item_id):

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -13,6 +13,7 @@ from zotero_mcp import utils as _utils
 from zotero_mcp._app import mcp
 from zotero_mcp._context import Context
 from zotero_mcp.client import with_zotero_api_lock
+from zotero_mcp.config import load_config
 from zotero_mcp.tools import _helpers
 
 
@@ -148,13 +149,13 @@ def get_item_fulltext(
             from zotero_mcp.local_db import LocalZoteroReader
 
             if _utils.is_local_mode():
-                semantic_cfg = _helpers._load_zotero_mcp_config().get("semantic_search", {})
-                zotero_db_path = semantic_cfg.get("zotero_db_path")
-                extraction_cfg = semantic_cfg.get("extraction", {})
-                pdf_max_pages = extraction_cfg.get("pdf_max_pages")
+                cfg = load_config()
+                zotero_db_path = cfg.semantic_search.zotero_db_path
+                extraction = cfg.semantic_search.extraction
+                pdf_max_pages = extraction.pdf_max_pages
                 # Separate display limit for when Claude reads papers
                 # (reduces token usage vs. indexing which can be higher)
-                fulltext_display_max = extraction_cfg.get("fulltext_display_max_pages")
+                fulltext_display_max = extraction.fulltext_display_max_pages
 
                 # Use display limit if configured, otherwise fall back to
                 # pdf_max_pages, with a default cap of 10 pages.
@@ -267,11 +268,7 @@ def get_attachment_path(
     try:
         from zotero_mcp.local_db import LocalZoteroReader
 
-        zotero_db_path = (
-            _helpers._load_zotero_mcp_config()
-            .get("semantic_search", {})
-            .get("zotero_db_path")
-        )
+        zotero_db_path = load_config().semantic_search.zotero_db_path
 
         with LocalZoteroReader(db_path=zotero_db_path) as reader:
             attachments = reader.get_attachment_paths(item_key)

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -149,9 +149,9 @@ def get_item_fulltext(
             from zotero_mcp.local_db import LocalZoteroReader
 
             if _utils.is_local_mode():
-                cfg = load_config()
-                zotero_db_path = cfg.semantic_search.zotero_db_path
-                extraction = cfg.semantic_search.extraction
+                config = load_config()
+                zotero_db_path = config.resolve_zotero_db_path()
+                extraction = config.semantic_search.extraction
                 pdf_max_pages = extraction.pdf_max_pages
                 # Separate display limit for when Claude reads papers
                 # (reduces token usage vs. indexing which can be higher)
@@ -268,9 +268,7 @@ def get_attachment_path(
     try:
         from zotero_mcp.local_db import LocalZoteroReader
 
-        zotero_db_path = load_config().semantic_search.zotero_db_path
-
-        with LocalZoteroReader(db_path=zotero_db_path) as reader:
+        with LocalZoteroReader(db_path=load_config().resolve_zotero_db_path()) as reader:
             attachments = reader.get_attachment_paths(item_key)
 
         if not attachments:
@@ -971,7 +969,7 @@ def list_libraries(*, ctx: Context) -> str:
         if local:
             from zotero_mcp.local_db import LocalZoteroReader
 
-            reader = LocalZoteroReader()
+            reader = LocalZoteroReader(db_path=load_config().resolve_zotero_db_path())
             try:
                 libraries = reader.get_libraries()
 
@@ -1147,7 +1145,7 @@ def validate_library_switch(library_id: str, library_type: str) -> str | None:
         try:
             from zotero_mcp.local_db import LocalZoteroReader
 
-            reader = LocalZoteroReader()
+            reader = LocalZoteroReader(db_path=load_config().resolve_zotero_db_path())
             try:
                 libraries = reader.get_libraries()
                 if library_type == "group":
@@ -1205,7 +1203,7 @@ def list_feeds(*, ctx: Context) -> str:
         ctx.info("Listing RSS feeds")
         from zotero_mcp.local_db import LocalZoteroReader
 
-        reader = LocalZoteroReader()
+        reader = LocalZoteroReader(db_path=load_config().resolve_zotero_db_path())
         try:
             feeds = reader.get_feeds()
             if not feeds:
@@ -1278,7 +1276,7 @@ def get_feed_items(
         ctx.info(f"Fetching items from feed (libraryID={library_id})")
         from zotero_mcp.local_db import LocalZoteroReader
 
-        reader = LocalZoteroReader()
+        reader = LocalZoteroReader(db_path=load_config().resolve_zotero_db_path())
         try:
             # Verify this is actually a feed
             feeds = reader.get_feeds()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ import pytest
 
 from zotero_mcp.config import (
     ExtractionConfig,
+    SemanticSearchConfig,
     ZoteroMcpConfig,
     _strip_nulls,
     load_config,
@@ -126,3 +127,26 @@ def test_load_malformed_json_falls_back(tmp_path, monkeypatch):
     monkeypatch.setattr("zotero_mcp.config.ZOTERO_MCP_CONFIG_PATH", p)
     cfg = load_config()
     assert cfg == ZoteroMcpConfig()
+
+
+# -- resolve_zotero_db_path ---------------------------------------------------
+
+
+def test_resolve_top_level_takes_precedence():
+    cfg = ZoteroMcpConfig(
+        zotero_db_path="/top/level.sqlite",
+        semantic_search=SemanticSearchConfig(zotero_db_path="/legacy/path.sqlite"),
+    )
+    assert cfg.resolve_zotero_db_path() == "/top/level.sqlite"
+
+
+def test_resolve_falls_back_to_semantic_search():
+    cfg = ZoteroMcpConfig(
+        semantic_search=SemanticSearchConfig(zotero_db_path="/legacy/path.sqlite"),
+    )
+    assert cfg.resolve_zotero_db_path() == "/legacy/path.sqlite"
+
+
+def test_resolve_returns_none_when_unset():
+    cfg = ZoteroMcpConfig()
+    assert cfg.resolve_zotero_db_path() is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,128 @@
+"""Tests for zotero_mcp.config — typed config loading."""
+
+import json
+
+import pytest
+
+from zotero_mcp.config import (
+    ExtractionConfig,
+    ZoteroMcpConfig,
+    _strip_nulls,
+    load_config,
+)
+
+# -- _strip_nulls ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "inp, expected",
+    [
+        ({}, {}),
+        ({"a": 1, "b": None}, {"a": 1}),
+        ({"a": {"b": None, "c": 2}}, {"a": {"c": 2}}),
+        ({"a": None}, {}),
+        ("not a dict", "not a dict"),
+    ],
+    ids=["empty", "top-level-null", "nested-null", "all-null", "non-dict"],
+)
+def test_strip_nulls(inp, expected):
+    assert _strip_nulls(inp) == expected
+
+
+# -- load_config --------------------------------------------------------------
+
+
+def test_load_missing_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "zotero_mcp.config.ZOTERO_MCP_CONFIG_PATH",
+        tmp_path / "nonexistent.json",
+    )
+    cfg = load_config()
+    assert cfg == ZoteroMcpConfig()
+
+
+def test_load_empty_file(tmp_path, monkeypatch):
+    p = tmp_path / "config.json"
+    p.write_text("{}")
+    monkeypatch.setattr("zotero_mcp.config.ZOTERO_MCP_CONFIG_PATH", p)
+    cfg = load_config()
+    assert cfg == ZoteroMcpConfig()
+
+
+def test_load_normal(tmp_path, monkeypatch):
+    p = tmp_path / "config.json"
+    p.write_text(
+        json.dumps(
+            {
+                "semantic_search": {
+                    "zotero_db_path": "/some/path.sqlite",
+                    "extraction": {"pdf_max_pages": 50},
+                }
+            }
+        )
+    )
+    monkeypatch.setattr("zotero_mcp.config.ZOTERO_MCP_CONFIG_PATH", p)
+    cfg = load_config()
+    assert cfg.semantic_search.zotero_db_path == "/some/path.sqlite"
+    assert cfg.semantic_search.extraction.pdf_max_pages == 50
+
+
+def test_load_extra_keys_ignored(tmp_path, monkeypatch):
+    p = tmp_path / "config.json"
+    p.write_text(
+        json.dumps(
+            {
+                "unknown_top_key": True,
+                "semantic_search": {
+                    "zotero_db_path": "/db.sqlite",
+                    "future_setting": [1, 2, 3],
+                },
+            }
+        )
+    )
+    monkeypatch.setattr("zotero_mcp.config.ZOTERO_MCP_CONFIG_PATH", p)
+    cfg = load_config()
+    assert cfg.semantic_search.zotero_db_path == "/db.sqlite"
+    assert not hasattr(cfg, "unknown_top_key")
+
+
+def test_load_null_nested_uses_defaults(tmp_path, monkeypatch):
+    p = tmp_path / "config.json"
+    p.write_text(
+        json.dumps(
+            {
+                "semantic_search": {
+                    "extraction": None,
+                    "reranker": None,
+                }
+            }
+        )
+    )
+    monkeypatch.setattr("zotero_mcp.config.ZOTERO_MCP_CONFIG_PATH", p)
+    cfg = load_config()
+    assert cfg.semantic_search.extraction == ExtractionConfig()
+    assert cfg.semantic_search.reranker.enabled is False
+
+
+def test_load_type_coercion(tmp_path, monkeypatch):
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps({"semantic_search": {"last_sync_version": "42"}}))
+    monkeypatch.setattr("zotero_mcp.config.ZOTERO_MCP_CONFIG_PATH", p)
+    cfg = load_config()
+    assert cfg.semantic_search.last_sync_version == 42
+
+
+def test_load_invalid_type_falls_back(tmp_path, monkeypatch):
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps({"semantic_search": {"last_sync_version": "not_a_number"}}))
+    monkeypatch.setattr("zotero_mcp.config.ZOTERO_MCP_CONFIG_PATH", p)
+    cfg = load_config()
+    assert cfg == ZoteroMcpConfig()
+
+
+def test_load_malformed_json_falls_back(tmp_path, monkeypatch):
+    p = tmp_path / "config.json"
+    p.write_text("{invalid json")
+    monkeypatch.setattr("zotero_mcp.config.ZOTERO_MCP_CONFIG_PATH", p)
+    cfg = load_config()
+    assert cfg == ZoteroMcpConfig()

--- a/tests/test_feed_retrieval.py
+++ b/tests/test_feed_retrieval.py
@@ -7,26 +7,33 @@ class DummyContext:
 
 
 class FakeFeedReader:
+    def __init__(self, db_path=None):
+        pass
+
     def get_feeds(self):
-        return [{
-            "libraryID": 10,
-            "name": "Example Feed",
-            "url": "https://example.test/feed.xml",
-        }]
+        return [
+            {
+                "libraryID": 10,
+                "name": "Example Feed",
+                "url": "https://example.test/feed.xml",
+            }
+        ]
 
     def get_feed_items(self, library_id, limit=20):
         assert library_id == 10
         assert limit == 20
-        return [{
-            "title": "Feed Item Title",
-            "readTime": None,
-            "creators": "Lovelace, Ada",
-            "url": "https://example.test/item",
-            "date": "2024-05-15",
-            "DOI": "10.1234/example.doi",
-            "dateAdded": "2026-06-01 10:00:00",
-            "abstract": None,
-        }]
+        return [
+            {
+                "title": "Feed Item Title",
+                "readTime": None,
+                "creators": "Lovelace, Ada",
+                "url": "https://example.test/item",
+                "date": "2024-05-15",
+                "DOI": "10.1234/example.doi",
+                "dateAdded": "2026-06-01 10:00:00",
+                "abstract": None,
+            }
+        ]
 
     def close(self):
         return None


### PR DESCRIPTION
## Problem

Several local-mode tools (`list_libraries`, `validate_library_switch`, `list_feeds`, `get_feed_items`, `get_local_zotero_reader`, `read_pdf`) ignore the configured `zotero_db_path` and rely on auto-detection only. This causes them to read the wrong database when the user's Zotero profile uses a non-default DB location.

## Changes

- Refactor config-parsing to use Pydantic for validation and expose values as a nested dataclass.
- Replace raw-dict `_load_zotero_mcp_config()` in `_helpers.py` with typed `load_config()` returning `ZoteroMcpConfig`
- Add top-level `zotero_db_path` config setting with `resolve_zotero_db_path()` method (checks top-level first, falls back to `semantic_search.zotero_db_path`)
- Make all six inconsistent tool call sites to pass the resolved db_path to `LocalZoteroReader`
- Update `get_item_fulltext` and `get_attachment_path` to use the same resolution
- Replace manual config file parsing in `read_pdf.py` with `load_config()`
- Make the setup wizard and the CLI option respect the new setting.
- Add tests for config parsing edge cases (null values, extra keys, type coercion, malformed JSON) and resolution precedence

## Backward compatibility

- Existing configs with `semantic_search.zotero_db_path` continue to work unchanged
- Extra/unknown keys in config JSON are silently ignored
- null values for nested objects are treated as absent (defaults fill in)
- Non-coercible type errors fall back to all-defaults with a log warning
