### PR TITLE
Tag semantic search index with group_id for multi-library filtering (#163, phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Multi-library tagging in the semantic search index (#163, phase 1)** — ChromaDB documents are now tagged with a `group_id` field (0 = personal library, else the Zotero groupID — the same `0`/groupID convention already used by `zotero_switch_library`). `zotero_semantic_search` gains a `library_id` parameter (accepting `0`, `"user"`, or a group's numeric groupID; omitted to search every indexed library — the new default) that filters on `group_id` DB-side via a ChromaDB `where` clause, never a Python post-filter. Existing collections are migrated automatically on the next `zotero_update_search_database` run (metadata-only backfill, no re-embedding, no downtime). Note: full item enrichment for a search hit still uses the currently active library's client, so a hit from a group library other than the active one may show limited detail until that capability lands in a follow-up; the incremental-update deletion pass is likewise not yet scoped per library (tracked separately, see #393 and related issues).
+
 ## [0.6.2] - 2026-07-13
 
 ### Added

--- a/src/zotero_mcp/client.py
+++ b/src/zotero_mcp/client.py
@@ -113,6 +113,21 @@ def get_active_library() -> dict[str, str]:
     return dict(_active_library_override)
 
 
+def get_active_group_id() -> int:
+    """group_id (0 = personal, else Zotero groupID) of the library
+    ``get_zotero_client()`` is currently scoped to."""
+    
+    override = _active_library_override
+    library_id = override.get("library_id") or os.getenv("ZOTERO_LIBRARY_ID") or "0"
+    library_type = override.get("library_type") or os.getenv("ZOTERO_LIBRARY_TYPE", "user")
+    if library_type == "group":
+        try:
+            return int(library_id)
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
 def _make_local_http_client() -> httpx.Client:
     """Return an httpx.Client pinned to HTTP/1.1 for the local Zotero server.
 

--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -13,7 +13,7 @@ import re
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from .utils import _normalize_for_search, is_local_mode
 
@@ -21,6 +21,25 @@ logger = logging.getLogger(__name__)
 
 # Sentinel returned by _extract_text_from_pdf on timeout
 _EXTRACTION_TIMEOUT = "__EXTRACTION_TIMEOUT__"
+
+# Library identity used throughout zotero-mcp (ChromaDB metadata, the
+# `zotero_switch_library` tool, etc.): 0 for the personal ("user") library,
+# else the Zotero server-assigned groupID. This matches Zotero's own
+# sentinel for the account-less personal library.
+PERSONAL_LIBRARY_GROUP_ID = 0
+
+
+class KeyGroupMap(NamedTuple):
+    """Result of :meth:`LocalZoteroReader.get_key_group_map`.
+
+    ``groups`` maps every non-deleted item key in the database to its
+    library's group_id. ``excluded_keys`` holds keys from libraries with no
+    group_id equivalent (feeds, "My Publications") — these are excluded from
+    the semantic index and global search rather than mis-tagged as personal.
+    """
+
+    groups: dict[str, int]
+    excluded_keys: set[str]
 
 
 def _extract_pdf_worker(file_path: str, maxpages: int, result_queue):
@@ -757,6 +776,46 @@ class LocalZoteroReader:
         conn = self._get_connection()
         rows = conn.execute("SELECT key FROM items").fetchall()
         return {row[0] for row in rows}
+
+    def get_key_group_map(self) -> KeyGroupMap:
+        """Map every non-deleted item key to its library's group_id.
+
+        Runs a single query joining ``items`` -> ``libraries`` -> ``groups``,
+        translating each item's ``libraryID`` to the codebase-wide group_id
+        (``0`` for the personal library, else the Zotero ``groupID``) in SQL.
+        Items in libraries with no group_id equivalent (feed subscriptions,
+        "My Publications") are returned in ``excluded_keys`` instead, so
+        callers can drop them from the semantic index rather than silently
+        mis-attribute them to the personal library.
+        """
+        conn = self._get_connection()
+        rows = conn.execute(
+            """
+            SELECT i.key AS item_key, l.type AS lib_type, g.groupID AS group_id
+            FROM items i
+            JOIN libraries l ON i.libraryID = l.libraryID
+            LEFT JOIN groups g ON l.libraryID = g.libraryID
+            WHERE i.itemID NOT IN (SELECT itemID FROM deletedItems)
+            """
+        ).fetchall()
+
+        groups: dict[str, int] = {}
+        excluded_keys: set[str] = set()
+        for row in rows:
+            key = row["item_key"]
+            lib_type = row["lib_type"]
+            group_id = row["group_id"]
+            if lib_type == "user":
+                groups[key] = PERSONAL_LIBRARY_GROUP_ID
+            elif lib_type == "group" and group_id is not None:
+                groups[key] = int(group_id)
+            else:
+                # Feeds, "My Publications", or any other non-group/user
+                # library type have no group_id equivalent — exclude rather
+                # than mis-attribute to the personal library.
+                excluded_keys.add(key)
+
+        return KeyGroupMap(groups, excluded_keys)
 
     def get_items_with_text(self, limit: int | None = None, include_fulltext: bool = False, key_filter: str | None = None, collection_keys: list[str] | None = None) -> list[ZoteroItem]:
         """

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -28,8 +28,8 @@ except Exception:
 
 from . import openai_batch
 from .chroma_client import ChromaClient, create_chroma_client
-from .client import get_zotero_client
-from .local_db import LocalZoteroReader
+from .client import get_active_group_id, get_zotero_client
+from .local_db import PERSONAL_LIBRARY_GROUP_ID, LocalZoteroReader
 from .utils import format_creators, is_local_mode, suppress_stdout
 
 logger = logging.getLogger(__name__)
@@ -144,6 +144,12 @@ _DEFAULT_UPDATE_CONFIG = {
     "last_update": None,
     "update_days": 7,
 }
+
+# Bumped when the ChromaDB metadata shape changes in a way that requires a
+# one-time migration of existing documents. Version 2 (#163) added the
+# `group_id` field. A persisted collection whose config.json records a lower
+# (or absent, i.e. 0) version gets migrated via `_backfill_group_ids()`.
+_INDEX_SCHEMA_VERSION = 2
 
 
 def load_update_config(config_path: str | None) -> dict[str, Any]:
@@ -531,6 +537,12 @@ class ZoteroSemanticSearch:
         Zero means "no prior successful sync; bootstrap required". Used to
         drive since-based incremental ingest via pyzotero's
         `item_versions(since=V)` and `new_fulltext(since=V)`.
+
+        NOTE: this watermark is shared across all libraries rather than
+        tracked per library — switching the active library with
+        `zotero_switch_library` can cause incremental updates to compare
+        against the wrong library's version counter. Tracked as a separate,
+        independent issue: https://github.com/54yyyu/zotero-mcp/issues/393
         """
         if not self.config_path or not os.path.exists(self.config_path):
             return 0
@@ -573,6 +585,99 @@ class ZoteroSemanticSearch:
                 json.dump(full_config, f, indent=2)
         except Exception as e:
             logger.error(f"Error saving update config: {e}")
+
+    def _load_index_schema_version(self) -> int:
+        """Schema version of the persisted ChromaDB collection's metadata shape."""
+        if not self.config_path or not os.path.exists(self.config_path):
+            return 0
+        try:
+            with open(self.config_path) as f:
+                value = json.load(f).get("semantic_search", {}).get("index_schema_version", 0)
+                return int(value) if value is not None else 0
+        except Exception as e:
+            logger.warning(f"Error loading index_schema_version: {e}")
+            return 0
+
+    def _save_index_schema_version(self, version: int) -> None:
+        """Record that the collection's metadata now matches ``version``."""
+        if not self.config_path:
+            return
+        config_dir = Path(self.config_path).parent
+        config_dir.mkdir(parents=True, exist_ok=True)
+        full_config = {}
+        if os.path.exists(self.config_path):
+            try:
+                with open(self.config_path) as f:
+                    full_config = json.load(f)
+            except Exception:
+                pass
+        full_config.setdefault("semantic_search", {})["index_schema_version"] = int(version)
+        try:
+            with open(self.config_path, "w") as f:
+                json.dump(full_config, f, indent=2)
+        except Exception as e:
+            logger.error(f"Error saving index_schema_version: {e}")
+
+    def _backfill_group_ids(self) -> dict[str, int]:
+        """One-time metadata-only migration: tag pre-#163 docs with ``group_id``.
+
+        Docs indexed before #163 carry no ``group_id`` metadata key. This
+        pages through the collection and attaches one via
+        ``ChromaClient.update_metadatas()`` — metadata-only, so no
+        re-embedding and no doc-id change. Local mode attributes each doc
+        via ``LocalZoteroReader.get_key_group_map()`` (ground truth from the
+        live database, keyed by ``item_key``); web mode — and any local-mode
+        item missing from the live DB (e.g. since deleted) — falls back to
+        the currently active library's group_id, since a pre-#163
+        collection only ever held one library's docs at a time. Idempotent:
+        docs that already carry ``group_id`` are left untouched, so a
+        partial/interrupted run just resumes on the next call.
+
+        Returns ``{"scanned": N, "migrated": N}``.
+        """
+        stats = {"scanned": 0, "migrated": 0}
+
+        key_group_map: dict[str, int] | None = None
+        if is_local_mode():
+            try:
+                zotero_db_path = self.db_path
+                if not zotero_db_path and self.config_path and os.path.exists(self.config_path):
+                    with open(self.config_path) as f:
+                        zotero_db_path = (
+                            json.load(f).get("semantic_search", {}).get("zotero_db_path")
+                        )
+                with LocalZoteroReader(db_path=zotero_db_path) as reader:
+                    key_group_map, _ = reader.get_key_group_map()
+            except Exception as e:
+                logger.warning(
+                    f"group_id backfill: could not read local database, "
+                    f"falling back to active-library attribution: {e}"
+                )
+                key_group_map = None
+
+        fallback_group_id = get_active_group_id()
+
+        for ids, metadatas in self.chroma_client.iter_metadatas():
+            stats["scanned"] += len(ids)
+            update_ids: list[str] = []
+            update_metas: list[dict[str, Any]] = []
+            for doc_id, meta in zip(ids, metadatas):
+                meta = dict(meta or {})
+                if "group_id" in meta:
+                    continue
+                item_key = meta.get("item_key") or doc_id.split("#", 1)[0]
+                if key_group_map is not None and item_key in key_group_map:
+                    group_id = key_group_map[item_key]
+                else:
+                    group_id = fallback_group_id
+                meta["group_id"] = int(group_id)
+                update_ids.append(doc_id)
+                update_metas.append(meta)
+            if update_ids:
+                self.chroma_client.update_metadatas(update_ids, update_metas)
+                stats["migrated"] += len(update_ids)
+
+        return stats
 
     def _create_document_text(self, item: dict[str, Any]) -> str:
         """
@@ -671,6 +776,11 @@ class ZoteroSemanticSearch:
             "publication": data.get("publicationTitle", ""),
             "url": data.get("url", ""),
             "doi": data.get("DOI", ""),
+            # Library attribution (#163): 0 = personal, else groupID. Every
+            # item-producing path (local scan, API scan, incremental API
+            # fetch) stamps data["group_id"] before this runs; default to
+            # personal only for the hypothetical case of an untagged caller.
+            "group_id": int(data.get("group_id", PERSONAL_LIBRARY_GROUP_ID) or 0),
         }
         # If fulltext was extracted (or attempted), mark it so incremental
         # updates don't keep re-trying items that failed extraction
@@ -808,11 +918,19 @@ class ZoteroSemanticSearch:
                 # actually see — a fresh read taken later could already
                 # include rows from a WAL checkpoint that landed mid-scan.
                 self._last_scan_snapshot_keys = reader.get_all_item_keys()
+                # Library attribution (#163): map every item key to its
+                # group_id (0 = personal, else Zotero groupID) via direct SQL
+                # on the same connection this scan uses. Feed/publications
+                # items have no group_id equivalent and are dropped below
+                # rather than mis-tagged as personal.
+                key_group_map, excluded_keys = reader.get_key_group_map()
                 # Phase 1: fetch metadata only (fast)
                 sys.stderr.write("Scanning local Zotero database for items...\n")
                 if collection_keys:
                     sys.stderr.write(f"Filtering to collections: {collection_keys}\n")
                 local_items = reader.get_items_with_text(limit=limit, include_fulltext=False, collection_keys=collection_keys)
+                if excluded_keys:
+                    local_items = [it for it in local_items if it.key not in excluded_keys]
                 candidate_count = len(local_items)
                 sys.stderr.write(f"Found {candidate_count} candidate items.\n")
 
@@ -1115,6 +1233,11 @@ class ZoteroSemanticSearch:
                             "dateAdded": item.date_added,
                             "dateModified": item.date_modified,
                             "creators": self._parse_creators_string(item.creators) if item.creators else [],
+                            # Library attribution (#163): 0 = personal, else
+                            # groupID. Ground truth from get_key_group_map();
+                            # defaults to personal for the rare item missing
+                            # from the map (e.g. added mid-scan).
+                            "group_id": key_group_map.get(item.key, PERSONAL_LIBRARY_GROUP_ID),
                         },
                     }
                     # Attachment-key set (computed during the extraction scan);
@@ -1263,6 +1386,20 @@ class ZoteroSemanticSearch:
         except Exception:
             pass
 
+    def _tag_group_id(self, items: list[dict[str, Any]]) -> None:
+        """Stamp every item's ``data.group_id`` with the active library, in place.
+
+        Web-API item/version fetches always cover exactly one library — the
+        one ``get_zotero_client()`` is currently pointed at (override or env
+        vars) — so every item an API-mode scan or incremental fetch returns
+        can be tagged with the correct library via
+        ``client.get_active_group_id()``, the same lookup the search-tool
+        fallback cascade uses.
+        """
+        group_id = get_active_group_id()
+        for item in items:
+            item.setdefault("data", {})["group_id"] = group_id
+
     def _get_items_from_api(self, limit: int | None = None, include_fulltext: bool = False) -> list[dict[str, Any]]:
         """
         Get items from Zotero API (original implementation).
@@ -1322,6 +1459,8 @@ class ZoteroSemanticSearch:
         if include_fulltext:
             self._attach_web_fulltext(all_items)
 
+        self._tag_group_id(all_items)
+
         logger.info(f"Retrieved {len(all_items)} items from API")
         return all_items
 
@@ -1374,6 +1513,8 @@ class ZoteroSemanticSearch:
 
         if include_fulltext and changed_items:
             self._attach_web_fulltext(changed_items)
+
+        self._tag_group_id(changed_items)
 
         return changed_items, current_keys
 
@@ -1577,6 +1718,29 @@ class ZoteroSemanticSearch:
             return stats
 
         try:
+            # One-time metadata migration (#163): tag any pre-existing docs
+            # that lack group_id. Skipped on a force rebuild — the reset
+            # below wipes the collection anyway, so every doc gets tagged
+            # fresh via the normal indexing path.
+            if not force_full_rebuild and self._load_index_schema_version() < _INDEX_SCHEMA_VERSION:
+                try:
+                    backfill_stats = self._backfill_group_ids()
+                    if backfill_stats["migrated"]:
+                        try:
+                            sys.stderr.write(
+                                f"Migrated {backfill_stats['migrated']} existing document(s) "
+                                "to the multi-library index format.\n"
+                            )
+                        except Exception:
+                            pass
+                    self._save_index_schema_version(_INDEX_SCHEMA_VERSION)
+                except Exception as e:
+                    logger.error(
+                        f"group_id metadata backfill failed ({e}); existing documents "
+                        "may be missing library attribution. Run with --force-rebuild "
+                        "to fully reindex, or retry the update."
+                    )
+
             # Resolve include_fulltext default from config if not specified
             if include_fulltext is None:
                 include_fulltext = self._load_include_fulltext_setting()
@@ -2153,7 +2317,8 @@ class ZoteroSemanticSearch:
     def search(self,
                query: str,
                limit: int = 10,
-               filters: dict[str, Any] | None = None) -> dict[str, Any]:
+               filters: dict[str, Any] | None = None,
+               group_id: int | None = None) -> dict[str, Any]:
         """
         Perform semantic search over the Zotero library.
 
@@ -2161,6 +2326,10 @@ class ZoteroSemanticSearch:
             query: Search query text
             limit: Maximum number of results to return
             filters: Optional metadata filters
+            group_id: Restrict results to one library (0 = personal, else
+                groupID). ``None`` (default) searches every indexed library —
+                DB-side filtering via a ChromaDB ``where`` clause, never a
+                Python post-filter.
 
         Returns:
             Search results with Zotero item details
@@ -2178,8 +2347,13 @@ class ZoteroSemanticSearch:
                 multiplier = self._reranker_config.get("candidate_multiplier", 3)
                 fetch_limit = max(fetch_limit, limit * multiplier)
 
+            where = filters
+            if group_id is not None:
+                group_clause = {"group_id": int(group_id)}
+                where = {"$and": [filters, group_clause]} if filters else group_clause
+
             # Perform semantic search
-            results = self.chroma_client.search(query_texts=[query], n_results=fetch_limit, where=filters)
+            results = self.chroma_client.search(query_texts=[query], n_results=fetch_limit, where=where)
 
             # Re-rank results with cross-encoder if enabled. With chunking we
             # rerank ALL candidates (grouping to `limit` items happens in
@@ -2200,6 +2374,7 @@ class ZoteroSemanticSearch:
                 "query": query,
                 "limit": limit,
                 "filters": filters,
+                "group_id": group_id,
                 "results": enriched_results,
                 "total_found": len(enriched_results),
             }
@@ -2210,6 +2385,7 @@ class ZoteroSemanticSearch:
                 "query": query,
                 "limit": limit,
                 "filters": filters,
+                "group_id": group_id,
                 "results": [],
                 "total_found": 0,
                 "error": str(e),

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -241,6 +241,33 @@ def _normalize_limit(limit: int | str | None, default: int = 10, max_val: int = 
     return max(1, min(limit, max_val))
 
 
+def _parse_library_id_param(value: int | str | None) -> int | None:
+    """Parse a `library_id` filter param into a group_id (0=personal library).
+
+    Accepts an int, a numeric string (the Zotero groupID), "0"/"user" for
+    the personal library, or None (no filter — search all indexed
+    libraries). This is the single-parameter convention `zotero_semantic_search`
+    exposes; `zotero_switch_library` instead takes separate library_id +
+    library_type args since it must also validate library_type ("feed" has
+    no meaning here — feed libraries are never semantically indexed).
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        if stripped.lower() == "user":
+            return 0
+        try:
+            return int(stripped)
+        except ValueError:
+            raise ValueError(
+                f"Invalid library_id: {value!r}. Use an integer groupID, 0, or 'user'."
+            ) from None
+    return int(value)
+
+
 def _normalize_str_list_input(value, field_name="value"):
     """Normalize list-like user input into a list of non-empty strings."""
     if value is None:

--- a/src/zotero_mcp/tools/search.py
+++ b/src/zotero_mcp/tools/search.py
@@ -278,7 +278,15 @@ def search_items(
                             sem_search = create_semantic_search(str(config_path))
                             _search_logger.debug(f"[CASCADE] semantic init: {_time.monotonic() - t0:.2f}s")
                             t0 = _time.monotonic()
-                            sem_results = sem_search.search(query=query, limit=limit or 10)
+                            # The semantic index can span multiple libraries
+                            # (#163) while this tool's own results come from
+                            # exactly one (whichever zot is scoped to) — scope
+                            # the fallback the same way so it never surfaces a
+                            # group-library hit for what looks like a
+                            # single-library search.
+                            sem_results = sem_search.search(
+                                query=query, limit=limit or 10, group_id=_client.get_active_group_id()
+                            )
                             _search_logger.debug(f"[CASCADE] semantic query: {_time.monotonic() - t0:.2f}s")
                             if sem_results and sem_results.get("results"):
                                 seen_keys: set[str] = set()
@@ -776,12 +784,17 @@ def advanced_search(
         "to a query using AI embeddings — the BEST tool for finding papers "
         "on a topic (e.g. 'papers about mindfulness-based therapy'), far "
         "more efficient than scanning collection items or reading "
-        "abstracts. Works across the entire active library. "
+        "abstracts. Searches across every indexed library by default (your "
+        "personal library plus any group libraries that have been synced); "
+        "use library_id to scope to one. "
         "query: the topic or concept; natural-language phrases work well. "
         "limit: max results (default 10). "
         "filters: optional metadata filters as a dict (e.g. "
         "{'itemType': 'journalArticle', 'year': '2023'}); also accepts a "
         "JSON string. "
+        "library_id: optional — restrict results to one library. 0 or "
+        "'user' for your personal library, or a group's numeric groupID "
+        "(see zotero_list_libraries). Omit to search all indexed libraries. "
         "Requires the semantic search database to be POPULATED — run "
         "zotero_update_search_database first if you just installed the "
         "server or added new items; check readiness with "
@@ -797,6 +810,7 @@ def semantic_search(
     query: str,
     limit: int = 10,
     filters: dict[str, str] | str | None = None,
+    library_id: int | str | None = None,
     *,
     ctx: Context
 ) -> str:
@@ -807,6 +821,9 @@ def semantic_search(
         query: Search query text - can be concepts, topics, or natural language descriptions
         limit: Maximum number of results to return (default: 10)
         filters: Optional metadata filters as dict or JSON string. Example: {"item_type": "note"}
+        library_id: Optional library scope — 0/"user" for the personal library, a
+            groupID for a group library, or None (default) to search every
+            indexed library.
         ctx: MCP context
 
     Returns:
@@ -815,6 +832,11 @@ def semantic_search(
     try:
         if not query.strip():
             return "Error: Search query cannot be empty"
+
+        try:
+            group_id = _helpers._parse_library_id_param(library_id)
+        except ValueError as e:
+            return f"Error: {e}"
 
         # Parse and validate filters parameter
         if filters is not None:
@@ -862,7 +884,7 @@ def semantic_search(
         _maybe_fire_presearch_sync(search)
 
         # Perform search
-        results = search.search(query=query, limit=limit, filters=filters)
+        results = search.search(query=query, limit=limit, filters=filters, group_id=group_id)
 
         if results.get("error"):
             return f"Semantic search error: {results['error']}"

--- a/tests/test_failed_marker_retry.py
+++ b/tests/test_failed_marker_retry.py
@@ -54,6 +54,11 @@ class FakeReader:
     def get_all_item_keys(self):
         return {"ITEMKEY1"}
 
+    def get_key_group_map(self):
+        # Fixed result rather than a real query — this file tests
+        # failed-marker retry, not library attribution.
+        return ({"ITEMKEY1": 0}, set())
+
     def get_items_with_text(self, limit=None, include_fulltext=False, key_filter=None, collection_keys=None):
         return [FakeItem()]
 

--- a/tests/test_fulltext_sync_watermark.py
+++ b/tests/test_fulltext_sync_watermark.py
@@ -35,6 +35,17 @@ def make_zotero_db(path, keys):
             "'2026-01-01 00:00:00', '2026-01-01 00:00:00', 1, ?, 1, 0)",
             (i, key),
         )
+    # libraries/groups: required by LocalZoteroReader.get_key_group_map (#163),
+    # which every local-db item scan now runs to attribute items to a library.
+    conn.execute(
+        "CREATE TABLE libraries (libraryID INTEGER PRIMARY KEY, type TEXT, "
+        "editable INT, filesEditable INT)"
+    )
+    conn.execute("INSERT INTO libraries VALUES (1, 'user', 1, 1)")
+    conn.execute(
+        "CREATE TABLE groups (groupID INTEGER PRIMARY KEY, libraryID INT UNIQUE, "
+        "name TEXT, description TEXT, version INT)"
+    )
     # Empty side tables referenced by get_items_with_text / get_item_count
     conn.execute("CREATE TABLE deletedItems (itemID INTEGER PRIMARY KEY)")
     conn.execute(
@@ -81,8 +92,14 @@ class FakeChroma:
     def reset_collection(self):
         raise AssertionError("reset_collection should not be called")
 
-    def get_all_ids(self):
+    def get_all_ids(self, where=None):
         return set()
+
+    def iter_metadatas(self, batch_size=500):
+        return iter(())
+
+    def update_metadatas(self, ids, metadatas):
+        pass
 
 
 def make_search(db_path, zotero, config_path=None):

--- a/tests/test_fulltext_web_mode.py
+++ b/tests/test_fulltext_web_mode.py
@@ -36,11 +36,17 @@ class FakeChromaClient:
     def get_existing_ids(self, ids):
         return {i for i in ids if i in self._ids}
 
-    def get_all_ids(self):
+    def get_all_ids(self, where=None):
         return set(self._ids)
 
     def get_document_metadata(self, doc_id):
         return None
+
+    def iter_metadatas(self, batch_size=500):
+        return iter(())
+
+    def update_metadatas(self, ids, metadatas):
+        pass
 
     def upsert_documents(self, documents, metadatas, ids):
         self.added.append((list(documents), list(metadatas), list(ids)))

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -1,6 +1,7 @@
+import sqlite3
 from pathlib import Path
 
-from zotero_mcp.local_db import LocalZoteroReader, ZoteroItem
+from zotero_mcp.local_db import PERSONAL_LIBRARY_GROUP_ID, LocalZoteroReader, ZoteroItem
 
 
 class FakeLocalZoteroReader(LocalZoteroReader):
@@ -315,3 +316,132 @@ def test_get_feed_items_includes_doi(tmp_path):
         reader.close()
 
     assert items[0]["DOI"] == "10.1234/example.doi"
+
+
+# ---------------------------------------------------------------------------
+# get_key_group_map (#163): library attribution for the semantic indexer
+# ---------------------------------------------------------------------------
+
+GROUP_ID = 6015547
+
+
+def _create_multilib_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE libraries (
+            libraryID INTEGER PRIMARY KEY,
+            type TEXT NOT NULL,
+            editable INT NOT NULL,
+            filesEditable INT NOT NULL
+        );
+        CREATE TABLE groups (
+            groupID INTEGER PRIMARY KEY,
+            libraryID INT NOT NULL UNIQUE,
+            name TEXT NOT NULL,
+            description TEXT NOT NULL,
+            version INT NOT NULL
+        );
+        CREATE TABLE items (
+            itemID INTEGER PRIMARY KEY,
+            key TEXT,
+            libraryID INT
+        );
+        CREATE TABLE deletedItems (
+            itemID INTEGER PRIMARY KEY
+        );
+        """
+    )
+    # libraryID 1 = personal ("user"), matching Zotero's own convention.
+    conn.execute("INSERT INTO libraries VALUES (1, 'user', 1, 1)")
+    conn.execute("INSERT INTO libraries VALUES (5, 'group', 1, 1)")
+    conn.execute("INSERT INTO libraries VALUES (10, 'feed', 0, 0)")
+    conn.execute("INSERT INTO libraries VALUES (20, 'publications', 1, 0)")
+    conn.execute(
+        f"INSERT INTO groups (groupID, libraryID, name, description, version) "
+        f"VALUES ({GROUP_ID}, 5, 'AI in entrepreneurship', '', 1)"
+    )
+
+    conn.execute("INSERT INTO items (itemID, key, libraryID) VALUES (1, 'USERKEY1', 1)")
+    conn.execute("INSERT INTO items (itemID, key, libraryID) VALUES (2, 'GROUPKEY1', 5)")
+    conn.execute("INSERT INTO items (itemID, key, libraryID) VALUES (3, 'FEEDKEY1', 10)")
+    conn.execute("INSERT INTO items (itemID, key, libraryID) VALUES (4, 'PUBKEY1', 20)")
+    conn.execute("INSERT INTO items (itemID, key, libraryID) VALUES (5, 'DELETEDKEY1', 1)")
+    conn.execute("INSERT INTO deletedItems (itemID) VALUES (5)")
+    conn.commit()
+    conn.close()
+
+
+def test_get_key_group_map_user_library_maps_to_zero(tmp_path):
+    db_path = tmp_path / "zotero.sqlite"
+    _create_multilib_db(db_path)
+    reader = LocalZoteroReader(db_path=str(db_path))
+    try:
+        result = reader.get_key_group_map()
+    finally:
+        reader.close()
+    assert result.groups["USERKEY1"] == PERSONAL_LIBRARY_GROUP_ID == 0
+
+
+def test_get_key_group_map_group_library_maps_to_group_id(tmp_path):
+    db_path = tmp_path / "zotero.sqlite"
+    _create_multilib_db(db_path)
+    reader = LocalZoteroReader(db_path=str(db_path))
+    try:
+        result = reader.get_key_group_map()
+    finally:
+        reader.close()
+    assert result.groups["GROUPKEY1"] == GROUP_ID
+
+
+def test_get_key_group_map_feed_items_excluded_not_personal(tmp_path):
+    db_path = tmp_path / "zotero.sqlite"
+    _create_multilib_db(db_path)
+    reader = LocalZoteroReader(db_path=str(db_path))
+    try:
+        result = reader.get_key_group_map()
+    finally:
+        reader.close()
+    assert "FEEDKEY1" not in result.groups
+    assert "FEEDKEY1" in result.excluded_keys
+
+
+def test_get_key_group_map_publications_library_excluded_not_personal(tmp_path):
+    """'My Publications' has no group_id equivalent; must not silently
+    collapse into the personal library (0)."""
+    db_path = tmp_path / "zotero.sqlite"
+    _create_multilib_db(db_path)
+    reader = LocalZoteroReader(db_path=str(db_path))
+    try:
+        result = reader.get_key_group_map()
+    finally:
+        reader.close()
+    assert "PUBKEY1" not in result.groups
+    assert "PUBKEY1" in result.excluded_keys
+
+
+def test_get_key_group_map_deleted_items_omitted_entirely(tmp_path):
+    db_path = tmp_path / "zotero.sqlite"
+    _create_multilib_db(db_path)
+    reader = LocalZoteroReader(db_path=str(db_path))
+    try:
+        result = reader.get_key_group_map()
+    finally:
+        reader.close()
+    assert "DELETEDKEY1" not in result.groups
+    assert "DELETEDKEY1" not in result.excluded_keys
+
+
+def test_get_key_group_map_full_key_set_partition(tmp_path):
+    """Every non-deleted key ends up in exactly one of groups/excluded_keys."""
+    db_path = tmp_path / "zotero.sqlite"
+    _create_multilib_db(db_path)
+    reader = LocalZoteroReader(db_path=str(db_path))
+    try:
+        result = reader.get_key_group_map()
+    finally:
+        reader.close()
+    assert set(result.groups) | result.excluded_keys == {
+        "USERKEY1", "GROUPKEY1", "FEEDKEY1", "PUBKEY1",
+    }
+    assert not (set(result.groups) & result.excluded_keys)

--- a/tests/test_semantic_multilibrary.py
+++ b/tests/test_semantic_multilibrary.py
@@ -1,0 +1,335 @@
+"""Tests for group_id into ChromaDB metadata + DB-side filtering (#163, phase 1).
+
+Covers: metadata tagging (local scan + web-API scan), feed exclusion,
+metadata-only migration backfill, and DB-side `where` filtering in
+`search()`.
+
+Out of scope for this PR (see linked issues, fixed in the bug-fix phase that
+follows the global-search PR): per-library sync_versions
+(https://github.com/54yyyu/zotero-mcp/issues/393) and scoping the deletion
+passes to one library — both are pre-existing bugs independent of group_id,
+not required for tagging/filtering correctness. Also deferred: cross-library
+result enrichment (fetching a group hit's full item via a client scoped to
+that group).
+"""
+
+import sqlite3
+import sys
+
+import pytest
+
+if sys.version_info >= (3, 14):
+    pytest.skip(
+        "chromadb currently relies on pydantic v1 paths that are incompatible with Python 3.14+",
+        allow_module_level=True,
+    )
+
+from zotero_mcp import client as zclient
+from zotero_mcp import semantic_search
+
+GROUP_ID = 6015547
+
+
+@pytest.fixture(autouse=True)
+def _clean_environment(monkeypatch):
+    """Every test in this file must be deterministic regardless of the host
+    shell's Zotero env vars, and must not leak the process-wide
+    active-library override across tests."""
+    monkeypatch.delenv("ZOTERO_LOCAL", raising=False)
+    monkeypatch.delenv("ZOTERO_LIBRARY_ID", raising=False)
+    monkeypatch.delenv("ZOTERO_LIBRARY_TYPE", raising=False)
+    zclient.clear_active_library()
+    yield
+    zclient.clear_active_library()
+
+
+class _StubZot:
+    """Minimal pyzotero-shaped client."""
+
+    def __init__(self, items_by_key=None):
+        self._items = items_by_key or {}
+
+    def item(self, key):
+        if key not in self._items:
+            raise LookupError(f"item {key} not found")
+        return self._items[key]
+
+
+class _FakeChromaClient:
+    """ChromaClient stand-in tracking metadata per doc id."""
+
+    def __init__(self, docs: dict | None = None):
+        self.embedding_max_tokens = 8000
+        self._docs: dict[str, dict] = {k: dict(v) for k, v in (docs or {}).items()}
+        self.deleted: list[str] = []
+        self.reset_calls = 0
+        self.update_calls: list[tuple[list[str], list[dict]]] = []
+        self.last_search_where = "UNSET"
+
+    def truncate_text(self, text, max_tokens=None):
+        return text
+
+    def get_existing_ids(self, ids):
+        return {i for i in ids if i in self._docs}
+
+    def get_all_ids(self):
+        return set(self._docs)
+
+    def get_document_metadata(self, doc_id):
+        return self._docs.get(doc_id)
+
+    def upsert_documents(self, documents, metadatas, ids):
+        for i, m in zip(ids, metadatas):
+            self._docs[i] = dict(m)
+
+    def delete_documents(self, ids):
+        for i in ids:
+            self._docs.pop(i, None)
+        self.deleted.extend(ids)
+
+    def reset_collection(self):
+        self.reset_calls += 1
+        self._docs = {}
+
+    def iter_metadatas(self, batch_size=500):
+        ids = list(self._docs.keys())
+        if ids:
+            yield ids, [self._docs[i] for i in ids]
+
+    def update_metadatas(self, ids, metadatas):
+        self.update_calls.append((list(ids), [dict(m) for m in metadatas]))
+        for i, m in zip(ids, metadatas):
+            self._docs.setdefault(i, {}).update(m)
+
+    def search(self, query_texts, n_results, where=None, where_document=None):
+        self.last_search_where = where
+        return {"ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]}
+
+
+def _build_search(monkeypatch, chroma, *, config_path=None, get_zotero_client_fn=None, is_local=False):
+    if get_zotero_client_fn is None:
+        get_zotero_client_fn = lambda: _StubZot()  # noqa: E731
+    monkeypatch.setattr(semantic_search, "get_zotero_client", get_zotero_client_fn)
+    monkeypatch.setattr(semantic_search, "is_local_mode", lambda: is_local)
+    return semantic_search.ZoteroSemanticSearch(chroma_client=chroma, config_path=config_path)
+
+
+# ---------------------------------------------------------------------------
+# _create_metadata tagging
+# ---------------------------------------------------------------------------
+
+def test_create_metadata_includes_group_id_from_data(monkeypatch):
+    search = _build_search(monkeypatch, _FakeChromaClient())
+    item = {"key": "K1", "data": {"title": "T", "group_id": GROUP_ID}}
+    meta = search._create_metadata(item)
+    assert meta["group_id"] == GROUP_ID
+
+
+def test_create_metadata_defaults_group_id_to_personal_when_missing(monkeypatch):
+    search = _build_search(monkeypatch, _FakeChromaClient())
+    item = {"key": "K1", "data": {"title": "T"}}
+    meta = search._create_metadata(item)
+    assert meta["group_id"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _tag_group_id (web-API scan attribution)
+# ---------------------------------------------------------------------------
+
+def test_tag_group_id_defaults_to_personal(monkeypatch):
+    search = _build_search(monkeypatch, _FakeChromaClient())
+    items = [{"key": "A", "data": {}}]
+    search._tag_group_id(items)
+    assert items[0]["data"]["group_id"] == 0
+
+
+def test_tag_group_id_uses_active_group_override(monkeypatch):
+    search = _build_search(monkeypatch, _FakeChromaClient())
+    zclient.set_active_library(library_id=str(GROUP_ID), library_type="group")
+    items = [{"key": "A", "data": {}}]
+    search._tag_group_id(items)
+    assert items[0]["data"]["group_id"] == GROUP_ID
+
+
+def test_get_items_from_api_tags_active_group(monkeypatch):
+    class _ItemsZot(_StubZot):
+        def items(self, start=0, limit=100, **kw):
+            if start > 0:
+                return []
+            return [{"key": "A", "data": {"itemType": "journalArticle", "title": "T"}}]
+
+    search = _build_search(
+        monkeypatch, _FakeChromaClient(),
+        get_zotero_client_fn=lambda: _ItemsZot(),
+    )
+    search.zotero_client = _ItemsZot()
+    zclient.set_active_library(library_id=str(GROUP_ID), library_type="group")
+
+    items = search._get_items_from_api()
+
+    assert len(items) == 1
+    assert items[0]["data"]["group_id"] == GROUP_ID
+
+
+def test_get_changed_items_from_api_tags_active_group(monkeypatch):
+    class _ChangedZot(_StubZot):
+        def item_versions(self, since=None, **kw):
+            return {"A": 9}
+
+        def item(self, key):
+            return {"key": key, "data": {"itemType": "journalArticle", "title": "T"}}
+
+    search = _build_search(monkeypatch, _FakeChromaClient())
+    search.zotero_client = _ChangedZot()
+    zclient.set_active_library(library_id=str(GROUP_ID), library_type="group")
+
+    changed_items, current_keys = search._get_changed_items_from_api(since_version=5)
+
+    assert len(changed_items) == 1
+    assert changed_items[0]["data"]["group_id"] == GROUP_ID
+    assert current_keys == {"A"}
+
+
+# ---------------------------------------------------------------------------
+# Local-scan attribution + feed exclusion (LocalZoteroReader.get_key_group_map)
+# ---------------------------------------------------------------------------
+
+def _build_multilib_db(db_path):
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE libraries (libraryID INTEGER PRIMARY KEY, type TEXT, editable INT, filesEditable INT);
+        CREATE TABLE groups (groupID INTEGER PRIMARY KEY, libraryID INT UNIQUE, name TEXT, description TEXT, version INT);
+        CREATE TABLE items (itemID INTEGER PRIMARY KEY, key TEXT, itemTypeID INT, libraryID INT, dateAdded TEXT, dateModified TEXT);
+        CREATE TABLE itemTypes (itemTypeID INTEGER PRIMARY KEY, typeName TEXT);
+        CREATE TABLE fields (fieldID INTEGER PRIMARY KEY, fieldName TEXT);
+        CREATE TABLE itemData (itemID INT, fieldID INT, valueID INT);
+        CREATE TABLE itemDataValues (valueID INTEGER PRIMARY KEY, value TEXT);
+        CREATE TABLE itemNotes (itemID INT, parentItemID INT, note TEXT);
+        CREATE TABLE itemCreators (itemID INT, creatorID INT);
+        CREATE TABLE creators (creatorID INTEGER PRIMARY KEY, firstName TEXT, lastName TEXT);
+        CREATE TABLE deletedItems (itemID INTEGER PRIMARY KEY);
+        """
+    )
+    conn.execute("INSERT INTO libraries VALUES (1, 'user', 1, 1)")
+    conn.execute("INSERT INTO libraries VALUES (5, 'group', 1, 1)")
+    conn.execute("INSERT INTO libraries VALUES (10, 'feed', 0, 0)")
+    conn.execute(f"INSERT INTO groups VALUES ({GROUP_ID}, 5, 'AI in entrepreneurship', '', 1)")
+    conn.execute("INSERT INTO itemTypes VALUES (1, 'journalArticle')")
+
+    def add_item(item_id, key, lib_id, title):
+        conn.execute(
+            "INSERT INTO items (itemID, key, itemTypeID, libraryID, dateAdded, dateModified) "
+            "VALUES (?, ?, 1, ?, '2026-01-01 00:00:00', '2026-01-01 00:00:00')",
+            (item_id, key, lib_id),
+        )
+        conn.execute("INSERT INTO itemDataValues (valueID, value) VALUES (?, ?)", (item_id, title))
+        conn.execute("INSERT INTO itemData (itemID, fieldID, valueID) VALUES (?, 1, ?)", (item_id, item_id))
+
+    add_item(1, "PERSONAL1", 1, "Personal Paper")
+    add_item(2, "GROUPITEM1", 5, "Group Paper")
+    add_item(3, "FEEDITEM1", 10, "Feed Paper")
+    conn.commit()
+    conn.close()
+
+
+def test_local_db_scan_tags_group_id_and_excludes_feeds(monkeypatch, tmp_path):
+    db_path = tmp_path / "zotero.sqlite"
+    _build_multilib_db(db_path)
+    search = _build_search(monkeypatch, _FakeChromaClient(), is_local=True)
+    search.db_path = str(db_path)
+
+    items = search._get_items_from_local_db(extract_fulltext=False)
+
+    by_key = {it["key"]: it for it in items}
+    assert set(by_key) == {"PERSONAL1", "GROUPITEM1"}, "feed item must be excluded"
+    assert by_key["PERSONAL1"]["data"]["group_id"] == 0
+    assert by_key["GROUPITEM1"]["data"]["group_id"] == GROUP_ID
+
+
+# ---------------------------------------------------------------------------
+# Migration backfill (metadata-only, idempotent)
+# ---------------------------------------------------------------------------
+
+def test_backfill_group_ids_web_mode_uses_active_library(monkeypatch):
+    chroma = _FakeChromaClient({"KEY1": {"item_key": "KEY1", "title": "T"}})
+    search = _build_search(monkeypatch, chroma, is_local=False)
+
+    stats = search._backfill_group_ids()
+    assert stats == {"scanned": 1, "migrated": 1}
+    assert chroma._docs["KEY1"]["group_id"] == 0
+    # Document text/embedding untouched — only update_metadatas was called.
+    assert chroma.update_calls == [(["KEY1"], [{"item_key": "KEY1", "title": "T", "group_id": 0}])]
+
+    # Idempotent: nothing left to migrate on a second run.
+    stats2 = search._backfill_group_ids()
+    assert stats2 == {"scanned": 1, "migrated": 0}
+
+
+def test_backfill_group_ids_local_mode_uses_key_group_map(monkeypatch):
+    chroma = _FakeChromaClient({
+        "GROUPKEY": {"item_key": "GROUPKEY", "title": "T"},
+        "USERKEY": {"item_key": "USERKEY", "title": "T2"},
+    })
+    search = _build_search(monkeypatch, chroma, is_local=True)
+
+    class _NullReader:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def get_key_group_map(self):
+            return ({"GROUPKEY": GROUP_ID, "USERKEY": 0}, set())
+
+    monkeypatch.setattr(semantic_search, "LocalZoteroReader", lambda **kw: _NullReader())
+
+    stats = search._backfill_group_ids()
+    assert stats["migrated"] == 2
+    assert chroma._docs["GROUPKEY"]["group_id"] == GROUP_ID
+    assert chroma._docs["USERKEY"]["group_id"] == 0
+
+
+def test_backfill_group_ids_skips_already_tagged_docs(monkeypatch):
+    chroma = _FakeChromaClient({"KEY1": {"item_key": "KEY1", "group_id": GROUP_ID}})
+    search = _build_search(monkeypatch, chroma, is_local=False)
+
+    stats = search._backfill_group_ids()
+    assert stats == {"scanned": 1, "migrated": 0}
+    assert chroma.update_calls == []
+    assert chroma._docs["KEY1"]["group_id"] == GROUP_ID  # untouched
+
+
+# ---------------------------------------------------------------------------
+# search(): DB-side `where` filtering
+# ---------------------------------------------------------------------------
+
+def test_search_no_group_id_means_no_library_filter(monkeypatch):
+    chroma = _FakeChromaClient()
+    search = _build_search(monkeypatch, chroma)
+    search.search(query="q")
+    assert chroma.last_search_where is None
+
+
+def test_search_group_id_only_filter(monkeypatch):
+    chroma = _FakeChromaClient()
+    search = _build_search(monkeypatch, chroma)
+    search.search(query="q", group_id=GROUP_ID)
+    assert chroma.last_search_where == {"group_id": GROUP_ID}
+
+
+def test_search_group_id_personal_filter_is_not_falsy_none(monkeypatch):
+    """group_id=0 (personal library) must still apply a filter — 0 is a
+    valid group_id, not 'no filter'."""
+    chroma = _FakeChromaClient()
+    search = _build_search(monkeypatch, chroma)
+    search.search(query="q", group_id=0)
+    assert chroma.last_search_where == {"group_id": 0}
+
+
+def test_search_merges_group_id_with_user_filters(monkeypatch):
+    chroma = _FakeChromaClient()
+    search = _build_search(monkeypatch, chroma)
+    search.search(query="q", filters={"item_type": "note"}, group_id=GROUP_ID)
+    assert chroma.last_search_where == {"$and": [{"item_type": "note"}, {"group_id": GROUP_ID}]}


### PR DESCRIPTION
## Summary
- ChromaDB documents in the semantic search index are now tagged with a `group_id` field (`0` = personal library, else the Zotero groupID) — local mode via a new `LocalZoteroReader.get_key_group_map()`, web mode via the active `zotero_switch_library` override.
- `zotero_semantic_search` gains a `library_id` parameter (`0`/`"user"` for personal, a group's numeric groupID, or omitted to search every indexed library — the new default) that filters DB-side via a ChromaDB `where` clause, never a Python post-filter.
- Existing collections migrate automatically on the next `zotero_update_search_database` run: a metadata-only backfill (no re-embedding, no doc-id changes), gated by a new `index_schema_version` config key.

This is phase 1 of #163 (global multi-library search). It's deliberately scoped to just tagging + migration + filtering:
- Cross-library result enrichment (fetching a search hit's full item via a client scoped to *its* library, rather than whichever library is currently active) is left for a follow-up — a hit from a group library other than the active one currently degrades to the existing bare-key fallback instead of full detail.
- The incremental-update deletion pass is not yet scoped per library, and the sync watermark is still a single process-wide scalar (#393) — both are pre-existing bugs, independent of this change and not worsened by it, tracked for a later bug-fix pass rather than bundled here.

## Test plan
- [x] `pytest tests/` — 1106 passed
- [x] `ruff check` clean on all touched files
- [x] New tests: `tests/test_semantic_multilibrary.py` (tagging across all three item-producing paths, feed/publications-library exclusion, migration backfill idempotency, DB-side `where`-filter merging) and `LocalZoteroReader.get_key_group_map()` coverage added to `tests/test_local_db.py`
- [x] Manual: built an index, ran `zotero_update_search_database` without `--force-rebuild` — backfill ran, doc count/IDs unchanged, every doc gained `group_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)