### PR TITLE
fix: paginate children() calls that silently saw only the first 25 results

### DIFF
--- a/src/zotero_mcp/client.py
+++ b/src/zotero_mcp/client.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 from markitdown import MarkItDown
 from pyzotero import zotero
 
-from zotero_mcp.utils import format_creators
+from zotero_mcp.utils import _paginate, format_creators
 from zotero_mcp.webdav import (
     WebDAVNotConfiguredError,
     download_attachment_from_webdav,
@@ -492,7 +492,7 @@ def get_attachment_details(
 
     # For regular items, look for child attachments
     try:
-        children = zot.children(item_key)
+        children = _paginate(zot.children, item_key)
 
         # Group attachments by content type
         pdfs = []

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -30,7 +30,7 @@ from . import openai_batch
 from .chroma_client import ChromaClient, create_chroma_client
 from .client import get_zotero_client
 from .local_db import LocalZoteroReader
-from .utils import format_creators, is_local_mode, suppress_stdout
+from .utils import _paginate, format_creators, is_local_mode, suppress_stdout
 
 logger = logging.getLogger(__name__)
 
@@ -1200,7 +1200,7 @@ class ZoteroSemanticSearch:
 
         # 2. Walk PDF attachment children and try each in order.
         try:
-            children = self.zotero_client.children(item_key) or []
+            children = _paginate(self.zotero_client.children, item_key) or []
         except Exception as e:
             logger.debug(f"children({item_key}) failed: {e}")
             children = []

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -13,6 +13,7 @@ import requests
 
 from zotero_mcp import client as _client
 from zotero_mcp import utils as _utils
+from zotero_mcp.utils import _paginate
 
 # ---------------------------------------------------------------------------
 # Config file
@@ -34,34 +35,6 @@ def _load_zotero_mcp_config() -> dict:
             return json.load(f) or {}
     except (json.JSONDecodeError, OSError):
         return {}
-
-
-# ---------------------------------------------------------------------------
-# Pagination helper
-# ---------------------------------------------------------------------------
-
-def _paginate(zot_method, *args, max_items=None, **kwargs):
-    """Fetch all results from a pyzotero method using manual pagination.
-
-    Avoids zot.everything() which can cause RLock pickling in MCP contexts.
-    Accepts the same positional and keyword arguments as the wrapped method,
-    plus an optional max_items to cap the total results.
-    """
-    items = []
-    start = 0
-    page_size = 100
-    while True:
-        batch = zot_method(*args, start=start, limit=page_size, **kwargs)
-        if not batch:
-            break
-        items.extend(batch)
-        if len(batch) < page_size:
-            break
-        start += page_size
-        if max_items and len(items) >= max_items:
-            items = items[:max_items]
-            break
-    return items
 
 
 # ---------------------------------------------------------------------------

--- a/src/zotero_mcp/tools/annotations.py
+++ b/src/zotero_mcp/tools/annotations.py
@@ -295,7 +295,7 @@ def get_annotations(
                     # Ensure PDF annotation tool is installed
                     if ensure_pdfannots_installed():
                         # Get PDF attachments via the resolved parent key
-                        children = zot.children(parent_item_key)
+                        children = _helpers._paginate(zot.children, parent_item_key)
                         pdf_attachments = [
                             item for item in children
                             if item.get("data", {}).get("contentType") == "application/pdf"

--- a/src/zotero_mcp/tools/discovery.py
+++ b/src/zotero_mcp/tools/discovery.py
@@ -254,7 +254,7 @@ def _item_has_pdf(zot, item: dict) -> bool:
     if not key:
         return False
     try:
-        children = zot.children(key)
+        children = _helpers._paginate(zot.children, key)
     except Exception:
         return False
     for child in children or []:

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -654,7 +654,7 @@ def get_item_children(
             parent_title = f"Item {item_key}"
 
         # Then get the children
-        children = zot.children(item_key)
+        children = _helpers._paginate(zot.children, item_key)
         if not children:
             return f"No child items found for: {parent_title} (Key: {item_key})"
 
@@ -797,7 +797,7 @@ def get_items_children(
             output.append(f"## {title} (`{key}`)")
 
             try:
-                children = zot.children(key)
+                children = _helpers._paginate(zot.children, key)
             except Exception as e:
                 output.append(f"  Error fetching children: {e}")
                 output.append("")

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -2229,13 +2229,14 @@ def merge_duplicates(
         if not dup_keys:
             return "Error: No duplicate keys to merge (after removing keeper if present)."
 
-        # Fetch all items and children
+        # Fetch all items and children (children() returns only the first
+        # API page without explicit pagination — see _paginate)
         keeper = write_zot.item(keeper_key)
-        keeper_children = write_zot.children(keeper_key)
+        keeper_children = _helpers._paginate(write_zot.children, keeper_key)
         duplicates = []
         for dk in dup_keys:
             dup_item = write_zot.item(dk)
-            dup_children = write_zot.children(dk)
+            dup_children = _helpers._paginate(write_zot.children, dk)
             duplicates.append({"item": dup_item, "children": dup_children})
 
         # Compute what will be merged
@@ -2437,7 +2438,7 @@ def get_pdf_outline(
         ctx.info(f"Getting PDF outline for item {item_key}")
 
         # Find PDF attachment
-        children = zot.children(item_key)
+        children = _helpers._paginate(zot.children, item_key)
         pdf_child = None
         for child in children:
             if child.get("data", {}).get("contentType") == "application/pdf":

--- a/src/zotero_mcp/utils.py
+++ b/src/zotero_mcp/utils.py
@@ -51,6 +51,35 @@ def is_local_mode() -> bool:
     value = os.getenv("ZOTERO_LOCAL", "")
     return value.lower() in {"true", "yes", "1"}
 
+
+# ---------------------------------------------------------------------------
+# Pagination helper
+# ---------------------------------------------------------------------------
+
+def _paginate(zot_method, *args, max_items=None, **kwargs):
+    """Fetch all results from a pyzotero method using manual pagination.
+
+    Avoids zot.everything() which can cause RLock pickling in MCP contexts.
+    Accepts the same positional and keyword arguments as the wrapped method,
+    plus an optional max_items to cap the total results.
+    """
+    items = []
+    start = 0
+    page_size = 100
+    while True:
+        batch = zot_method(*args, start=start, limit=page_size, **kwargs)
+        if not batch:
+            break
+        items.extend(batch)
+        if len(batch) < page_size:
+            break
+        start += page_size
+        if max_items and len(items) >= max_items:
+            items = items[:max_items]
+            break
+    return items
+
+
 def format_item_result(
     item: dict,
     index: int | None = None,

--- a/tests/test_children_pagination.py
+++ b/tests/test_children_pagination.py
@@ -1,0 +1,151 @@
+"""Regression tests: children() call sites must paginate.
+
+pyzotero's ``children()`` does not paginate — without an explicit ``limit``
+the Zotero API returns only its default first page of 25 results, so every
+unpaginated call site silently sees at most the first 25 children of an
+item. These tests pin each call site to a fake that pages like the real
+API, with more than 100 children so ``_paginate``'s ``page_size=100`` must
+itself request at least two pages.
+"""
+
+import sys
+import types
+
+from conftest import FakeZotero
+
+from zotero_mcp import client as client_module
+from zotero_mcp import server
+from zotero_mcp.tools import discovery
+
+
+class PagedChildrenZotero(FakeZotero):
+    """children() honors start/limit like the real Zotero API (default 25)."""
+
+    def children(self, item_key, start=0, limit=25, **kwargs):
+        kids = self._children.get(item_key, [])
+        return kids[int(start):int(start) + int(limit)]
+
+
+def _note(key):
+    return {"key": key, "version": 1, "data": {"key": key, "itemType": "note"}}
+
+
+def _pdf(key, filename="paper.pdf", md5="abc123"):
+    return {"key": key, "version": 1, "data": {
+        "key": key,
+        "itemType": "attachment",
+        "contentType": "application/pdf",
+        "filename": filename,
+        "title": filename,
+        "md5": md5,
+    }}
+
+
+def _parent(key, title="Parent Item"):
+    return {"key": key, "version": 1, "data": {
+        "key": key, "itemType": "journalArticle", "title": title,
+    }}
+
+
+# 130 note children in front of the PDF: past the API's first page of 25
+# AND past _paginate's first page of 100.
+def _children_with_pdf_last(pdf):
+    return [_note(f"N{i:03d}") for i in range(130)] + [pdf]
+
+
+class TestGetAttachmentDetailsPagination:
+    def test_finds_pdf_attachment_past_first_api_page(self):
+        zot = PagedChildrenZotero()
+        pdf = _pdf("PDF00001")
+        zot._children = {"PAR00001": _children_with_pdf_last(pdf)}
+
+        details = client_module.get_attachment_details(zot, _parent("PAR00001"))
+
+        assert details is not None, "PDF attachment past page 1 was not found"
+        assert details.key == "PDF00001"
+        assert details.content_type == "application/pdf"
+
+
+class TestGetItemChildrenPagination:
+    def test_lists_children_past_first_api_page(self, monkeypatch, dummy_ctx):
+        zot = PagedChildrenZotero()
+        pdf = _pdf("PDF00001")
+        zot._items = [_parent("PAR00001")]
+        zot._children = {"PAR00001": _children_with_pdf_last(pdf)}
+        monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: zot)
+
+        result = server.get_item_children(item_key="PAR00001", ctx=dummy_ctx)
+
+        assert "PDF00001" in result, "attachment past page 1 missing from listing"
+
+    def test_batch_variant_lists_children_past_first_api_page(self, monkeypatch, dummy_ctx):
+        zot = PagedChildrenZotero()
+        pdf = _pdf("PDF00001")
+        zot._items = [_parent("PAR00001")]
+        zot._children = {"PAR00001": _children_with_pdf_last(pdf)}
+        monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: zot)
+
+        result = server.get_items_children(item_keys=["PAR00001"], ctx=dummy_ctx)
+
+        assert "PDF00001" in result, "attachment past page 1 missing from batch listing"
+
+
+class TestItemHasPdfPagination:
+    def test_detects_pdf_past_first_api_page(self):
+        zot = PagedChildrenZotero()
+        pdf = _pdf("PDF00001")
+        zot._children = {"PAR00001": _children_with_pdf_last(pdf)}
+
+        assert discovery._item_has_pdf(zot, _parent("PAR00001")) is True
+
+
+class TestGetPdfOutlinePagination:
+    def test_finds_pdf_attachment_past_first_api_page(self, monkeypatch, dummy_ctx):
+        fake_fitz = types.ModuleType("fitz")
+
+        class _Doc:
+            def get_toc(self):
+                return [(1, "Introduction", 1)]
+
+            def close(self):
+                pass
+
+        fake_fitz.open = lambda *a, **k: _Doc()
+        monkeypatch.setitem(sys.modules, "fitz", fake_fitz)
+
+        zot = PagedChildrenZotero()
+        pdf = _pdf("PDF00001")
+        zot._items = [_parent("PAR00001")]
+        zot._children = {"PAR00001": _children_with_pdf_last(pdf)}
+        monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: zot)
+
+        result = server.get_pdf_outline(item_key="PAR00001", ctx=dummy_ctx)
+
+        assert "No PDF attachment found" not in result
+        assert "Introduction" in result
+
+
+class TestGetAnnotationsPdfFallbackPagination:
+    def test_pdf_extraction_scans_attachments_past_first_api_page(self, monkeypatch, dummy_ctx):
+        import zotero_mcp.pdfannots_helper as ph
+
+        monkeypatch.delenv("ZOTERO_LOCAL", raising=False)
+        monkeypatch.setattr(ph, "ensure_pdfannots_installed", lambda: True)
+        monkeypatch.setattr(ph, "extract_annotations_from_pdf", lambda path, tmpdir: [
+            {"id": "a1", "type": "highlight", "annotatedText": "MARKER TEXT PAST PAGE ONE",
+             "comment": "", "color": "", "page": 3},
+        ])
+
+        zot = PagedChildrenZotero()
+        pdf = _pdf("PDF00001")
+        zot._items = [_parent("PAR00001")]
+        zot._children = {"PAR00001": _children_with_pdf_last(pdf)}
+        monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: zot)
+
+        result = server.get_annotations(
+            item_key="PAR00001", use_pdf_extraction=True, ctx=dummy_ctx
+        )
+
+        assert "MARKER TEXT PAST PAGE ONE" in result, (
+            "annotations on a PDF attachment past page 1 were not extracted"
+        )

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -505,3 +505,91 @@ class TestMergeDuplicatesConfirm:
 
         # Should succeed — DUP1 trashed via direct PATCH
         assert any("DUP1" in c["url"] for c in fake.client.patch_calls)
+
+
+class PagedChildrenFake(FakeZoteroForDuplicates):
+    """children() honors start/limit like the real Zotero API.
+
+    Without an explicit ``limit`` the API returns its default page of 25
+    results — exactly the behavior that truncates unpaginated call sites.
+    """
+
+    def children(self, item_key, start=0, limit=25, **kwargs):
+        kids = self._children.get(item_key, [])
+        return kids[int(start):int(start) + int(limit)]
+
+
+def _make_attachment(key, parent, filename, version=1):
+    return {"key": key, "version": version, "data": {
+        "key": key,
+        "itemType": "attachment",
+        "parentItem": parent,
+        "contentType": "application/pdf",
+        "filename": filename,
+        "md5": f"md5-{filename}",
+        "url": "",
+    }}
+
+
+class TestMergeDuplicatesPagination:
+    """merge_duplicates must see ALL children, not the API's first page of 25."""
+
+    def test_all_duplicate_children_reparented_past_first_api_page(self, monkeypatch, dummy_ctx):
+        """A duplicate with >100 children gets every child re-parented (not
+        just 25 — the rest would silently go to Trash with the duplicate)."""
+        fake = PagedChildrenFake()
+        n = 130  # > 100 so the fix's page_size=100 must also paginate
+        children = [
+            {"key": f"N{i:04d}", "version": 1, "data": {
+                "itemType": "note", "parentItem": "DUP1", "note": f"note {i}",
+            }}
+            for i in range(n)
+        ]
+        fake._items = [
+            _make_item("KEEP", "Keeper"),
+            _make_item("DUP1", "Dup"),
+            *children,
+        ]
+        fake._children = {"KEEP": [], "DUP1": children}
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client", lambda ctx: (fake, fake))
+
+        result = server.merge_duplicates(
+            keeper_key="KEEP", duplicate_keys=["DUP1"], confirm=True, ctx=dummy_ctx
+        )
+
+        reparented = {
+            u["key"] for u in fake.update_calls
+            if u.get("key", "").startswith("N") and u["data"].get("parentItem") == "KEEP"
+        }
+        assert len(reparented) == n
+        assert f"Children re-parented: {n}" in result
+
+    def test_keeper_dedupe_signatures_scan_past_first_api_page(self, monkeypatch, dummy_ctx):
+        """Attachment dedupe must consider keeper children beyond the first
+        API page — otherwise a duplicate of keeper attachment #26+ gets
+        copied onto the keeper instead of skipped."""
+        fake = PagedChildrenFake()
+        keeper_children = [
+            _make_attachment(f"KA{i:04d}", "KEEP", f"paper-{i}.pdf") for i in range(130)
+        ]
+        # Same signature (contentType, filename, md5, url) as the keeper's
+        # last attachment — far past the first API page.
+        dup_att = _make_attachment("DUPATT01", "DUP1", "paper-129.pdf")
+        fake._items = [
+            _make_item("KEEP", "Keeper"),
+            _make_item("DUP1", "Dup"),
+            *keeper_children,
+            dup_att,
+        ]
+        fake._children = {"KEEP": keeper_children, "DUP1": [dup_att]}
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client", lambda ctx: (fake, fake))
+
+        result = server.merge_duplicates(
+            keeper_key="KEEP", duplicate_keys=["DUP1"], confirm=True, ctx=dummy_ctx
+        )
+
+        reparented_keys = {u.get("key") for u in fake.update_calls}
+        assert "DUPATT01" not in reparented_keys, (
+            "duplicate attachment should be skipped, not re-parented onto keeper"
+        )
+        assert "1 duplicate attachments skipped" in result

--- a/tests/test_fulltext_web_mode.py
+++ b/tests/test_fulltext_web_mode.py
@@ -102,9 +102,12 @@ class FakeZoteroClient:
             raise LookupError(f"item {key} not found")
         return self.items_by_key[key]
 
-    def children(self, key):
+    def children(self, key, start=0, limit=25, **kwargs):
+        # Real Zotero API paging: without an explicit limit only the first
+        # 25 children are returned.
         self.calls.append(("children", key))
-        return list(self.children_by_parent.get(key, []))
+        kids = self.children_by_parent.get(key, [])
+        return kids[int(start):int(start) + int(limit)]
 
     def fulltext_item(self, key):
         self.calls.append(("fulltext_item", key))
@@ -209,6 +212,28 @@ def test_fetch_fulltext_skips_non_pdf_children(monkeypatch):
     search = _build_search(monkeypatch, zot, FakeChromaClient())
     text, source = search._fetch_fulltext_via_web_api("PAR")
     # Should skip the HTML attachment and return the PDF's content
+    assert text == "PDF text."
+    assert source == "web-api:attachment:PDF"
+
+
+def test_fetch_fulltext_walks_children_past_first_api_page(monkeypatch):
+    """A PDF attachment past the API's default first page of 25 children
+    must still be found — otherwise the item is silently never indexed."""
+    parent = _paper("PAR")
+    notes = [
+        {"key": f"N{i:03d}", "version": 1, "data": {"key": f"N{i:03d}", "itemType": "note"}}
+        for i in range(130)  # > 100 so the fix's page_size=100 must also paginate
+    ]
+    child_pdf = {"key": "PDF", "version": 1,
+                 "data": {"key": "PDF", "itemType": "attachment", "contentType": "application/pdf"}}
+    zot = FakeZoteroClient()
+    zot.load_scenario(
+        [parent],
+        fulltext={"PDF": {"content": "PDF text."}},
+        children={"PAR": notes + [child_pdf]},  # PDF is the 131st child
+    )
+    search = _build_search(monkeypatch, zot, FakeChromaClient())
+    text, source = search._fetch_fulltext_via_web_api("PAR")
     assert text == "PDF text."
     assert source == "web-api:attachment:PDF"
 

--- a/tests/test_v021_fixes.py
+++ b/tests/test_v021_fixes.py
@@ -196,7 +196,7 @@ class TestMergeAttachmentDedup:
             # For child re-fetch during execute, return the child itself
             next((c for c in keeper_children + dup_children if c.get("key") == k), {"key": k, "version": 1, "data": {}})
         )
-        write_zot.children.side_effect = lambda k: (
+        write_zot.children.side_effect = lambda k, **kwargs: (
             keeper_children if k == "KEEPER" else
             dup_children if k == "DUP1" else []
         )


### PR DESCRIPTION
## Problem

pyzotero's `children()` does not paginate — it's a bare `@retrieve` passthrough, and without an explicit `limit` the Zotero API returns its **default page of 25 results**. Every unpaginated call site therefore silently operated on at most the first 25 children of an item. Items with many notes/attachments/annotations are not exotic, and nothing in the output hinted at truncation.

## Worst symptom: silent data displacement in `merge_duplicates`

`merge_duplicates` fetched children unpaginated in two places, with two consequences:

1. **Children lost to the Trash.** Only the first ≤25 children of each duplicate were re-parented onto the keeper — any further notes, attachments, and annotations went to the Trash along with the duplicate item, in the operation users trust most to be conservative.
2. **Dedupe misses.** The keeper's attachment-dedupe signatures were built from ≤25 keeper children, so a duplicate of keeper attachment #26+ was copied onto the keeper instead of skipped.

## Other affected call sites (all fixed)

- `semantic_search._fetch_fulltext_via_web_api` — a PDF attachment past page 1 was never tried, so the item was silently never indexed
- `client.get_attachment_details` — PDF past page 1 not found, breaking fulltext/read paths for that item
- `get_annotations` PDF-extraction fallback — attachments past page 1 skipped
- `get_item_children` / `get_items_children` — truncated listings presented as complete
- `zotero_library_coverage` (`_item_has_pdf`) — undercounted PDF coverage
- `get_pdf_outline` — attachment scan truncated

## Fix

All sites now go through the existing `_paginate` helper (page size 100, loops until a short page). Since `tools/_helpers.py` imports `zotero_mcp.client`, `client.py` and `semantic_search.py` couldn't import it from there — the first commit moves `_paginate` to `utils.py` (which has no internal imports) and keeps a re-export in `_helpers`, so all existing `_helpers._paginate` references and tests keep working unchanged.

## Tests

Each call site is pinned by a regression test using a fake whose `children()` pages like the real API (default page of 25), with >100 children so `_paginate`'s own page size of 100 must also paginate at least twice:

- `tests/test_children_pagination.py` (new) — `get_attachment_details`, `get_item_children`, `get_items_children`, `_item_has_pdf`, `get_pdf_outline`, `get_annotations` PDF fallback
- `tests/test_duplicates.py` — both `merge_duplicates` failure modes (re-parenting truncation, dedupe-signature truncation)
- `tests/test_fulltext_web_mode.py` — fulltext attachment walk past page 1 (the file's `FakeZoteroClient.children` now pages like the real API)

Full suite: **1095 passed** (baseline 1086 + 9 new).

## Notes

- One `children()` call is deliberately left unpaginated: the add-from-file dedupe scan in `tools/write.py`, because #386 replaces that code with a paginated `_find_child_attachment`. This PR and #386 are otherwise independent; whichever lands second rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)