### PR TITLE
fix(semantic): chunked items are never recognized as indexed, so every fulltext update re-embeds the whole library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Chunking no longer forces a full re-extract and re-embed of the whole library on every update.** With `semantic_search.chunking` enabled (#350), items are indexed only under their chunk ids (`<key>#<n>`), but the "already indexed?" check in the local-fulltext path looked each item up by its bare key. That exact-id lookup never matched, so every item counted as new: each fulltext update re-extracted every PDF and re-embedded the entire library, silently and without an error. `get_document_metadata` now falls back to chunk 0, which carries the item-level `date_modified` and `has_fulltext` that the check needs, so unchanged items are skipped again.
+
 ## [0.6.1] - 2026-07-03
 
 ### Fixed

--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -795,16 +795,22 @@ class ChromaClient:
 
     def get_document_metadata(self, doc_id: str) -> dict[str, Any] | None:
         """
-        Get metadata for a document if it exists.
+        Get metadata for an item if it is indexed.
+
+        With passage chunking enabled, an item is stored only under its chunk
+        ids (``<key>#<n>``) and never under the bare item key, so an exact-id
+        lookup on the key alone misses every chunked item. Chunk 0 carries the
+        same item-level metadata (``date_modified``, ``has_fulltext``) that
+        callers need, so fall back to it.
 
         Args:
-            doc_id: Document ID to look up
+            doc_id: Item key (or full document id) to look up
 
         Returns:
-            Metadata dictionary if document exists, None otherwise
+            Metadata dictionary if the item is indexed, None otherwise
         """
         try:
-            result = self.collection.get(ids=[doc_id], include=["metadatas"])
+            result = self.collection.get(ids=[doc_id, f"{doc_id}#0"], include=["metadatas"])
             if result['ids'] and result['metadatas']:
                 return result['metadatas'][0]
             return None

--- a/tests/test_chunked_metadata_lookup.py
+++ b/tests/test_chunked_metadata_lookup.py
@@ -1,0 +1,67 @@
+"""Regression: item-level metadata lookup must find chunked records.
+
+With passage chunking enabled, items are indexed only under their chunk ids
+(``<key>#<n>``). ``get_document_metadata`` looked the item up by its bare key,
+which never matched, so the local-fulltext skip-check in ``_get_items_from_local_db``
+treated every already-indexed item as new and re-extracted plus re-embedded the
+entire library on every update.
+"""
+
+import sys
+
+import pytest
+
+if sys.version_info >= (3, 14):
+    pytest.skip(
+        "chromadb currently relies on pydantic v1 paths that are incompatible with Python 3.14+",
+        allow_module_level=True,
+    )
+
+from zotero_mcp.chroma_client import ChromaClient
+
+
+class FakeCollection:
+    """Stand-in for a Chroma collection with exact-id `get` semantics."""
+
+    def __init__(self, store):
+        self.store = store
+
+    def get(self, ids, include=None):
+        found = [i for i in ids if i in self.store]
+        return {"ids": found, "metadatas": [self.store[i] for i in found]}
+
+
+def _client(store):
+    client = object.__new__(ChromaClient)
+    client.collection = FakeCollection(store)
+    return client
+
+
+def test_finds_chunked_item_by_bare_key():
+    """A chunked item is found by its item key, via chunk 0."""
+    client = _client({
+        "ABCD1234#0": {"item_key": "ABCD1234", "date_modified": "2025-05-07T09:58:54Z"},
+        "ABCD1234#1": {"item_key": "ABCD1234", "date_modified": "2025-05-07T09:58:54Z"},
+    })
+
+    metadata = client.get_document_metadata("ABCD1234")
+
+    assert metadata is not None
+    assert metadata["date_modified"] == "2025-05-07T09:58:54Z"
+
+
+def test_finds_unchunked_item_by_bare_key():
+    """Item-level (unchunked) records keep working."""
+    client = _client({"ABCD1234": {"item_key": "ABCD1234", "date_modified": "2025-05-07T09:58:54Z"}})
+
+    metadata = client.get_document_metadata("ABCD1234")
+
+    assert metadata is not None
+    assert metadata["date_modified"] == "2025-05-07T09:58:54Z"
+
+
+def test_returns_none_for_unindexed_item():
+    """An item that is not indexed is still reported as absent."""
+    client = _client({"OTHER999#0": {"item_key": "OTHER999"}})
+
+    assert client.get_document_metadata("ABCD1234") is None


### PR DESCRIPTION
## Problem

With `semantic_search.chunking` enabled (#350), every fulltext update re-extracts all PDFs and re-embeds the entire library, even when nothing changed. There is no error, just a long CPU-heavy run every time.

Chunked items are indexed **only** under their chunk ids (`<key>#<n>`), never under the bare item key. In my own library, all 17,245 embeddings carry a chunk id and not one is a bare key:

```
sample ids: ['238MSPGL#0', '25DLIMLN#0', '25DLIMLN#1', '25DLIMLN#10', ...]
total: 17245 | chunk ids: 17245 | bare keys: 0
```

The "is this item already indexed?" check in `_get_items_from_local_db` (semantic_search.py:964) looks the item up by its bare key:

```python
existing_metadata = chroma_client.get_document_metadata(it.key)
```

and `get_document_metadata` does an exact-id `collection.get(ids=[doc_id])`. For a chunked item that never matches, so `existing_metadata` is `None`, every item counts as new, `skipped_existing` never increments, and the run re-extracts and re-embeds everything.

The since-based incremental sync from #260 does not save this path. It is gated on `not extract_fulltext` (semantic_search.py:1567):

```python
use_incremental = (
    not force_full_rebuild and not extract_fulltext and limit is None and last_sync_version > 0
)
```

and local-mode auto-update always passes `extract_fulltext=is_local_mode()` (tools/search.py:50). So for a local-mode user with chunking on, this per-item check is the only thing standing between them and a full rebuild, and chunking silently disabled it.

This is not a duplicate of #212: that was closed by #260, which fixed the web-API path. Chunking (48a2200, 2026-06-18) landed after #260 (2026-05-19) and reintroduced the same symptom for the local-fulltext path.

## Fix

Chunk 0 carries the item-level metadata the check reads (`date_modified`, `has_fulltext`, `item_key`), so `get_document_metadata` falls back to it when the bare key misses:

```python
result = self.collection.get(ids=[doc_id, f"{doc_id}#0"], include=["metadatas"])
```

Three lines, one call site (`semantic_search.py:964` is the only caller). Unchunked (item-level) records keep working unchanged, since the bare key is still tried.

Verified against my real ChromaDB:

```
before (bare key):     []                -> MISS, item counted as new
after  (with #0):      ['238MSPGL#0']
  date_modified = 2025-05-07T09:58:54Z
  has_fulltext  = failed
```

## Tests

`tests/test_chunked_metadata_lookup.py` covers the chunked lookup, the unchunked lookup, and the not-indexed case. The chunked test fails on `main` and passes with the fix:

```
# on main
FAILED tests/test_chunked_metadata_lookup.py::test_finds_chunked_item_by_bare_key
1 failed, 2 passed

# with fix
3 passed
```

Related existing suites still pass (`test_fulltext_local_mode`, `test_fulltext_web_mode`, `test_fulltext_sync_watermark`, `test_semantic_stats`): 38 passed.

## Note for affected users

Because the broken check made every run look like a full rebuild, the symptom for anyone on chunking plus local mode is a machine that spins up an embedding run on every sync. Worth a line in the release notes, since the config that triggers it (`chunking.enabled: true`) is the one #350 recommends for grounded retrieval.
