### PR TITLE
fix(bibtex): include ISBN and ISSN in fallback field_mappings

### DIFF
--- a/src/zotero_mcp/client.py
+++ b/src/zotero_mcp/client.py
@@ -430,6 +430,8 @@ def generate_bibtex(item: dict[str, Any]) -> str:
         ("publisher", "publisher"),
         ("place", "address"),
         ("DOI", "doi"),
+        ("ISBN", "isbn"),
+        ("ISSN", "issn"),
         ("url", "url"),
         ("abstractNote", "abstract")
     ]


### PR DESCRIPTION
## Summary

The hand-rolled BibTeX builder in `generate_bibtex()` fires when Better BibTeX is not installed / not reachable. Its `field_mappings` list omits ISBN and ISSN, so books and journal articles emitted via the fallback lose those identifiers — even though the underlying Zotero record carries them (visible via the markdown/JSON views).

This matches the shape of the ISBN fix already merged for the markdown output path in an earlier release: the record has the field; only the serializer was dropping it.

Two-line addition: append `ISBN → isbn` and `ISSN → issn` to the `field_mappings` list in `src/zotero_mcp/client.py`, grouped near the other identifier fields (DOI, url).

Downstream impact: any consumer that reads `format='bibtex'` (e.g. tools building citation records for citeproc pipelines) now sees ISBN/ISSN in the emitted BibTeX regardless of BBT availability.

## Test plan

- [ ] `format='bibtex'` on a book record with an ISBN → `isbn = {...}` appears in the emitted BibTeX
- [ ] `format='bibtex'` on a journal-article record with an ISSN → `issn = {...}` appears in the emitted BibTeX
- [ ] No change when Better BibTeX is installed (BBT path handles ISBN/ISSN natively via `item.export`)