### PR TITLE
Restrict default Chroma storage permissions

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -27,6 +27,17 @@ from zotero_mcp.utils import suppress_stdout
 logger = logging.getLogger(__name__)
 
 
+def _restrict_directory_permissions(path: Path) -> None:
+    """Best-effort owner-only permissions for sensitive local storage."""
+    if os.name != "posix":
+        return
+
+    try:
+        os.chmod(path, 0o700)
+    except OSError as exc:
+        logger.warning("Could not restrict permissions on %s: %s", path, exc)
+
+
 @register_embedding_function
 class OpenAIEmbeddingFunction(EmbeddingFunction):
     """Custom OpenAI embedding function for ChromaDB.
@@ -465,7 +476,8 @@ class ChromaClient:
         if persist_directory is None:
             # Use user's config directory by default
             config_dir = Path.home() / ".config" / "zotero-mcp"
-            config_dir.mkdir(parents=True, exist_ok=True)
+            config_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+            _restrict_directory_permissions(config_dir)
             persist_directory = str(config_dir / "chroma_db")
 
         self.persist_directory = persist_directory

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -38,6 +38,20 @@ def test_restrict_file_permissions_swallows_errors():
     _restrict_file_permissions("/nonexistent/path/to/config.json")
 
 
+def test_restrict_chroma_directory_permissions_sets_owner_only(tmp_path):
+    """Default semantic-search storage is inaccessible to other local users."""
+    if os.name != "posix":
+        pytest.skip("POSIX directory permissions only")
+    from zotero_mcp.chroma_client import _restrict_directory_permissions
+
+    config_dir = tmp_path / "zotero-mcp"
+    config_dir.mkdir(mode=0o755)
+
+    _restrict_directory_permissions(config_dir)
+
+    assert stat.S_IMODE(config_dir.stat().st_mode) == 0o700
+
+
 def test_pdfannots_timeout_returns_empty(monkeypatch):
     """A pdfannots2json timeout is handled gracefully (returns [])."""
     import zotero_mcp.pdfannots_helper as ph


### PR DESCRIPTION
## Summary

- create the default `~/.config/zotero-mcp` directory with owner-only permissions on POSIX systems
- tighten existing default config directories to `0700` when semantic search initializes
- keep the hardening best-effort and leave custom persistence directories unchanged
- add a regression test for the directory permissions

## Why

The default ChromaDB directory can contain indexed Zotero metadata and full text. The previous `mkdir` call inherited the process umask, which commonly creates a traversable `0755` directory and exposes that index to other local accounts.

## User impact

On POSIX systems, the next semantic-search initialization makes the default Zotero MCP config directory accessible only to its owner. Windows behavior and explicitly configured persistence directories are unchanged.

## Validation

- `uv run ruff check src/zotero_mcp/chroma_client.py tests/test_security_hardening.py`
- `uv run pytest tests/test_security_hardening.py -q` — 4 passed
- `uv run pytest -q --deselect tests/test_local_db.py::TestResolveAttachmentPath::test_attachments_without_base_path_returns_none` — 1,086 passed, 1 deselected

The deselected test reads the machine's real Zotero attachment preference and expected no configured base path; this machine has one configured.
