### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,16 @@ Example prompts:
 - **"Research that relates to the intersection of AI and healthcare"** *(semantic search)*
 - **"Papers that discuss topics similar to this abstract: [paste text]"** *(semantic search)*
 
+### For Autohand Code
+
+After installing Zotero MCP, add a local read-only server with:
+
+```bash
+autohand mcp add zotero env ZOTERO_LOCAL=true zotero-mcp
+```
+
+Add `--scope project` after `add` to keep the server configuration in the current project. For hybrid or web API access, add the credentials described above to the `env` command. See [Autohand Code](https://github.com/autohandai/code-cli/) for current installation and CLI details.
+
 ### For Cherry Studio
 
 #### Configuration


### PR DESCRIPTION
## What changed

Adds an Autohand Code setup example after the existing Claude client instructions. It uses Zotero MCP's installed `zotero-mcp` entry point with the documented `ZOTERO_LOCAL=true` read-only configuration.

The note points hybrid and web API users back to the existing credential guidance and includes the project-scoped option.

## Verification

- Checked the stdio command against the current Autohand Code MCP CLI
- Ran `git diff --check`

This is a documentation-only change.
