### PR TITLE
fix: auto-detect custom Zotero data directory from profile prefs.js (implements documented ZOTERO_DB_PATH)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,8 @@ ZOTERO_LIBRARY_TYPE=user
 
 # Google Gemini API Key (可选)
 # GEMINI_API_KEY=your_gemini_key_here
+
+# 自定义 zotero.sqlite 路径 (可选; 本地模式)
+# Custom zotero.sqlite path (optional; local mode). When unset, the database
+# is auto-detected from Zotero's configured data directory, then ~/Zotero.
+# ZOTERO_DB_PATH=/path/to/Zotero/zotero.sqlite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Local database auto-discovery now honors a custom Zotero data directory** — the `extensions.zotero.dataDir` preference is read from the Zotero profile's `prefs.js` (macOS/Windows/Linux), so relocated data directories no longer fail with "Zotero database not found at ~/Zotero/zotero.sqlite" (#68). The `ZOTERO_DB_PATH` environment variable, documented in the README but previously unimplemented, now works as an override, and the not-found error lists every location checked plus how to fix it. `extensions.zotero.baseAttachmentPath` is likewise read from the profile's `prefs.js`, fixing resolution of linked attachments relative to a base directory.
+
 ## [0.6.1] - 2026-07-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -366,7 +366,10 @@ zotero-mcp setup --no-local --api-key YOUR_API_KEY --library-id YOUR_LIBRARY_ID
 - `GEMINI_BASE_URL`: Custom Gemini endpoint URL (optional, for use with compatible APIs)
 - `OLLAMA_EMBEDDING_MODEL`: Ollama embedding model name (qwen3-embedding by default)
 - `OLLAMA_BASE_URL`: Ollama server URL (default: http://localhost:11434)
-- `ZOTERO_DB_PATH`: Custom `zotero.sqlite` path (optional)
+- `ZOTERO_DB_PATH`: Custom `zotero.sqlite` path (optional). When unset, the
+  database is located automatically: a data directory configured in Zotero's
+  preferences (read from the profile's `prefs.js`) is tried first, then the
+  default `~/Zotero` location.
 
 ### Command-Line Options
 

--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -5,9 +5,11 @@ Provides direct SQLite access to Zotero's local database for faster semantic sea
 when running in local mode.
 """
 
+import json
 import logging
 import os
 import platform
+import re
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
@@ -39,6 +41,67 @@ def _extract_pdf_worker(file_path: str, maxpages: int, result_queue):
     except Exception:
         result_queue.put("")
 
+
+
+def _read_string_pref(prefs_path: Path, pref: str) -> str | None:
+    """Read a string preference from a Zotero prefs.js file.
+
+    Returns None if the file cannot be read or the preference is absent.
+    """
+    try:
+        text = prefs_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    m = re.search(
+        r'user_pref\("' + re.escape(pref) + r'",\s*"([^"]*)"\)',
+        text,
+    )
+    if not m:
+        return None
+    raw = m.group(1)
+    # prefs.js values are JavaScript string literals; unescape backslash
+    # sequences so Windows paths like C:\\Users\\... resolve correctly.
+    try:
+        return json.loads(f'"{raw}"')
+    except ValueError:
+        return raw
+
+
+def _zotero_profiles_dirs() -> list[Path]:
+    """Return OS-specific directories that may contain Zotero profiles."""
+    system = platform.system()
+    home = Path.home()
+    if system == "Darwin":
+        return [home / "Library" / "Application Support" / "Zotero" / "Profiles"]
+    if system == "Windows":
+        appdata = os.getenv("APPDATA")
+        return [Path(appdata) / "Zotero" / "Zotero" / "Profiles"] if appdata else []
+    # Linux and others: profile folders live directly under ~/.zotero/zotero
+    return [home / ".zotero" / "zotero"]
+
+
+def _profile_prefs_files() -> list[Path]:
+    """Return prefs.js files from all Zotero profiles found on this system."""
+    prefs_files: list[Path] = []
+    for profiles_dir in _zotero_profiles_dirs():
+        if profiles_dir.is_dir():
+            prefs_files.extend(sorted(profiles_dir.glob("*/prefs.js")))
+    return prefs_files
+
+
+def _data_dirs_from_profiles() -> list[Path]:
+    """Collect custom data directories declared in Zotero profiles.
+
+    A user-configured data directory is stored as the
+    ``extensions.zotero.dataDir`` preference in the profile directory's
+    prefs.js — not inside the data directory itself.
+    """
+    data_dirs: list[Path] = []
+    for prefs_path in _profile_prefs_files():
+        data_dir = _read_string_pref(prefs_path, "extensions.zotero.dataDir")
+        if data_dir:
+            data_dirs.append(Path(data_dir))
+    return data_dirs
 
 
 @dataclass
@@ -121,7 +184,13 @@ class LocalZoteroReader:
 
     def _find_zotero_db(self) -> str:
         """
-        Auto-detect the Zotero database location based on OS.
+        Auto-detect the Zotero database location.
+
+        Resolution order:
+        1. The ``ZOTERO_DB_PATH`` environment variable.
+        2. A custom data directory configured in Zotero's preferences
+           (``extensions.zotero.dataDir`` in the profile's prefs.js).
+        3. The default data directory (``~/Zotero``).
 
         Returns:
             Path to zotero.sqlite file.
@@ -129,26 +198,47 @@ class LocalZoteroReader:
         Raises:
             FileNotFoundError: If database cannot be located.
         """
-        system = platform.system()
-
-        if system == "Darwin":  # macOS
-            db_path = Path.home() / "Zotero" / "zotero.sqlite"
-        elif system == "Windows":
-            # Try Windows 7+ location first
-            db_path = Path.home() / "Zotero" / "zotero.sqlite"
-            if not db_path.exists():
-                # Fallback to XP/2000 location
-                db_path = Path(os.path.expanduser("~/Documents and Settings")) / os.getenv("USERNAME", "") / "Zotero" / "zotero.sqlite"
-        else:  # Linux and others
-            db_path = Path.home() / "Zotero" / "zotero.sqlite"
-
-        if not db_path.exists():
+        env_path = os.getenv("ZOTERO_DB_PATH")
+        if env_path:
+            db_path = Path(env_path).expanduser()
+            if db_path.is_file():
+                return str(db_path)
             raise FileNotFoundError(
-                f"Zotero database not found at {db_path}. "
-                "Please ensure Zotero is installed and has been run at least once."
+                f"ZOTERO_DB_PATH is set to {db_path}, but no file exists there."
             )
 
-        return str(db_path)
+        # A data directory configured in Zotero's own preferences is
+        # authoritative; a leftover ~/Zotero from an old install is not.
+        candidates = [
+            data_dir / "zotero.sqlite" for data_dir in _data_dirs_from_profiles()
+        ]
+        candidates.append(Path.home() / "Zotero" / "zotero.sqlite")
+        if platform.system() == "Windows":
+            # Fallback to XP/2000 location
+            candidates.append(
+                Path(os.path.expanduser("~/Documents and Settings"))
+                / os.getenv("USERNAME", "")
+                / "Zotero"
+                / "zotero.sqlite"
+            )
+
+        seen: set[str] = set()
+        checked: list[Path] = []
+        for db_path in candidates:
+            if str(db_path) in seen:
+                continue
+            seen.add(str(db_path))
+            checked.append(db_path)
+            if db_path.is_file():
+                return str(db_path)
+
+        raise FileNotFoundError(
+            "Could not locate the Zotero database (checked: "
+            + ", ".join(str(c) for c in checked)
+            + "). If Zotero stores its data in a custom location, set the "
+            "ZOTERO_DB_PATH environment variable to your zotero.sqlite file "
+            "or configure the path by running `zotero-mcp setup`."
+        )
 
     def _get_connection(self) -> sqlite3.Connection:
         """Get database connection, creating if needed."""
@@ -172,22 +262,20 @@ class LocalZoteroReader:
         """Read the linked attachment base directory from Zotero's prefs.js.
 
         Returns the configured ``extensions.zotero.baseAttachmentPath`` or
-        ``None`` if the preference is not set or the file cannot be read.
+        ``None`` if the preference is not set or cannot be read. The
+        preference lives in the profile directory's prefs.js; a prefs.js
+        next to the database is also checked for unusual setups.
         """
-        prefs_path = Path(self.db_path).parent / "prefs.js"
-        if not prefs_path.exists():
-            return None
-        try:
-            import re
-            text = prefs_path.read_text(encoding="utf-8", errors="replace")
-            m = re.search(
-                r'user_pref\("extensions\.zotero\.baseAttachmentPath",\s*"([^"]+)"\)',
-                text,
+        prefs_files = [Path(self.db_path).parent / "prefs.js"]
+        prefs_files.extend(_profile_prefs_files())
+        for prefs_path in prefs_files:
+            if not prefs_path.exists():
+                continue
+            value = _read_string_pref(
+                prefs_path, "extensions.zotero.baseAttachmentPath"
             )
-            if m:
-                return Path(m.group(1))
-        except Exception:
-            pass
+            if value:
+                return Path(value)
         return None
 
     def _iter_parent_attachments(self, parent_item_id: int):

--- a/tests/test_local_db_discovery.py
+++ b/tests/test_local_db_discovery.py
@@ -1,0 +1,138 @@
+"""Tests for Zotero database auto-discovery in LocalZoteroReader."""
+
+from pathlib import Path
+
+import pytest
+from conftest import skip_on_ci
+
+import zotero_mcp.local_db as local_db
+from zotero_mcp.local_db import LocalZoteroReader, _read_string_pref
+
+
+def _make_profile(tmp_path: Path, prefs: dict[str, str]) -> Path:
+    """Create a fake Zotero profiles dir with one profile's prefs.js."""
+    profiles_dir = tmp_path / "Profiles"
+    profile = profiles_dir / "abcd1234.default"
+    profile.mkdir(parents=True)
+    lines = [f'user_pref("{k}", "{v}");' for k, v in prefs.items()]
+    (profile / "prefs.js").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return profiles_dir
+
+
+def _make_data_dir(tmp_path: Path, name: str) -> Path:
+    """Create a fake Zotero data dir containing a zotero.sqlite file."""
+    data_dir = tmp_path / name
+    data_dir.mkdir(parents=True)
+    (data_dir / "zotero.sqlite").write_bytes(b"")
+    return data_dir
+
+
+@pytest.fixture
+def isolated_discovery(monkeypatch, tmp_path):
+    """Point discovery at an empty home and no profiles; clear env override."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    monkeypatch.setattr(local_db, "_zotero_profiles_dirs", lambda: [])
+    monkeypatch.delenv("ZOTERO_DB_PATH", raising=False)
+    return fake_home
+
+
+@skip_on_ci
+def test_env_var_is_honored(monkeypatch, tmp_path, isolated_discovery):
+    data_dir = _make_data_dir(tmp_path, "custom")
+    monkeypatch.setenv("ZOTERO_DB_PATH", str(data_dir / "zotero.sqlite"))
+
+    reader = LocalZoteroReader()
+    assert reader.db_path == str(data_dir / "zotero.sqlite")
+
+
+@skip_on_ci
+def test_env_var_pointing_at_missing_file_raises(monkeypatch, tmp_path, isolated_discovery):
+    missing = tmp_path / "nowhere" / "zotero.sqlite"
+    monkeypatch.setenv("ZOTERO_DB_PATH", str(missing))
+
+    with pytest.raises(FileNotFoundError, match="ZOTERO_DB_PATH"):
+        LocalZoteroReader()
+
+
+@skip_on_ci
+def test_default_location_is_found(isolated_discovery):
+    default_dir = _make_data_dir(isolated_discovery, "Zotero")
+
+    reader = LocalZoteroReader()
+    assert reader.db_path == str(default_dir / "zotero.sqlite")
+
+
+@skip_on_ci
+def test_custom_data_dir_from_prefs_is_found(monkeypatch, tmp_path, isolated_discovery):
+    data_dir = _make_data_dir(tmp_path, "Documents/Zotero")
+    profiles_dir = _make_profile(
+        tmp_path, {"extensions.zotero.dataDir": str(data_dir)}
+    )
+    monkeypatch.setattr(local_db, "_zotero_profiles_dirs", lambda: [profiles_dir])
+
+    reader = LocalZoteroReader()
+    assert reader.db_path == str(data_dir / "zotero.sqlite")
+
+
+@skip_on_ci
+def test_prefs_data_dir_beats_default_location(monkeypatch, tmp_path, isolated_discovery):
+    stale_default = _make_data_dir(isolated_discovery, "Zotero")
+    configured = _make_data_dir(tmp_path, "configured")
+    profiles_dir = _make_profile(
+        tmp_path, {"extensions.zotero.dataDir": str(configured)}
+    )
+    monkeypatch.setattr(local_db, "_zotero_profiles_dirs", lambda: [profiles_dir])
+
+    reader = LocalZoteroReader()
+    assert reader.db_path == str(configured / "zotero.sqlite")
+    assert reader.db_path != str(stale_default / "zotero.sqlite")
+
+
+@skip_on_ci
+def test_error_lists_candidates_and_remedy(isolated_discovery):
+    with pytest.raises(FileNotFoundError) as excinfo:
+        LocalZoteroReader()
+
+    message = str(excinfo.value)
+    assert "ZOTERO_DB_PATH" in message
+    assert "zotero-mcp setup" in message
+    assert str(isolated_discovery / "Zotero" / "zotero.sqlite") in message
+
+
+@skip_on_ci
+def test_read_string_pref_unescapes_windows_paths(tmp_path):
+    prefs_path = tmp_path / "prefs.js"
+    prefs_path.write_text(
+        'user_pref("extensions.zotero.dataDir", "C:\\\\Users\\\\dan\\\\Zotero");\n',
+        encoding="utf-8",
+    )
+
+    value = _read_string_pref(prefs_path, "extensions.zotero.dataDir")
+    assert value == "C:\\Users\\dan\\Zotero"
+
+
+@skip_on_ci
+def test_read_string_pref_absent_returns_none(tmp_path):
+    prefs_path = tmp_path / "prefs.js"
+    prefs_path.write_text('user_pref("some.other.pref", "x");\n', encoding="utf-8")
+
+    assert _read_string_pref(prefs_path, "extensions.zotero.dataDir") is None
+    assert _read_string_pref(tmp_path / "missing.js", "any.pref") is None
+
+
+@skip_on_ci
+def test_base_attachment_path_from_profile_prefs(monkeypatch, tmp_path, isolated_discovery):
+    data_dir = _make_data_dir(tmp_path, "data")
+    profiles_dir = _make_profile(
+        tmp_path,
+        {
+            "extensions.zotero.dataDir": str(data_dir),
+            "extensions.zotero.baseAttachmentPath": str(tmp_path / "attachments"),
+        },
+    )
+    monkeypatch.setattr(local_db, "_zotero_profiles_dirs", lambda: [profiles_dir])
+
+    reader = LocalZoteroReader()
+    assert reader._get_base_attachment_path() == tmp_path / "attachments"


### PR DESCRIPTION
## Problem

`LocalZoteroReader._find_zotero_db()` claims to "auto-detect the Zotero database location based on OS", but on every OS it only checks the hardcoded default `~/Zotero/zotero.sqlite`. A relocated data directory — a first-class Zotero setting (`extensions.zotero.dataDir`, set via *Preferences → Advanced → Files and Folders*) — is never consulted, so every local-mode feature (`zotero_get_item_fulltext`, `zotero_get_attachment_path`, `read_pdf`, semantic-search indexing) fails for those users with:

```
Zotero database not found at /Users/<user>/Zotero/zotero.sqlite.
Please ensure Zotero is installed and has been run at least once.
```

The message is doubly misleading: Zotero *is* installed and running (the same server happily talks to it over the local API), and the message doesn't mention either remedy. #68 was this exact failure; it was resolved with the manual `--db-path` workaround rather than fixing detection.

Two related defects share the root cause:

1. **`ZOTERO_DB_PATH` is documented but not implemented.** The README lists it under environment variables ("Custom `zotero.sqlite` path"), but nothing in `src/` reads it — setting it silently does nothing.
2. **`_get_base_attachment_path()` reads `prefs.js` from the wrong directory.** It looks for `prefs.js` next to `zotero.sqlite` (the data directory), but Zotero keeps `prefs.js` in the *profile* directory. On standard installs the file is never found, so `extensions.zotero.baseAttachmentPath` is never read and `attachments:` linked files can't resolve.

## Fix

`_find_zotero_db()` now resolves in this order:

1. **`ZOTERO_DB_PATH` env var** — implements the documented interface; raises a targeted error if set but pointing at a missing file.
2. **Data directories declared in Zotero profile `prefs.js`** (`extensions.zotero.dataDir`), searched in the OS profile locations:
   - macOS: `~/Library/Application Support/Zotero/Profiles/*/prefs.js`
   - Windows: `%APPDATA%\Zotero\Zotero\Profiles\*\prefs.js`
   - Linux: `~/.zotero/zotero/*/prefs.js`
   A directory configured in Zotero's own preferences is authoritative, so it is checked before the default (a leftover `~/Zotero` from an old install shouldn't shadow the real library).
3. **The `~/Zotero` default**, plus the legacy XP path on Windows (unchanged behavior for the common case).

If nothing is found, the error now lists every path checked and both remedies (`ZOTERO_DB_PATH` or `zotero-mcp setup`).

`_get_base_attachment_path()` now also checks the profile `prefs.js` files (keeping the data-dir check first for unusual setups), via shared helpers. Preference values are unescaped as JS string literals so Windows paths (`C:\\Users\\...`) parse correctly — the previous regex would have returned the raw escaped string.

Existing precedence is untouched: an explicit `db_path` argument (from `--db-path` or `semantic_search.zotero_db_path` config) still wins over everything, since `_find_zotero_db()` only runs when no path was supplied.

## Testing

- `tests/test_local_db_discovery.py` (9 new tests): env-var override, env-var-points-at-nothing error, default location, prefs.js `dataDir` detection, prefs-beats-stale-default precedence, error-message content, Windows path unescaping, absent-pref handling, `baseAttachmentPath` from profile prefs.
- Full suite: **1074 passed** (no regressions).
- Verified on a real library with a relocated data directory (`~/Documents/Zotero`, macOS): auto-discovery finds the database with no env var and no config — previously an immediate `FileNotFoundError` — and reads 37k items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
