### PR TITLE
feat: zotero_attach_file — attach a local or URL file to an existing item

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ zotero_remove_item_relation(
 - `zotero_add_from_file`: Import a local PDF or EPUB file with automatic DOI extraction
 
 All add tools take a `collections` parameter accepting collection keys, names, or `parent/child` paths — resolved and validated before the item is created, so unknown or ambiguous specs fail with suggestions instead of producing an unfiled item. They also take `if_exists` (`"duplicate"` — default — always creates; `"file"` reuses an existing item matching the DOI/arXiv ID/ISBN/URL, filing it into missing collections and adding missing tags; `"skip"` leaves a match untouched) and `create_missing_collections` (create unknown collection specs, including path chains, instead of failing). The `zotero-cli add` commands default to `--if-exists file`.
+- `zotero_attach_file`: Attach a local file or a PDF URL to an existing item by key (no new item created; idempotent per filename)
 - `zotero_create_collection`: Create a new collection (folder/project) in your library
 - `zotero_search_collections`: Search for collections by name to find their keys
 - `zotero_manage_collections`: Add or remove items from collections (accepts keys, names, or `parent/child` paths)

--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ zotero_remove_item_relation(
 - `zotero_add_from_file`: Import a local PDF or EPUB file with automatic DOI extraction
 
 All add tools take a `collections` parameter accepting collection keys, names, or `parent/child` paths — resolved and validated before the item is created, so unknown or ambiguous specs fail with suggestions instead of producing an unfiled item. They also take `if_exists` (`"duplicate"` — default — always creates; `"file"` reuses an existing item matching the DOI/arXiv ID/ISBN/URL, filing it into missing collections and adding missing tags; `"skip"` leaves a match untouched) and `create_missing_collections` (create unknown collection specs, including path chains, instead of failing). The `zotero-cli add` commands default to `--if-exists file`.
-- `zotero_attach_file`: Attach a local file or a PDF URL to an existing item by key (no new item created; idempotent per filename)
+- `zotero_attach_file`: Attach a local file or a PDF URL to an existing item by key (no new item created; returns the attachment key; idempotent per filename and content hash)
 - `zotero_create_collection`: Create a new collection (folder/project) in your library
 - `zotero_search_collections`: Search for collections by name to find their keys
 - `zotero_manage_collections`: Add or remove items from collections (accepts keys, names, or `parent/child` paths)

--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -114,6 +114,7 @@ from zotero_mcp.tools.write import (  # noqa: F401
     merge_duplicates,
     get_pdf_outline,
     add_from_file,
+    attach_file,
     add_item_relation,
     remove_item_relation,
     add_by_bibtex,

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -865,6 +865,19 @@ def _maybe_upload_to_webdav(attach_result, file_path, ctx):
         )
 
 
+def _attachment_filename_exists(write_zot, parent_key, filename):
+    """True if ``parent_key`` already has a child attachment stored as ``filename``.
+
+    Non-fatal: errors while listing children count as "not present", so
+    attach flows degrade to re-uploading rather than failing outright.
+    """
+    try:
+        kids = write_zot.children(parent_key)
+    except Exception:
+        return False
+    return any((k.get("data", {}) or {}).get("filename") == filename for k in kids)
+
+
 def _attach_pdf_linked_url(write_zot, pdf_url, parent_key, ctx):
     """Create a linked-URL attachment (bookmarks the PDF URL without downloading)."""
     try:

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -1,5 +1,6 @@
 """Shared private helpers used across tool modules."""
 
+import hashlib
 import json
 import os
 import re
@@ -837,16 +838,7 @@ def _maybe_upload_to_webdav(attach_result, file_path, ctx):
     if not _webdav.is_webdav_configured():
         return ""
 
-    attachment_key = None
-    if isinstance(attach_result, dict):
-        for status in ("success", "unchanged"):
-            for entry in attach_result.get(status, []) or []:
-                if isinstance(entry, dict) and entry.get("key"):
-                    attachment_key = entry["key"]
-                    break
-            if attachment_key:
-                break
-
+    attachment_key = _extract_attachment_key(attach_result)
     if not attachment_key:
         return ""
 
@@ -865,17 +857,66 @@ def _maybe_upload_to_webdav(attach_result, file_path, ctx):
         )
 
 
-def _attachment_filename_exists(write_zot, parent_key, filename):
-    """True if ``parent_key`` already has a child attachment stored as ``filename``.
+def _extract_attachment_key(attach_result):
+    """First attachment key in a pyzotero upload result, or ``None``.
 
-    Non-fatal: errors while listing children count as "not present", so
-    attach flows degrade to re-uploading rather than failing outright.
+    ``Zupload.upload()`` returns ``{"success": [...], "failure": [...],
+    "unchanged": [...]}`` with the registered key on each payload entry.
+    """
+    if not isinstance(attach_result, dict):
+        return None
+    for status in ("success", "unchanged"):
+        for entry in attach_result.get(status, []) or []:
+            if isinstance(entry, dict) and entry.get("key"):
+                return entry["key"]
+    return None
+
+
+def _file_md5(path):
+    """MD5 hex digest of ``path``, or ``None`` if unreadable.
+
+    Non-fatal so content dedupe degrades to filename-only rather than
+    failing the attach.
     """
     try:
-        kids = write_zot.children(parent_key)
+        digest = hashlib.md5()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError:
+        return None
+
+
+def _find_child_attachment(write_zot, parent_key, filename=None, file_md5=None):
+    """First child of ``parent_key`` stored as ``filename`` or hashing to ``file_md5``.
+
+    Either criterion matching returns the child dict; ``None`` criteria are
+    skipped (a child without an ``md5`` field never matches ``file_md5=None``).
+    Paginates past the API's default page size and ignores trashed children
+    (``deleted`` flag), so a match beyond the first page isn't missed and a
+    trashed attachment doesn't count as "already attached".
+    Non-fatal: errors while listing children count as "no match", so attach
+    flows degrade to re-uploading rather than failing outright.
+    """
+    try:
+        kids = _paginate(write_zot.children, parent_key)
     except Exception:
-        return False
-    return any((k.get("data", {}) or {}).get("filename") == filename for k in kids)
+        return None
+    for kid in kids:
+        data = kid.get("data", {}) or {}
+        if data.get("deleted"):
+            continue
+        if filename is not None and data.get("filename") == filename:
+            return kid
+        if file_md5 is not None and data.get("md5") == file_md5:
+            return kid
+    return None
+
+
+def _attachment_filename_exists(write_zot, parent_key, filename):
+    """True if ``parent_key`` already has a child attachment stored as ``filename``."""
+    return _find_child_attachment(write_zot, parent_key, filename=filename) is not None
 
 
 def _attach_pdf_linked_url(write_zot, pdf_url, parent_key, ctx):

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -2786,8 +2786,53 @@ def attach_file(
 
 
 def _attach_from_url(write_zot, item_key, url, filename, ctx):
-    """Download ``url`` (PDF-only) and attach it to ``item_key``."""
-    return "Error: URL attachment not implemented yet."
+    """Download ``url`` (PDF-only) and attach it to ``item_key``.
+
+    The URL is user/LLM-supplied, so it goes through ``_guarded_pdf_get``
+    (SSRF guard + per-hop redirect re-validation) like the third-party
+    OA-PDF URLs elsewhere in the codebase.
+    """
+    if not url.lower().startswith(("http://", "https://")):
+        return "Error: url must be an http(s) URL."
+
+    ctx.info(f"Downloading PDF for {item_key}: {url}")
+    resp = _helpers._guarded_pdf_get(url, ctx)
+    if resp is None:
+        return (
+            "Error: URL rejected (unreachable, resolves to a private "
+            "network, or too many redirects)."
+        )
+    try:
+        resp.raise_for_status()
+    except Exception as e:
+        return f"Error: Download failed: {e}"
+
+    content_type = resp.headers.get("Content-Type", "")
+    if "pdf" not in content_type and "octet-stream" not in content_type:
+        return (
+            f"Error: URL did not return a PDF (Content-Type: "
+            f"{content_type}). For non-PDF formats, download the file "
+            "locally and use file_path."
+        )
+
+    if not filename:
+        seg = os.path.basename(unquote(urlparse(url).path))
+        filename = seg if seg.lower().endswith(".pdf") else f"{item_key}.pdf"
+    elif not filename.lower().endswith(".pdf"):
+        filename += ".pdf"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filepath = os.path.join(tmpdir, filename)
+        with open(filepath, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=8192):
+                f.write(chunk)
+        if os.path.getsize(filepath) < 1000:
+            return (
+                "Error: Downloaded file is under 1 KB — likely an error "
+                "page, not a real PDF."
+            )
+        # Must run inside the with-block — temp file disappears on exit.
+        return _upload_attachment(write_zot, item_key, filename, filepath, ctx)
 
 
 def _build_relation_uri(library_type: str, library_id: str, item_key: str) -> str:

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -2632,13 +2632,8 @@ def add_from_file(
         try:
             display_name = os.path.basename(file_path)
             if item_reused:
-                try:
-                    kids = write_zot.children(parent_key)
-                except Exception:
-                    kids = []
-                if any(
-                    (k.get("data", {}) or {}).get("filename") == display_name
-                    for k in kids
+                if _helpers._attachment_filename_exists(
+                    write_zot, parent_key, display_name
                 ):
                     return (
                         f"{result_msg}\n"

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -3,6 +3,7 @@
 import json
 import os
 import re
+import shutil
 import tempfile
 import time as _time
 import xml.etree.ElementTree as ET
@@ -2743,8 +2744,8 @@ def attach_file(
         # Validate the parent item before touching any file.
         try:
             item = write_zot.item(item_key)
-        except Exception:
-            return f"Error: Item '{item_key}' not found."
+        except Exception as e:
+            return f"Error: Item '{item_key}' not found ({e})."
         item_data = item.get("data", {}) or {}
         item_type = item_data.get("itemType")
         if item_type in ("attachment", "note", "annotation"):
@@ -2776,6 +2777,20 @@ def attach_file(
                 )
             display_name = filename or os.path.basename(file_path)
             ctx.info(f"Attaching local file to {item_key}: {display_name}")
+            if filename and filename != os.path.basename(file_path):
+                # pyzotero's attachment_both() derives the *stored* filename
+                # from the real file's basename, not the title tuple element
+                # — stage the file under the override name in a scratch dir
+                # so the override actually controls what gets stored (and so
+                # the dedupe check in _upload_attachment, which compares
+                # against stored filenames, converges on re-run).
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    staged_path = os.path.join(tmpdir, filename)
+                    shutil.copy2(file_path, staged_path)
+                    # Must run inside the with-block — temp file disappears on exit.
+                    return _upload_attachment(
+                        write_zot, item_key, display_name, staged_path, ctx
+                    )
             return _upload_attachment(write_zot, item_key, display_name, file_path, ctx)
 
         return _attach_from_url(write_zot, item_key, url, filename, ctx)

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -2675,21 +2675,54 @@ def _upload_attachment(write_zot, item_key, display_name, filepath, ctx):
     """Dedupe-checked upload of ``filepath`` onto ``item_key``.
 
     Returns the user-facing markdown message. Idempotent: if the item
-    already has a child attachment stored under ``display_name``, nothing
-    is uploaded.
+    already has a child attachment stored under ``display_name`` or with
+    identical content (MD5), nothing is uploaded.
     """
-    if _helpers._attachment_filename_exists(write_zot, item_key, display_name):
+    file_md5 = _helpers._file_md5(filepath)
+    existing = _helpers._find_child_attachment(
+        write_zot,
+        item_key,
+        filename=display_name,
+        file_md5=file_md5,
+    )
+    if existing is not None:
+        data = existing.get("data", {}) or {}
+        existing_key = existing.get("key") or data.get("key")
+        key_note = f" (key `{existing_key}`)" if existing_key else ""
+        existing_name = data.get("filename")
+        if existing_name == display_name:
+            msg = (
+                f"Attachment already present on `{item_key}`: {display_name}"
+                f"{key_note} — not re-uploaded."
+            )
+            if file_md5 and data.get("md5") and data["md5"] != file_md5:
+                msg += (
+                    " Note: the local file's content differs from the stored "
+                    "copy — delete the existing attachment first to replace it."
+                )
+            return msg
         return (
-            f"Attachment already present on `{item_key}`: {display_name} "
-            "(not re-uploaded)"
+            f"Identical file (same MD5) already attached to `{item_key}` as "
+            f"'{existing_name}'{key_note} — '{display_name}' not re-uploaded."
         )
     attach_result = write_zot.attachment_both(
         [(display_name, filepath)],
         parentid=item_key,
     )
+    attachment_key = _helpers._extract_attachment_key(attach_result)
+    if (
+        attachment_key is None
+        and isinstance(attach_result, dict)
+        and attach_result.get("failure")
+    ):
+        return (
+            f"Error: upload of '{display_name}' to `{item_key}` failed: "
+            f"{attach_result['failure']}"
+        )
+    key_note = f" (key `{attachment_key}`)" if attachment_key else ""
     suffix = _helpers._maybe_upload_to_webdav(attach_result, filepath, ctx)
     return (
-        f"File attached to `{item_key}`: {display_name}{suffix}\n\n"
+        f"File attached to `{item_key}`: {display_name}{key_note}{suffix}\n\n"
         "_Note: To include this item in semantic search, run "
         "zotero_update_search_database._"
     )
@@ -2712,9 +2745,10 @@ def _upload_attachment(write_zot, item_key, display_name, filepath, ctx):
         "file_path/url must be given. "
         "filename: optional stored-filename override; defaults to the "
         "file's basename or the URL's last path segment (falling back to "
-        "<item_key>.pdf). "
-        "Idempotent: if the item already has an attachment with the same "
-        "filename, nothing is re-uploaded. Requires a writable library "
+        "<item_key>.pdf); a missing extension is appended automatically. "
+        "Returns the created attachment's key. Idempotent: if the item "
+        "already has an attachment with the same filename or identical "
+        "content (MD5), nothing is re-uploaded. Requires a writable library "
         "(fails in local-only mode). Uploads count against the Zotero "
         "cloud storage quota unless WebDAV sync is configured. Run "
         "zotero_update_search_database afterwards to index the new file "
@@ -2775,6 +2809,11 @@ def attach_file(
                     f"Error: Unsupported file type '{ext}'. "
                     f"Allowed: {', '.join(sorted(_ATTACH_ALLOWED_EXTS))}"
                 )
+            if filename and not filename.lower().endswith(ext):
+                # Mirror the URL branch's .pdf enforcement: an override
+                # without the source's extension would strip it from the
+                # stored file (and break the MIME-type guess).
+                filename += ext
             display_name = filename or os.path.basename(file_path)
             ctx.info(f"Attaching local file to {item_key}: {display_name}")
             if filename and filename != os.path.basename(file_path):

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -7,6 +7,7 @@ import tempfile
 import time as _time
 import xml.etree.ElementTree as ET
 from typing import Annotated, Literal
+from urllib.parse import unquote, urlparse
 
 import requests
 from pydantic import Field
@@ -21,6 +22,9 @@ from zotero_mcp.tools import _helpers
 
 # Accessed as _helpers.X so that monkeypatch/mock on the module attribute works.
 CROSSREF_TYPE_MAP = _helpers.CROSSREF_TYPE_MAP
+
+# Shared by add_from_file and attach_file. URL attach mode is PDF-only.
+_ATTACH_ALLOWED_EXTS = {".pdf", ".epub", ".djvu", ".doc", ".docx", ".odt", ".rtf"}
 
 
 def _resolve_collections_arg(
@@ -2551,7 +2555,7 @@ def add_from_file(
             return f"Error: {e}"
 
         ext = os.path.splitext(file_path)[1].lower()
-        allowed_exts = {".pdf", ".epub", ".djvu", ".doc", ".docx", ".odt", ".rtf"}
+        allowed_exts = _ATTACH_ALLOWED_EXTS
         if ext not in allowed_exts:
             return f"Error: Unsupported file type '{ext}'. Allowed: {', '.join(sorted(allowed_exts))}"
 
@@ -2664,6 +2668,126 @@ def add_from_file(
     except Exception as e:
         ctx.error(f"Error adding from file: {e}")
         return f"Error adding from file: {e}"
+
+
+def _upload_attachment(write_zot, item_key, display_name, filepath, ctx):
+    """Dedupe-checked upload of ``filepath`` onto ``item_key``.
+
+    Returns the user-facing markdown message. Idempotent: if the item
+    already has a child attachment stored under ``display_name``, nothing
+    is uploaded.
+    """
+    if _helpers._attachment_filename_exists(write_zot, item_key, display_name):
+        return (
+            f"Attachment already present on `{item_key}`: {display_name} "
+            "(not re-uploaded)"
+        )
+    attach_result = write_zot.attachment_both(
+        [(display_name, filepath)],
+        parentid=item_key,
+    )
+    suffix = _helpers._maybe_upload_to_webdav(attach_result, filepath, ctx)
+    return (
+        f"File attached to `{item_key}`: {display_name}{suffix}\n\n"
+        "_Note: To include this item in semantic search, run "
+        "zotero_update_search_database._"
+    )
+
+
+@mcp.tool(
+    name="zotero_attach_file",
+    description=(
+        "Attach a file to an EXISTING Zotero item as an imported child "
+        "attachment (uploads the file bytes). Use when the item is already "
+        "in the library and you have its key — e.g. attaching a PDF you "
+        "found for a reference. To create a NEW item from a file, use "
+        "zotero_add_from_file instead. "
+        "item_key: key of the existing REGULAR item. Passing an "
+        "attachment/note key fails with a hint to use its parent. "
+        "file_path: ABSOLUTE local path (.pdf, .epub, .djvu, .doc, .docx, "
+        ".odt, .rtf). "
+        "url: direct http(s) link, downloaded server-side — PDF-only; for "
+        "other formats download locally and use file_path. Exactly one of "
+        "file_path/url must be given. "
+        "filename: optional stored-filename override; defaults to the "
+        "file's basename or the URL's last path segment (falling back to "
+        "<item_key>.pdf). "
+        "Idempotent: if the item already has an attachment with the same "
+        "filename, nothing is re-uploaded. Requires a writable library "
+        "(fails in local-only mode). Uploads count against the Zotero "
+        "cloud storage quota unless WebDAV sync is configured. Run "
+        "zotero_update_search_database afterwards to index the new file "
+        "for semantic search. "
+        "Example: zotero_attach_file(item_key='ABCD2345', "
+        "file_path='/Users/me/smith-2020.pdf')."
+    ),
+)
+@with_zotero_api_lock
+def attach_file(
+    item_key: str,
+    file_path: str | None = None,
+    url: str | None = None,
+    filename: str | None = None,
+    *,
+    ctx: Context,
+) -> str:
+    try:
+        _read_zot, write_zot = _helpers._get_write_client(ctx)
+    except ValueError as e:
+        return str(e)
+
+    try:
+        if bool(file_path) == bool(url):
+            return "Error: Provide exactly one of file_path or url."
+
+        # Validate the parent item before touching any file.
+        try:
+            item = write_zot.item(item_key)
+        except Exception:
+            return f"Error: Item '{item_key}' not found."
+        item_data = item.get("data", {}) or {}
+        item_type = item_data.get("itemType")
+        if item_type in ("attachment", "note", "annotation"):
+            parent = item_data.get("parentItem")
+            hint = f" Use its parent item key '{parent}' instead." if parent else ""
+            return (
+                f"Error: '{item_key}' has itemType '{item_type}', not a "
+                f"regular item — attachments must go on the parent item.{hint}"
+            )
+
+        if filename:
+            # Strip any path components from a caller-supplied name.
+            filename = os.path.basename(filename.strip())
+
+        if file_path:
+            # Path validation — check symlink BEFORE resolving
+            if os.path.islink(file_path):
+                return "Error: Symlinks are not allowed for security reasons."
+            if not os.path.isabs(file_path):
+                return "Error: file_path must be an absolute path."
+            file_path = os.path.realpath(file_path)
+            if not os.path.isfile(file_path):
+                return f"Error: File not found: {file_path}"
+            ext = os.path.splitext(file_path)[1].lower()
+            if ext not in _ATTACH_ALLOWED_EXTS:
+                return (
+                    f"Error: Unsupported file type '{ext}'. "
+                    f"Allowed: {', '.join(sorted(_ATTACH_ALLOWED_EXTS))}"
+                )
+            display_name = filename or os.path.basename(file_path)
+            ctx.info(f"Attaching local file to {item_key}: {display_name}")
+            return _upload_attachment(write_zot, item_key, display_name, file_path, ctx)
+
+        return _attach_from_url(write_zot, item_key, url, filename, ctx)
+
+    except Exception as e:
+        ctx.error(f"Error attaching file: {e}")
+        return f"Error attaching file: {e}"
+
+
+def _attach_from_url(write_zot, item_key, url, filename, ctx):
+    """Download ``url`` (PDF-only) and attach it to ``item_key``."""
+    return "Error: URL attachment not implemented yet."
 
 
 def _build_relation_uri(library_type: str, library_id: str, item_key: str) -> str:

--- a/tests/test_attach_file.py
+++ b/tests/test_attach_file.py
@@ -1,0 +1,46 @@
+"""Tests for zotero_attach_file (tools/write.attach_file) and its helpers."""
+
+import pytest
+from conftest import DummyContext, FakeZotero
+
+from zotero_mcp.tools import _helpers
+
+
+@pytest.fixture
+def dummy_ctx():
+    return DummyContext()
+
+
+# ---------------------------------------------------------------------------
+# _helpers._attachment_filename_exists
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentFilenameExists:
+    def test_true_when_child_has_same_filename(self):
+        zot = FakeZotero()
+        zot._children["ITEM1"] = [
+            {"data": {"itemType": "attachment", "filename": "paper.pdf"}}
+        ]
+        assert _helpers._attachment_filename_exists(zot, "ITEM1", "paper.pdf")
+
+    def test_false_when_no_children(self):
+        zot = FakeZotero()
+        assert not _helpers._attachment_filename_exists(zot, "ITEM1", "paper.pdf")
+
+    def test_false_when_different_filename(self):
+        zot = FakeZotero()
+        zot._children["ITEM1"] = [{"data": {"filename": "other.pdf"}}]
+        assert not _helpers._attachment_filename_exists(zot, "ITEM1", "paper.pdf")
+
+    def test_false_when_children_call_raises(self):
+        class Boom(FakeZotero):
+            def children(self, item_key, **kwargs):
+                raise RuntimeError("api down")
+
+        assert not _helpers._attachment_filename_exists(Boom(), "ITEM1", "paper.pdf")
+
+    def test_tolerates_none_data(self):
+        zot = FakeZotero()
+        zot._children["ITEM1"] = [{"data": None}]
+        assert not _helpers._attachment_filename_exists(zot, "ITEM1", "paper.pdf")

--- a/tests/test_attach_file.py
+++ b/tests/test_attach_file.py
@@ -44,3 +44,233 @@ class TestAttachmentFilenameExists:
         zot = FakeZotero()
         zot._children["ITEM1"] = [{"data": None}]
         assert not _helpers._attachment_filename_exists(zot, "ITEM1", "paper.pdf")
+
+
+from zotero_mcp import server
+
+
+class FakeZoteroForAttach(FakeZotero):
+    """FakeZotero extended with attachment_both recording."""
+
+    def __init__(self):
+        super().__init__()
+        self.attachments = []
+
+    def attachment_both(self, files, parentid=None, **kwargs):
+        self.attachments.append({"files": files, "parentid": parentid})
+        return {"success": {"0": "ATCH0001"}, "successful": {}, "failed": {}}
+
+
+def _patch_write_client(monkeypatch, fake_zot):
+    monkeypatch.setattr(
+        "zotero_mcp.tools._helpers._get_write_client",
+        lambda ctx: (fake_zot, fake_zot),
+    )
+
+
+def _patch_path_valid(monkeypatch):
+    monkeypatch.setattr("os.path.exists", lambda p: True)
+    monkeypatch.setattr("os.path.isfile", lambda p: True)
+    monkeypatch.setattr("os.path.islink", lambda p: False)
+    monkeypatch.setattr("os.path.isabs", lambda p: p.startswith("/"))
+
+
+# ---------------------------------------------------------------------------
+# attach_file: argument and item validation
+# ---------------------------------------------------------------------------
+
+
+class TestAttachFileValidation:
+    def test_requires_exactly_one_source_neither(self, monkeypatch, dummy_ctx):
+        _patch_write_client(monkeypatch, FakeZoteroForAttach())
+        result = server.attach_file(item_key="ITEM1", ctx=dummy_ctx)
+        assert "exactly one of file_path or url" in result
+
+    def test_requires_exactly_one_source_both(self, monkeypatch, dummy_ctx):
+        _patch_write_client(monkeypatch, FakeZoteroForAttach())
+        result = server.attach_file(
+            item_key="ITEM1",
+            file_path="/tmp/a.pdf",
+            url="https://example.org/a.pdf",
+            ctx=dummy_ctx,
+        )
+        assert "exactly one of file_path or url" in result
+
+    def test_local_only_mode_message(self, monkeypatch, dummy_ctx):
+        def raise_local(ctx):
+            raise ValueError(
+                "Cannot perform write operations in local-only mode. "
+                "Add ZOTERO_API_KEY and ZOTERO_LIBRARY_ID to enable hybrid mode."
+            )
+
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client", raise_local)
+        result = server.attach_file(
+            item_key="ITEM1", file_path="/tmp/a.pdf", ctx=dummy_ctx
+        )
+        assert "local-only mode" in result
+
+    def test_item_not_found(self, monkeypatch, dummy_ctx):
+        class NotFound(FakeZoteroForAttach):
+            def item(self, item_key, **kwargs):
+                raise RuntimeError("404")
+
+        _patch_write_client(monkeypatch, NotFound())
+        result = server.attach_file(
+            item_key="NOPE", file_path="/tmp/a.pdf", ctx=dummy_ctx
+        )
+        assert "Error" in result and "not found" in result
+
+    def test_rejects_attachment_key_with_parent_hint(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        fake._items = [
+            {
+                "key": "ATT1",
+                "data": {
+                    "itemType": "attachment",
+                    "parentItem": "PARENT99",
+                    "filename": "x.pdf",
+                },
+            }
+        ]
+        _patch_write_client(monkeypatch, fake)
+        result = server.attach_file(
+            item_key="ATT1", file_path="/tmp/a.pdf", ctx=dummy_ctx
+        )
+        assert "itemType 'attachment'" in result
+        assert "PARENT99" in result
+
+    def test_rejects_note_key(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        fake._items = [{"key": "NOTE1", "data": {"itemType": "note"}}]
+        _patch_write_client(monkeypatch, fake)
+        result = server.attach_file(
+            item_key="NOTE1", file_path="/tmp/a.pdf", ctx=dummy_ctx
+        )
+        assert "Error" in result
+
+
+# ---------------------------------------------------------------------------
+# attach_file: local-file branch
+# ---------------------------------------------------------------------------
+
+
+class TestAttachFileLocal:
+    def test_happy_path_attaches_to_item(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+
+        result = server.attach_file(
+            item_key="ITEM1",
+            file_path="/Users/test/smith-2020.pdf",
+            ctx=dummy_ctx,
+        )
+
+        assert len(fake.attachments) == 1
+        att = fake.attachments[0]
+        assert att["parentid"] == "ITEM1"
+        assert att["files"][0] == ("smith-2020.pdf", "/Users/test/smith-2020.pdf")
+        assert "File attached" in result
+        assert "zotero_update_search_database" in result
+
+    def test_filename_override(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+
+        server.attach_file(
+            item_key="ITEM1",
+            file_path="/Users/test/dl (3).pdf",
+            filename="smith-2020.pdf",
+            ctx=dummy_ctx,
+        )
+        assert fake.attachments[0]["files"][0][0] == "smith-2020.pdf"
+
+    def test_skips_when_same_filename_present(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        fake._children["ITEM1"] = [
+            {"data": {"itemType": "attachment", "filename": "smith-2020.pdf"}}
+        ]
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+
+        result = server.attach_file(
+            item_key="ITEM1",
+            file_path="/Users/test/smith-2020.pdf",
+            ctx=dummy_ctx,
+        )
+        assert len(fake.attachments) == 0
+        assert "already present" in result
+        assert "not re-uploaded" in result
+
+    def test_rejects_symlink(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+        monkeypatch.setattr("os.path.islink", lambda p: True)
+
+        result = server.attach_file(
+            item_key="ITEM1", file_path="/Users/test/a.pdf", ctx=dummy_ctx
+        )
+        assert "Symlinks are not allowed" in result
+
+    def test_rejects_relative_path(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+
+        result = server.attach_file(
+            item_key="ITEM1", file_path="relative/a.pdf", ctx=dummy_ctx
+        )
+        assert "absolute path" in result
+
+    def test_rejects_bad_extension(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+
+        result = server.attach_file(
+            item_key="ITEM1", file_path="/Users/test/a.exe", ctx=dummy_ctx
+        )
+        assert "Unsupported file type" in result
+
+    def test_missing_file(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+        monkeypatch.setattr("os.path.isfile", lambda p: False)
+
+        result = server.attach_file(
+            item_key="ITEM1", file_path="/Users/test/a.pdf", ctx=dummy_ctx
+        )
+        assert "File not found" in result
+
+    def test_webdav_suffix_passthrough(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._maybe_upload_to_webdav",
+            lambda attach_result, file_path, ctx: (
+                " (uploaded to WebDAV as ATCH0001.zip)"
+            ),
+        )
+
+        result = server.attach_file(
+            item_key="ITEM1", file_path="/Users/test/a.pdf", ctx=dummy_ctx
+        )
+        assert "uploaded to WebDAV as ATCH0001.zip" in result
+
+    def test_upload_failure_reported_not_raised(self, monkeypatch, dummy_ctx):
+        class BoomUpload(FakeZoteroForAttach):
+            def attachment_both(self, files, parentid=None, **kwargs):
+                raise RuntimeError("quota exceeded")
+
+        _patch_write_client(monkeypatch, BoomUpload())
+        _patch_path_valid(monkeypatch)
+
+        result = server.attach_file(
+            item_key="ITEM1", file_path="/Users/test/a.pdf", ctx=dummy_ctx
+        )
+        assert result.startswith("Error")
+        assert "quota exceeded" in result

--- a/tests/test_attach_file.py
+++ b/tests/test_attach_file.py
@@ -3,6 +3,7 @@
 import pytest
 from conftest import DummyContext, FakeZotero
 
+from zotero_mcp import server
 from zotero_mcp.tools import _helpers
 
 
@@ -46,9 +47,6 @@ class TestAttachmentFilenameExists:
         assert not _helpers._attachment_filename_exists(zot, "ITEM1", "paper.pdf")
 
 
-from zotero_mcp import server
-
-
 class FakeZoteroForAttach(FakeZotero):
     """FakeZotero extended with attachment_both recording."""
 
@@ -73,6 +71,11 @@ def _patch_path_valid(monkeypatch):
     monkeypatch.setattr("os.path.isfile", lambda p: True)
     monkeypatch.setattr("os.path.islink", lambda p: False)
     monkeypatch.setattr("os.path.isabs", lambda p: p.startswith("/"))
+    # The filename-override branch stages the file via shutil.copy2 into a
+    # real TemporaryDirectory; the fake source paths above don't exist on
+    # disk, so make the copy a no-op here. Target the patch at the module
+    # attribute since write.py calls it as `shutil.copy2`.
+    monkeypatch.setattr("shutil.copy2", lambda src, dst: None)
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +188,34 @@ class TestAttachFileLocal:
             ctx=dummy_ctx,
         )
         assert fake.attachments[0]["files"][0][0] == "smith-2020.pdf"
+
+    def test_filename_override_controls_stored_path(self, monkeypatch, dummy_ctx):
+        """pyzotero's attachment_both() stores the file under the real file's
+        basename, ignoring the title tuple element — so a filename override
+        must stage the file under the override name, not just relabel it."""
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+
+        copy_calls = []
+        monkeypatch.setattr(
+            "shutil.copy2",
+            lambda src, dst: copy_calls.append((src, dst)),
+        )
+
+        server.attach_file(
+            item_key="ITEM1",
+            file_path="/Users/test/dl (3).pdf",
+            filename="smith-2020.pdf",
+            ctx=dummy_ctx,
+        )
+
+        assert len(fake.attachments) == 1
+        stored_path = fake.attachments[0]["files"][0][1]
+        assert stored_path.endswith("smith-2020.pdf")
+        assert len(copy_calls) == 1
+        assert copy_calls[0][0] == "/Users/test/dl (3).pdf"
+        assert copy_calls[0][1].endswith("smith-2020.pdf")
 
     def test_skips_when_same_filename_present(self, monkeypatch, dummy_ctx):
         fake = FakeZoteroForAttach()

--- a/tests/test_attach_file.py
+++ b/tests/test_attach_file.py
@@ -274,3 +274,149 @@ class TestAttachFileLocal:
         )
         assert result.startswith("Error")
         assert "quota exceeded" in result
+
+
+# ---------------------------------------------------------------------------
+# attach_file: URL branch
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        content=b"%PDF-1.4 " + b"x" * 2000,
+        content_type="application/pdf",
+        status=200,
+    ):
+        self._content = content
+        self.headers = {"Content-Type": content_type}
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def iter_content(self, chunk_size=8192):
+        for i in range(0, len(self._content), chunk_size):
+            yield self._content[i : i + chunk_size]
+
+
+def _patch_guarded_get(monkeypatch, response):
+    monkeypatch.setattr(
+        "zotero_mcp.tools._helpers._guarded_pdf_get",
+        lambda pdf_url, ctx: response,
+    )
+
+
+class TestAttachFileUrl:
+    def test_happy_path_downloads_and_attaches(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_guarded_get(monkeypatch, FakeResponse())
+
+        result = server.attach_file(
+            item_key="ITEM1",
+            url="https://example.org/papers/smith-2020.pdf",
+            ctx=dummy_ctx,
+        )
+
+        assert len(fake.attachments) == 1
+        att = fake.attachments[0]
+        assert att["parentid"] == "ITEM1"
+        assert att["files"][0][0] == "smith-2020.pdf"
+        assert "File attached" in result
+
+    def test_filename_from_url_falls_back_to_item_key(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_guarded_get(monkeypatch, FakeResponse())
+
+        server.attach_file(
+            item_key="ITEM1",
+            url="https://example.org/download?id=42",
+            ctx=dummy_ctx,
+        )
+        assert fake.attachments[0]["files"][0][0] == "ITEM1.pdf"
+
+    def test_filename_override_gets_pdf_extension(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_guarded_get(monkeypatch, FakeResponse())
+
+        server.attach_file(
+            item_key="ITEM1",
+            url="https://example.org/download?id=42",
+            filename="smith-2020",
+            ctx=dummy_ctx,
+        )
+        assert fake.attachments[0]["files"][0][0] == "smith-2020.pdf"
+
+    def test_rejects_non_http_url(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+
+        result = server.attach_file(
+            item_key="ITEM1", url="file:///etc/passwd", ctx=dummy_ctx
+        )
+        assert "http(s)" in result
+        assert len(fake.attachments) == 0
+
+    def test_ssrf_rejection_surfaces_error(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_guarded_get(monkeypatch, None)
+
+        result = server.attach_file(
+            item_key="ITEM1", url="https://internal.local/a.pdf", ctx=dummy_ctx
+        )
+        assert result.startswith("Error")
+        assert len(fake.attachments) == 0
+
+    def test_non_pdf_content_type_rejected(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_guarded_get(monkeypatch, FakeResponse(content_type="text/html"))
+
+        result = server.attach_file(
+            item_key="ITEM1", url="https://example.org/a.pdf", ctx=dummy_ctx
+        )
+        assert "did not return a PDF" in result
+        assert len(fake.attachments) == 0
+
+    def test_tiny_download_rejected(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_guarded_get(monkeypatch, FakeResponse(content=b"tiny"))
+
+        result = server.attach_file(
+            item_key="ITEM1", url="https://example.org/a.pdf", ctx=dummy_ctx
+        )
+        assert "1 KB" in result or "too small" in result
+        assert len(fake.attachments) == 0
+
+    def test_http_error_surfaced(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_guarded_get(monkeypatch, FakeResponse(status=403))
+
+        result = server.attach_file(
+            item_key="ITEM1", url="https://example.org/a.pdf", ctx=dummy_ctx
+        )
+        assert result.startswith("Error")
+        assert len(fake.attachments) == 0
+
+    def test_dedupe_applies_to_url_branch(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        fake._children["ITEM1"] = [
+            {"data": {"itemType": "attachment", "filename": "smith-2020.pdf"}}
+        ]
+        _patch_write_client(monkeypatch, fake)
+        _patch_guarded_get(monkeypatch, FakeResponse())
+
+        result = server.attach_file(
+            item_key="ITEM1",
+            url="https://example.org/papers/smith-2020.pdf",
+            ctx=dummy_ctx,
+        )
+        assert len(fake.attachments) == 0
+        assert "already present" in result

--- a/tests/test_attach_file.py
+++ b/tests/test_attach_file.py
@@ -1,5 +1,7 @@
 """Tests for zotero_attach_file (tools/write.attach_file) and its helpers."""
 
+import hashlib
+
 import pytest
 from conftest import DummyContext, FakeZotero
 
@@ -47,6 +49,106 @@ class TestAttachmentFilenameExists:
         assert not _helpers._attachment_filename_exists(zot, "ITEM1", "paper.pdf")
 
 
+class TestExtractAttachmentKey:
+    def test_key_from_success_entry(self):
+        result = {"success": [{"key": "ATCH0001"}], "failure": [], "unchanged": []}
+        assert _helpers._extract_attachment_key(result) == "ATCH0001"
+
+    def test_key_from_unchanged_entry(self):
+        result = {"success": [], "failure": [], "unchanged": [{"key": "ATCH0002"}]}
+        assert _helpers._extract_attachment_key(result) == "ATCH0002"
+
+    def test_none_when_no_entries(self):
+        result = {"success": [], "failure": [], "unchanged": []}
+        assert _helpers._extract_attachment_key(result) is None
+
+    def test_none_on_non_dict(self):
+        assert _helpers._extract_attachment_key(None) is None
+
+
+class TestFindChildAttachment:
+    def test_matches_filename(self):
+        zot = FakeZotero()
+        child = {"key": "ATT1", "data": {"filename": "paper.pdf"}}
+        zot._children["ITEM1"] = [child]
+        assert (
+            _helpers._find_child_attachment(zot, "ITEM1", filename="paper.pdf")
+            is child
+        )
+
+    def test_matches_md5(self):
+        zot = FakeZotero()
+        child = {"key": "ATT1", "data": {"filename": "other.pdf", "md5": "abc123"}}
+        zot._children["ITEM1"] = [child]
+        assert (
+            _helpers._find_child_attachment(
+                zot, "ITEM1", filename="paper.pdf", file_md5="abc123"
+            )
+            is child
+        )
+
+    def test_no_match_returns_none(self):
+        zot = FakeZotero()
+        zot._children["ITEM1"] = [
+            {"key": "ATT1", "data": {"filename": "other.pdf", "md5": "abc123"}}
+        ]
+        assert (
+            _helpers._find_child_attachment(
+                zot, "ITEM1", filename="paper.pdf", file_md5="def456"
+            )
+            is None
+        )
+
+    def test_none_md5_does_not_match_child_without_md5(self):
+        zot = FakeZotero()
+        zot._children["ITEM1"] = [{"key": "ATT1", "data": {"filename": "other.pdf"}}]
+        assert (
+            _helpers._find_child_attachment(
+                zot, "ITEM1", filename="paper.pdf", file_md5=None
+            )
+            is None
+        )
+
+    def test_children_error_returns_none(self):
+        class Boom(FakeZotero):
+            def children(self, item_key, **kwargs):
+                raise RuntimeError("api down")
+
+        assert (
+            _helpers._find_child_attachment(Boom(), "ITEM1", filename="paper.pdf")
+            is None
+        )
+
+    def test_scans_past_first_api_page(self):
+        """The Zotero API caps unpaginated requests (default 25 children) —
+        the scan must page through, or a match past the first page is missed."""
+
+        class PagedFake(FakeZotero):
+            def children(self, item_key, start=0, limit=25, **kwargs):
+                kids = self._children.get(item_key, [])
+                return kids[start : start + limit]
+
+        zot = PagedFake()
+        match = {"key": "ATT_PG2", "data": {"filename": "paper.pdf"}}
+        fillers = [{"key": f"NOTE{i:04d}", "data": {"itemType": "note"}} for i in range(150)]
+        zot._children["ITEM1"] = fillers + [match]
+        assert (
+            _helpers._find_child_attachment(zot, "ITEM1", filename="paper.pdf")
+            is match
+        )
+
+    def test_skips_trashed_children(self):
+        """A child in Zotero's trash must not count as 'already attached'."""
+        zot = FakeZotero()
+        zot._children["ITEM1"] = [
+            {"key": "ATT1", "data": {"filename": "paper.pdf", "deleted": 1}}
+        ]
+        assert (
+            _helpers._find_child_attachment(zot, "ITEM1", filename="paper.pdf")
+            is None
+        )
+
+
 class FakeZoteroForAttach(FakeZotero):
     """FakeZotero extended with attachment_both recording."""
 
@@ -56,7 +158,13 @@ class FakeZoteroForAttach(FakeZotero):
 
     def attachment_both(self, files, parentid=None, **kwargs):
         self.attachments.append({"files": files, "parentid": parentid})
-        return {"success": {"0": "ATCH0001"}, "successful": {}, "failed": {}}
+        # Shape matches pyzotero Zupload.upload(): status → list of payload
+        # dicts, each carrying the registered attachment key.
+        return {
+            "success": [{"key": "ATCH0001", "title": files[0][0]}],
+            "failure": [],
+            "unchanged": [],
+        }
 
 
 def _patch_write_client(monkeypatch, fake_zot):
@@ -67,7 +175,6 @@ def _patch_write_client(monkeypatch, fake_zot):
 
 
 def _patch_path_valid(monkeypatch):
-    monkeypatch.setattr("os.path.exists", lambda p: True)
     monkeypatch.setattr("os.path.isfile", lambda p: True)
     monkeypatch.setattr("os.path.islink", lambda p: False)
     monkeypatch.setattr("os.path.isabs", lambda p: p.startswith("/"))
@@ -234,6 +341,37 @@ class TestAttachFileLocal:
         assert "already present" in result
         assert "not re-uploaded" in result
 
+    def test_result_includes_attachment_key(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+
+        result = server.attach_file(
+            item_key="ITEM1",
+            file_path="/Users/test/smith-2020.pdf",
+            ctx=dummy_ctx,
+        )
+        assert "ATCH0001" in result
+
+    def test_already_present_reports_existing_key(self, monkeypatch, dummy_ctx):
+        fake = FakeZoteroForAttach()
+        fake._children["ITEM1"] = [
+            {
+                "key": "OLDATT01",
+                "data": {"itemType": "attachment", "filename": "smith-2020.pdf"},
+            }
+        ]
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+
+        result = server.attach_file(
+            item_key="ITEM1",
+            file_path="/Users/test/smith-2020.pdf",
+            ctx=dummy_ctx,
+        )
+        assert len(fake.attachments) == 0
+        assert "OLDATT01" in result
+
     def test_rejects_symlink(self, monkeypatch, dummy_ctx):
         fake = FakeZoteroForAttach()
         _patch_write_client(monkeypatch, fake)
@@ -305,6 +443,201 @@ class TestAttachFileLocal:
         )
         assert result.startswith("Error")
         assert "quota exceeded" in result
+
+    def test_upload_failure_entries_not_reported_as_success(
+        self, monkeypatch, dummy_ctx
+    ):
+        """Zupload can put the file on the failure list without raising —
+        that must not read as 'File attached'."""
+
+        class FailUpload(FakeZoteroForAttach):
+            def attachment_both(self, files, parentid=None, **kwargs):
+                return {
+                    "success": [],
+                    "failure": [{"title": files[0][0], "code": 400}],
+                    "unchanged": [],
+                }
+
+        _patch_write_client(monkeypatch, FailUpload())
+        _patch_path_valid(monkeypatch)
+
+        result = server.attach_file(
+            item_key="ITEM1", file_path="/Users/test/a.pdf", ctx=dummy_ctx
+        )
+        assert result.startswith("Error")
+        assert "File attached" not in result
+
+    def test_trashed_same_name_child_does_not_block_upload(
+        self, monkeypatch, dummy_ctx
+    ):
+        fake = FakeZoteroForAttach()
+        fake._children["ITEM1"] = [
+            {
+                "key": "OLDATT01",
+                "data": {
+                    "itemType": "attachment",
+                    "filename": "smith-2020.pdf",
+                    "deleted": 1,
+                },
+            }
+        ]
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+
+        result = server.attach_file(
+            item_key="ITEM1",
+            file_path="/Users/test/smith-2020.pdf",
+            ctx=dummy_ctx,
+        )
+        assert len(fake.attachments) == 1
+        assert "File attached" in result
+
+    def test_filename_override_inherits_source_extension(
+        self, monkeypatch, dummy_ctx
+    ):
+        """A local-mode override without an extension must inherit the source
+        file's, mirroring the URL branch's .pdf enforcement — otherwise the
+        stored file loses its extension (and MIME-type guess)."""
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+
+        server.attach_file(
+            item_key="ITEM1",
+            file_path="/Users/test/dl (3).pdf",
+            filename="smith-2020",
+            ctx=dummy_ctx,
+        )
+        assert fake.attachments[0]["files"][0][0] == "smith-2020.pdf"
+
+
+# ---------------------------------------------------------------------------
+# attach_file: content-hash (MD5) dedupe — uses real files on disk
+# ---------------------------------------------------------------------------
+
+
+class TestAttachFileMd5Dedupe:
+    def test_same_content_different_filename_skipped(
+        self, tmp_path, monkeypatch, dummy_ctx
+    ):
+        content = b"%PDF-1.4 same-bytes"
+        pdf = tmp_path / "new-name.pdf"
+        pdf.write_bytes(content)
+
+        fake = FakeZoteroForAttach()
+        fake._children["ITEM1"] = [
+            {
+                "key": "OLDATT01",
+                "data": {
+                    "itemType": "attachment",
+                    "filename": "old-name.pdf",
+                    "md5": hashlib.md5(content).hexdigest(),
+                },
+            }
+        ]
+        _patch_write_client(monkeypatch, fake)
+
+        result = server.attach_file(
+            item_key="ITEM1", file_path=str(pdf), ctx=dummy_ctx
+        )
+        assert len(fake.attachments) == 0
+        assert "old-name.pdf" in result
+        assert "OLDATT01" in result
+        assert "not re-uploaded" in result
+
+    def test_different_content_still_uploads(self, tmp_path, monkeypatch, dummy_ctx):
+        pdf = tmp_path / "new-name.pdf"
+        pdf.write_bytes(b"%PDF-1.4 new-bytes")
+
+        fake = FakeZoteroForAttach()
+        fake._children["ITEM1"] = [
+            {
+                "key": "OLDATT01",
+                "data": {
+                    "itemType": "attachment",
+                    "filename": "old-name.pdf",
+                    "md5": hashlib.md5(b"%PDF-1.4 other-bytes").hexdigest(),
+                },
+            }
+        ]
+        _patch_write_client(monkeypatch, fake)
+
+        result = server.attach_file(
+            item_key="ITEM1", file_path=str(pdf), ctx=dummy_ctx
+        )
+        assert len(fake.attachments) == 1
+        assert "File attached" in result
+
+    def test_same_name_different_content_notes_mismatch(
+        self, tmp_path, monkeypatch, dummy_ctx
+    ):
+        """A filename match with different bytes is a replace attempt — the
+        skip message must say the stored content differs, not look like a
+        no-op re-run."""
+        pdf = tmp_path / "smith-2020.pdf"
+        pdf.write_bytes(b"%PDF-1.4 corrected-bytes")
+
+        fake = FakeZoteroForAttach()
+        fake._children["ITEM1"] = [
+            {
+                "key": "OLDATT01",
+                "data": {
+                    "itemType": "attachment",
+                    "filename": "smith-2020.pdf",
+                    "md5": hashlib.md5(b"%PDF-1.4 old-bytes").hexdigest(),
+                },
+            }
+        ]
+        _patch_write_client(monkeypatch, fake)
+
+        result = server.attach_file(
+            item_key="ITEM1", file_path=str(pdf), ctx=dummy_ctx
+        )
+        assert len(fake.attachments) == 0
+        assert "content differs" in result
+        assert "delete the existing attachment" in result
+
+    def test_child_without_md5_still_uploads(self, tmp_path, monkeypatch, dummy_ctx):
+        pdf = tmp_path / "new-name.pdf"
+        pdf.write_bytes(b"%PDF-1.4 new-bytes")
+
+        fake = FakeZoteroForAttach()
+        fake._children["ITEM1"] = [
+            {"key": "OLDATT01", "data": {"itemType": "attachment", "filename": "old-name.pdf"}}
+        ]
+        _patch_write_client(monkeypatch, fake)
+
+        result = server.attach_file(
+            item_key="ITEM1", file_path=str(pdf), ctx=dummy_ctx
+        )
+        assert len(fake.attachments) == 1
+        assert "File attached" in result
+
+    def test_md5_dedupe_applies_to_url_branch(self, monkeypatch, dummy_ctx):
+        content = b"%PDF-1.4 " + b"x" * 2000  # FakeResponse default payload
+
+        fake = FakeZoteroForAttach()
+        fake._children["ITEM1"] = [
+            {
+                "key": "OLDATT01",
+                "data": {
+                    "itemType": "attachment",
+                    "filename": "old-name.pdf",
+                    "md5": hashlib.md5(content).hexdigest(),
+                },
+            }
+        ]
+        _patch_write_client(monkeypatch, fake)
+        _patch_guarded_get(monkeypatch, FakeResponse(content=content))
+
+        result = server.attach_file(
+            item_key="ITEM1",
+            url="https://example.org/papers/smith-2020.pdf",
+            ctx=dummy_ctx,
+        )
+        assert len(fake.attachments) == 0
+        assert "old-name.pdf" in result
+        assert "not re-uploaded" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_description_tokens.py
+++ b/tests/test_description_tokens.py
@@ -41,6 +41,7 @@ TOOL_BUDGETS = {
     # tools/write.py
     "zotero_batch_update_tags":        (155, 350),
     "zotero_batch_update_extra":       (165, 370),
+    "zotero_attach_file":              (190, 430),
     # tools/search.py
     "zotero_search_items":             (175, 400),
     "zotero_search_by_tag":            (115, 265),


### PR DESCRIPTION
## feat: zotero_attach_file — attach a local or URL file to an existing item

### Gap
No tool attaches a file to a caller-chosen existing item. `zotero_add_from_file`
always creates a new item (or reuses one only via DOI-match with
`if_exists='file'`). The gap has caused problems before (#335): the CLI's
`add file` was written assuming `add_from_file` took a `parent_key` parameter,
but no attach-to-an-existing-item capability existed anywhere — the phantom
flag crashed every invocation until it was removed.

### What this adds
`zotero_attach_file(item_key, file_path=None, url=None, filename=None)`:
- local absolute path (same validation + allowed-extension set as
  `zotero_add_from_file`) or direct PDF URL (downloaded through the existing
  SSRF-guarded `_guarded_pdf_get`; PDF-only)
- validates the target key and hints at the parent when given an
  attachment/note key
- returns the created attachment's key in the message, so follow-ups
  (annotate, verify, dedupe) don't need a `get_item_children` round-trip; a
  failure entry in the upload result is reported as an error rather than
  claiming success
- idempotent on filename **and** content: skips the upload when the item
  already has a child with the same stored filename or the same MD5 (an
  identical file under a different name), reporting the existing
  attachment's name and key. The children-scan paginates past the API's
  default page size and ignores trashed children; when a same-named stored
  copy has *different* content, the skip message says so (delete first to
  replace). The scan lives in a shared `_find_child_attachment` helper that
  also backs `add_from_file`'s existing filename-only dedupe (left
  filename-only there to keep this PR additive to existing behavior);
  hashing is non-fatal, degrading to filename-only if the file can't be read
- `filename` override genuinely controls the stored filename (file is staged
  under the override name before upload, so the idempotence check converges);
  an override missing an extension inherits the source file's, mirroring the
  URL branch's `.pdf` enforcement
- uploads via `attachment_both` + `_maybe_upload_to_webdav` — the same idiom
  as `add_from_file` on main

### Notes
- Interaction with #361 (WebDAV-first attach): no dependency, but this PR adds
  one new attach call site in `tools/write.py` and both PRs touch
  `tools/_helpers.py`, so whichever lands second needs a trivial rebase. If
  #361 lands first, `zotero_attach_file` should call `_webdav_first_attach`
  before falling through to `attachment_both` — a mechanical one-hunk change
  I'm happy to make.
- Known shared limitation kept for parity with `_download_and_attach_pdf`: the
  Content-Type check is case-sensitive, downloads aren't size-capped, and the
  streamed response isn't explicitly closed on early exits — happy to fix all
  three (they'd touch the shared helper) in this PR or a follow-up if
  preferred.
- README entry + description-token budget included; 51 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
