### PR TITLE
fix(annotations): map highlight rects to native PDF user space

### DIFF
--- a/src/zotero_mcp/pdf_utils.py
+++ b/src/zotero_mcp/pdf_utils.py
@@ -219,19 +219,42 @@ def _get_spans_in_range(
 # Coordinate Conversion
 # =============================================================================
 
+def _page_to_pdf_transform(page) -> tuple[float, float, float, float, float, float]:
+    """
+    Inverse of page.transformation_matrix as (a, b, c, d, e, f).
+
+    Maps PyMuPDF page space (top-left origin, normalized to the CropBox so
+    page.rect is (0, 0, w, h)) back to native PDF user space (MediaBox
+    lower-left origin), which is where Zotero positions annotations. Besides
+    flipping the y-axis, this restores any non-zero page box origin and
+    accounts for page rotation.
+    """
+    a, b, c, d, e, f = page.transformation_matrix
+    det = a * d - b * c
+    return (
+        d / det,
+        -b / det,
+        -c / det,
+        a / det,
+        (c * f - d * e) / det,
+        (b * e - a * f) / det,
+    )
+
+
 def _convert_rects_to_zotero(
     bboxes: list[tuple[float, float, float, float]],
-    page_height: float,
+    page,
 ) -> tuple[list[list[float]], float, float]:
     """
     Convert PyMuPDF bounding boxes to Zotero's coordinate system.
 
-    PyMuPDF uses top-left origin (y increases downward).
-    Zotero/PDF uses bottom-left origin (y increases upward).
+    PyMuPDF uses top-left origin (y increases downward) relative to the
+    CropBox. Zotero uses native PDF user space: bottom-left origin
+    (y increases upward) relative to the MediaBox.
 
     Args:
         bboxes: List of (x0, y0, x1, y1) tuples from PyMuPDF
-        page_height: Height of the page
+        page: The fitz page the bboxes belong to
 
     Returns:
         Tuple of:
@@ -239,19 +262,26 @@ def _convert_rects_to_zotero(
         - Minimum y position (for sort index)
         - Minimum x position (for sort index)
     """
+    a, b, c, d, e, f = _page_to_pdf_transform(page)
+
     rects = []
     min_y = float("inf")
     min_x = float("inf")
 
     for bbox in bboxes:
         x0, y0, x1, y1 = bbox
-        # Transform Y coordinates
-        pdf_y1 = page_height - y1  # Bottom in PDF coords
-        pdf_y2 = page_height - y0  # Top in PDF coords
+        corner_xs = (a * x0 + c * y0 + e, a * x1 + c * y1 + e)
+        corner_ys = (b * x0 + d * y0 + f, b * x1 + d * y1 + f)
 
-        rects.append([x0, pdf_y1, x1, pdf_y2])
-        min_y = min(min_y, pdf_y1)
-        min_x = min(min_x, x0)
+        rect = [
+            min(corner_xs),
+            min(corner_ys),
+            max(corner_xs),
+            max(corner_ys),
+        ]
+        rects.append(rect)
+        min_y = min(min_y, rect[1])
+        min_x = min(min_x, rect[0])
 
     return rects, min_y, min_x
 
@@ -277,7 +307,7 @@ def _build_search_result(
     page_index: int,
     bboxes: list,
     texts: list[str],
-    page_height: float,
+    page,
 ) -> dict:
     """
     Build a successful search result dict.
@@ -286,12 +316,12 @@ def _build_search_result(
         page_index: 0-indexed page number
         bboxes: List of bounding boxes
         texts: List of matched text strings
-        page_height: Page height for coordinate conversion
+        page: The fitz page for coordinate conversion
 
     Returns:
         Dict with pageIndex, rects, sort_index, matched_text
     """
-    rects, min_y, min_x = _convert_rects_to_zotero(bboxes, page_height)
+    rects, min_y, min_x = _convert_rects_to_zotero(bboxes, page)
     sort_index = _build_sort_index(page_index, min_y, min_x)
 
     return {
@@ -439,8 +469,6 @@ def _anchor_based_search(page, page_index: int, search_text: str) -> dict | None
     Returns:
         Search result dict if found, None otherwise
     """
-    page_height = page.rect.height
-
     # Extract anchors
     start_anchor = _extract_anchor(search_text, from_start=True)
     end_anchor = _extract_anchor(search_text, from_start=False)
@@ -494,7 +522,7 @@ def _anchor_based_search(page, page_index: int, search_text: str) -> dict | None
     if not bboxes:
         return None
 
-    return _build_search_result(page_index, bboxes, texts, page_height)
+    return _build_search_result(page_index, bboxes, texts, page)
 
 
 def _fuzzy_search_page(
@@ -590,8 +618,6 @@ def _search_single_page(
     Returns:
         Search result dict if found, None otherwise
     """
-    page_height = page.rect.height
-
     # Strategy 1: Anchor-based matching for long passages
     if len(search_text) > ANCHOR_MIN_TEXT_LENGTH:
         result = _anchor_based_search(page, page_index, search_text)
@@ -608,7 +634,7 @@ def _search_single_page(
 
     if text_instances:
         rects, min_y, min_x = _convert_rects_to_zotero(
-            [r for r in text_instances], page_height
+            [r for r in text_instances], page
         )
         return {
             "pageIndex": page_index,
@@ -632,7 +658,7 @@ def _search_single_page(
             # Return if we have valid rects
             if fuzzy_result.get("rects"):
                 bboxes = fuzzy_result["rects"]
-                rects, min_y, min_x = _convert_rects_to_zotero(bboxes, page_height)
+                rects, min_y, min_x = _convert_rects_to_zotero(bboxes, page)
 
                 return {
                     "pageIndex": page_index,
@@ -878,10 +904,7 @@ def build_area_position_data(
             round((x + width) * page.rect.width, 4),
             round((y + height) * page.rect.height, 4),
         )]
-        rects, min_y, min_x = _convert_rects_to_zotero(
-            bbox,
-            page.rect.height,
-        )
+        rects, min_y, min_x = _convert_rects_to_zotero(bbox, page)
 
         return {
             "pageIndex": target_index,

--- a/tests/test_area_annotations.py
+++ b/tests/test_area_annotations.py
@@ -13,8 +13,11 @@ from zotero_mcp import server
 class FakePage:
     """Minimal fitz page stub with geometry and optional label."""
 
-    def __init__(self, width=600, height=800, label="1"):
+    def __init__(self, width=600, height=800, label="1", transformation_matrix=None):
         self.rect = types.SimpleNamespace(width=width, height=height)
+        self.transformation_matrix = transformation_matrix or (
+            1.0, 0.0, 0.0, -1.0, 0.0, float(height),
+        )
         self._label = label
 
     def get_label(self):
@@ -94,6 +97,51 @@ def test_create_area_annotation_happy_path(monkeypatch, fake_zot):
         "pageIndex": 0,
         "rects": [[60.0, 320.0, 240.0, 640.0]],
     }
+
+
+def test_create_area_annotation_offset_mediabox(monkeypatch, fake_zot):
+    """Rects must land in native PDF user space, not CropBox-normalized space.
+
+    Page modeled after MediaBox [41.9, 46.5, 637.2, 840.2] with CropBox
+    [41.9, 0, 637.2, 793.7]: PyMuPDF reports rect (0, 0, 595.3, 793.7) and
+    transformation_matrix (1, 0, 0, -1, -41.9, 840.2).
+    """
+    fake_zot._items = [_pdf_attachment()]
+
+    monkeypatch.setattr("zotero_mcp.client.get_web_zotero_client", lambda: fake_zot)
+    monkeypatch.setattr("zotero_mcp.client.get_local_zotero_client", lambda: None)
+    monkeypatch.setattr("zotero_mcp.client.get_active_library", lambda: None)
+    _patch_fitz(
+        monkeypatch,
+        [FakePage(
+            width=595.3,
+            height=793.7,
+            transformation_matrix=(1.0, 0.0, 0.0, -1.0, -41.9, 840.2),
+        )],
+    )
+
+    result = server.create_area_annotation(
+        attachment_key="ATTACH01",
+        page=1,
+        x=0.1,
+        y=0.2,
+        width=0.3,
+        height=0.4,
+        ctx=DummyContext(),
+    )
+
+    assert "Successfully created area annotation" in result
+
+    created = fake_zot.created[0]
+    position = json.loads(created["annotationPosition"])
+    assert position["pageIndex"] == 0
+
+    # PyMuPDF-space bbox is (59.53, 158.74, 238.12, 476.22); mapping through
+    # the inverse transformation matrix adds the MediaBox origin: x + 41.9,
+    # y -> 840.2 - y.
+    (rect,) = position["rects"]
+    assert rect == pytest.approx([101.43, 363.98, 280.02, 681.46], abs=1e-4)
+    assert created["annotationSortIndex"] == "00000|000363|00101"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pdf_coordinates.py
+++ b/tests/test_pdf_coordinates.py
@@ -1,0 +1,117 @@
+"""Regression tests for annotation coordinate conversion (real PyMuPDF).
+
+Zotero stores annotation rects in the PDF's native user space (MediaBox
+lower-left origin), while PyMuPDF search results live in a CropBox-normalized
+space with a (0, 0) origin. These tests assert that find_text_position and
+build_area_position_data map coordinates back to user space via the inverse
+page transformation matrix, covering PDFs whose page box origin is not (0, 0).
+"""
+
+import os
+import tempfile
+
+import pytest
+
+from zotero_mcp.pdf_utils import build_area_position_data, find_text_position
+
+SENTENCE = "judgmental anchoring has durable effects lasting up to one week"
+
+# Page boxes from the reproduction case (Furnham & Boo 2011):
+# MediaBox [41.9, 46.5, 637.2, 840.2], CropBox [41.9, 0, 637.2, 793.7].
+OFFSET_MEDIABOX = (41.9, 46.5, 637.2, 840.2)
+
+
+def _make_pdf(tmpdir, mediabox=None, name="test.pdf"):
+    """Create a one-page PDF containing SENTENCE, return (path, reference_rects).
+
+    reference_rects are the search_for results mapped through the inverse
+    transformation matrix, i.e. the expected user-space rects.
+    """
+    import fitz
+
+    doc = fitz.open()
+    page = doc.new_page(width=612, height=792)
+    if mediabox is not None:
+        page.set_mediabox(fitz.Rect(*mediabox))
+    page.insert_text(fitz.Point(72, 100), SENTENCE, fontsize=11)
+
+    inv = ~page.transformation_matrix
+    reference_rects = [
+        [round(v, 4) for v in (r * inv)]
+        for r in page.search_for(SENTENCE)
+    ]
+    assert reference_rects, "test PDF must contain the search text"
+
+    path = os.path.join(tmpdir, name)
+    doc.save(path)
+    doc.close()
+    return path, reference_rects
+
+
+def _assert_rects_close(rects, reference_rects, tolerance=1.0):
+    assert len(rects) == len(reference_rects)
+    for rect, reference in zip(rects, reference_rects):
+        assert rect == pytest.approx(reference, abs=tolerance)
+
+
+@pytest.mark.parametrize("mediabox", [None, OFFSET_MEDIABOX])
+def test_find_text_position_returns_user_space_rects(mediabox):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path, reference_rects = _make_pdf(tmpdir, mediabox=mediabox)
+
+        result = find_text_position(path, 1, SENTENCE)
+
+        assert "error" not in result
+        assert result["pageIndex"] == 0
+        _assert_rects_close(result["rects"], reference_rects)
+
+
+def test_find_text_position_offset_mediabox_includes_origin():
+    """The stored rect must be translated by the MediaBox origin (41.9, 46.5)
+    relative to what the CropBox-normalized conversion would produce."""
+    import fitz
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path, _ = _make_pdf(tmpdir, mediabox=OFFSET_MEDIABOX)
+
+        doc = fitz.open(path)
+        page = doc[0]
+        pymupdf_rect = page.search_for(SENTENCE)[0]
+        crop_height = page.rect.height
+        doc.close()
+
+        result = find_text_position(path, 1, SENTENCE)
+        rect = result["rects"][0]
+
+        assert rect[0] == pytest.approx(pymupdf_rect.x0 + 41.9, abs=1.0)
+        assert rect[2] == pytest.approx(pymupdf_rect.x1 + 41.9, abs=1.0)
+        assert rect[1] == pytest.approx(
+            (crop_height - pymupdf_rect.y1) + 46.5, abs=1.0
+        )
+        assert rect[3] == pytest.approx(
+            (crop_height - pymupdf_rect.y0) + 46.5, abs=1.0
+        )
+
+        # Sort index is derived from the corrected coordinates.
+        page_part, y_part, x_part = result["sort_index"].split("|")
+        assert page_part == "00000"
+        assert int(y_part) == int(rect[1])
+        assert int(x_part) == int(rect[0])
+
+
+def test_build_area_position_offset_mediabox():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path, _ = _make_pdf(tmpdir, mediabox=OFFSET_MEDIABOX)
+
+        result = build_area_position_data(path, 1, 0.1, 0.2, 0.3, 0.4)
+
+        assert "error" not in result
+        (rect,) = result["rects"]
+
+        # Fractions are relative to the visible page (CropBox, 595.3 x 793.7);
+        # the stored rect adds the MediaBox origin: x + 41.9, y -> 840.2 - y.
+        crop_w, crop_h = 637.2 - 41.9, 793.7
+        assert rect[0] == pytest.approx(0.1 * crop_w + 41.9, abs=0.01)
+        assert rect[2] == pytest.approx(0.4 * crop_w + 41.9, abs=0.01)
+        assert rect[3] == pytest.approx(840.2 - 0.2 * crop_h, abs=0.01)
+        assert rect[1] == pytest.approx(840.2 - 0.6 * crop_h, abs=0.01)


### PR DESCRIPTION
`zotero_create_annotation` and `zotero_create_area_annotation` wrote highlight rectangles in PyMuPDF's CropBox-normalized coordinate space (where `page.rect` is always `(0, 0, w, h)`), but Zotero positions annotations in the PDF's **native user space**, whose origin is the MediaBox lower-left corner. For PDFs whose page box origin is not `(0, 0)` every created highlight was translated by exactly `(MediaBox.x0, MediaBox.y0)`: shifted into the margin horizontally and up/down the page vertically. The text search found the right text and the comment/tags/annotation key were correct; only the drawn rectangle (and the derived `annotationSortIndex`) was wrong.

PDFs with a default `(0, 0)` page box origin were unaffected, which made the bug easy to miss.