### PR TITLE
Fix ChromaDB max-batch-size overflow and chunk-unaware skip check when chunking is enabled

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -640,11 +640,19 @@ class ChromaClient:
             ids: List of unique IDs for each document
         """
         try:
-            self.collection.upsert(
-                documents=documents,
-                metadatas=metadatas,
-                ids=ids
-            )
+            # ChromaDB rejects batches larger than its max_batch_size
+            # (~5461). With passage-chunking enabled a batch of 25 books
+            # easily exceeds that, so split instead of failing.
+            try:
+                max_batch = int(self.client.get_max_batch_size())
+            except Exception:
+                max_batch = 5000
+            for i in range(0, len(ids), max_batch):
+                self.collection.upsert(
+                    documents=documents[i:i + max_batch],
+                    metadatas=metadatas[i:i + max_batch],
+                    ids=ids[i:i + max_batch]
+                )
             logger.info(f"Upserted {len(documents)} documents to ChromaDB collection")
         except Exception as e:
             logger.error(f"Error upserting documents to ChromaDB: {e}")

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -961,7 +961,13 @@ class ZoteroSemanticSearch:
 
                         # CHECK IF ITEM ALREADY EXISTS (unless force_rebuild or no client)
                         if chroma_client and not force_rebuild:
-                            existing_metadata = chroma_client.get_document_metadata(it.key)
+                            # With passage-chunking the stored ids are
+                            # "<key>#<n>", so also probe the first chunk —
+                            # otherwise every update re-extracts and re-embeds
+                            # the whole corpus.
+                            existing_metadata = chroma_client.get_document_metadata(
+                                it.key
+                            ) or chroma_client.get_document_metadata(f"{it.key}#0")
                             if existing_metadata:
                                 chroma_has_fulltext = existing_metadata.get("has_fulltext", False)
                                 local_has_fulltext = len(reader.get_fulltext_meta_for_item(it.item_id)) > 0


### PR DESCRIPTION
## Summary

Two bugs that surface when passage chunking (`semantic_search.chunking.enabled`) is on, found while indexing a ~535-item library with many long (300-900 page) books:

### 1. `upsert_documents()` exceeds ChromaDB's max batch size

The indexing loop accumulates chunk records for 25 items and upserts them in one `collection.upsert()` call. With chunking enabled, a batch containing a few long books easily exceeds ChromaDB's `max_batch_size` (~5,461 on the default backend):

```
ValueError: Batch size of 6965 is greater than max batch size of 5461
```

The whole batch then lands in `_failed_docs`, and the end-of-run retry re-inserts those records **one at a time** — in our case 20,570 single-record upserts (each an embedding API round-trip), turning a ~25-minute index run into hours.

**Fix:** split the upsert into sub-batches of `client.get_max_batch_size()` (with a conservative fallback of 5,000 when the API is unavailable).

### 2. Existing-item probe is chunk-unaware, so every update re-extracts the whole corpus

The "check if item already exists" probe in `_get_items_from_source()` looks up `get_document_metadata(it.key)`, but with chunking enabled the stored ids are `<key>#<n>` — the bare key never matches. Result: every incremental `update-db --fulltext` run re-extracts and re-embeds **all** items instead of only new/changed ones.

**Fix:** also probe `<key>#0` (the deletion pass and the stale-passage cleanup already handle chunked ids this way).

## Test plan

- Rebuilt a 535-item / ~63k-chunk collection with chunking enabled: no batch-size failures, no one-by-one retry pass.
- Subsequent `update-db --fulltext` run correctly reports 533/535 items "up to date" and only processes the 2 new items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
