### PR TITLE
Add opt-in collection filter for the semantic search database

### DIFF
--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -670,12 +670,15 @@ class LocalZoteroReader:
         rows = conn.execute("SELECT key FROM items").fetchall()
         return {row[0] for row in rows}
 
-    def get_items_with_text(self, limit: int | None = None, include_fulltext: bool = False, key_filter: str | None = None) -> list[ZoteroItem]:
+    def get_items_with_text(self, limit: int | None = None, include_fulltext: bool = False, key_filter: str | None = None, collection_keys: list[str] | None = None) -> list[ZoteroItem]:
         """
         Get all items with their text content for semantic search.
 
         Args:
             limit: Optional limit on number of items to return.
+            collection_keys: Optional list of collection keys; when set, only
+                items in those collections (or any of their subcollections)
+                are returned.
 
         Returns:
             List of ZoteroItem objects with text content.
@@ -737,6 +740,24 @@ class LocalZoteroReader:
         """
 
         params = []
+        if collection_keys:
+            # Restrict the corpus to the configured collections, including
+            # all of their subcollections (resolved recursively).
+            all_collection_ids = []
+            for ckey in collection_keys:
+                root = conn.execute("SELECT collectionID FROM collections WHERE key = ?", (ckey,)).fetchone()
+                if root:
+                    to_process = [root[0]]
+                    while to_process:
+                        cid = to_process.pop()
+                        all_collection_ids.append(cid)
+                        for sub in conn.execute("SELECT collectionID FROM collections WHERE parentCollectionID = ?", (cid,)).fetchall():
+                            to_process.append(sub[0])
+            if all_collection_ids:
+                placeholders = ','.join('?' * len(all_collection_ids))
+                query += f" AND i.itemID IN (SELECT DISTINCT itemID FROM collectionItems WHERE collectionID IN ({placeholders}))"
+                params.extend(all_collection_ids)
+
         if key_filter:
             query += " AND i.key = ?"
             params.append(key_filter)

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -773,6 +773,7 @@ class ZoteroSemanticSearch:
             pdf_max_pages = None
             pdf_timeout = 30
             zotero_db_path = self.db_path  # CLI override takes precedence
+            collection_keys = None
             # If semantic_search config file exists, prefer its setting
             try:
                 if self.config_path and os.path.exists(self.config_path):
@@ -782,6 +783,7 @@ class ZoteroSemanticSearch:
                         extraction_cfg = semantic_cfg.get("extraction", {})
                         pdf_max_pages = extraction_cfg.get("pdf_max_pages")
                         pdf_timeout = extraction_cfg.get("pdf_timeout", 30)
+                        collection_keys = semantic_cfg.get("collection_keys")
                         # Use config db_path only if no CLI override
                         if not zotero_db_path:
                             zotero_db_path = semantic_cfg.get("zotero_db_path")
@@ -802,7 +804,9 @@ class ZoteroSemanticSearch:
                 self._last_scan_snapshot_keys = reader.get_all_item_keys()
                 # Phase 1: fetch metadata only (fast)
                 sys.stderr.write("Scanning local Zotero database for items...\n")
-                local_items = reader.get_items_with_text(limit=limit, include_fulltext=False)
+                if collection_keys:
+                    sys.stderr.write(f"Filtering to collections: {collection_keys}\n")
+                local_items = reader.get_items_with_text(limit=limit, include_fulltext=False, collection_keys=collection_keys)
                 candidate_count = len(local_items)
                 sys.stderr.write(f"Found {candidate_count} candidate items.\n")
 
@@ -1566,6 +1570,31 @@ class ZoteroSemanticSearch:
             use_incremental = (
                 not force_full_rebuild and not extract_fulltext and limit is None and last_sync_version > 0
             )
+
+            # When a collection filter is configured, skip the API-based
+            # incremental path: it fetches changed items from the WHOLE
+            # library and its deletion pass compares against all library
+            # keys, both of which would bypass the filter. The local
+            # full-scan path applies collection_keys and skips
+            # already-indexed items, so filtered updates stay cheap.
+            configured_collection_keys = None
+            try:
+                if self.config_path and os.path.exists(self.config_path):
+                    with open(self.config_path) as _f:
+                        configured_collection_keys = (
+                            json.load(_f).get("semantic_search", {}).get("collection_keys")
+                        )
+            except Exception:
+                pass
+            if configured_collection_keys and use_incremental:
+                use_incremental = False
+                try:
+                    sys.stderr.write(
+                        f"Collection filter active ({configured_collection_keys}); "
+                        "using local full scan instead of API incremental update.\n"
+                    )
+                except Exception:
+                    pass
 
             target_sync_version: int | None = None
             all_items: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary

Adds an **opt-in collection filter** for the semantic search database. When `semantic_search.collection_keys` is set in `config.json`, the database is built from only those collections — resolved recursively, so subcollections count — instead of the whole library:

```json
"semantic_search": {
  "collection_keys": ["ABCD1234"]
}
```

Unset (the default), behaviour is completely unchanged.

## Motivation

Large personal libraries often mix one project's literature with teaching materials, feeds and unrelated topics. For focused semantic search (and to keep embedding costs down), you want the vector database to contain just one collection. I've been running this patch for months to keep a PhD-thesis collection (~535 items) searchable inside a much larger library.

## Implementation

- `LocalZoteroReader.get_items_with_text()` gains an optional `collection_keys` parameter that restricts the SQL query to items in the given collections or any of their subcollections (recursive resolution via `parentCollectionID`).
- `_get_items_from_source()` reads `collection_keys` from the config file and passes it to the scan (with a stderr note so runs are self-explaining).
- `update_database()` skips the API-based incremental path when the filter is active: that path fetches changed items from the whole library and its deletion pass compares stored ids against **all** library keys, both of which would bypass the filter. The local full-scan path applies the filter and skips already-indexed items, so filtered updates stay cheap.

## Test plan

- With `collection_keys` set: full rebuild indexes exactly the items in the collection + subcollections (535 of ~1,300 library items); items outside the collection never enter the database; subsequent `update-db --fulltext` runs report the unchanged items as up to date and only process new ones.
- Without `collection_keys`: scan returns the whole library and the incremental path is used exactly as before.

Related: #369 (bugfixes found while running this setup with chunking enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
