### PR TITLE
chore: release 0.6.4, list in the official MCP Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,3 +68,43 @@ jobs:
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
 
+  publish-registry:
+    needs: publish
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    permissions:
+      id-token: write   # required for mcp-publisher's GitHub OIDC login
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Sync server.json version to the release tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+      - name: Wait for the release to appear on PyPI
+        # The registry verifies that the referenced version actually exists on PyPI,
+        # and the index can lag a few seconds behind the upload in the previous job.
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          for i in $(seq 1 30); do
+            if curl -sf "https://pypi.org/pypi/zotero-mcp-server/$VERSION/json" > /dev/null; then
+              echo "zotero-mcp-server $VERSION is live on PyPI"
+              exit 0
+            fi
+            echo "attempt $i: not on PyPI yet, retrying in 10s"
+            sleep 10
+          done
+          echo "zotero-mcp-server $VERSION never appeared on PyPI"
+          exit 1
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+      - name: Publish to the MCP Registry
+        run: |
+          mcp-publisher login github-oidc
+          mcp-publisher publish
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.4] - 2026-07-28
+
+### Added
+- **Listed in the official MCP Registry** (`registry.modelcontextprotocol.io`) as `io.github.54yyyu/zotero-mcp`. A `server.json` at the repo root describes the PyPI package, its stdio transport, and the four env vars a client needs to prompt for (`ZOTERO_LOCAL`, `ZOTERO_API_KEY`, `ZOTERO_LIBRARY_ID`, `ZOTERO_LIBRARY_TYPE`); ownership is proven by the `mcp-name:` marker in the README, which is what PyPI serves as the package description. The release workflow republishes on every tag via GitHub OIDC, so the registry version can't drift from PyPI. Registry clients install by the distribution name rather than the console-script name, so `zotero-mcp-server` is now also a console-script alias for `zotero-mcp` and `uvx zotero-mcp-server serve` works without `--from`.
 
 ### Fixed
 - **`zotero-mcp update` no longer offers, or performs, a downgrade.** The check was `current_version != latest_version`, so any install ahead of the last PyPI release — every git checkout and dev build — was told an update was available, and running it replaced the newer code with the older release. Ordering is now compared rather than inequality, via `packaging.version.Version` where available and a numeric-tuple fallback where it isn't (`packaging` is not a declared dependency, only a common transitive one). Being ahead is reported as such instead of as a bare "already up to date", and `--force` from an ahead version warns before downgrading. As a side effect the comparison is numeric rather than lexical, so `0.10.0` is correctly newer than `0.9.0`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: io.github.54yyyu/zotero-mcp -->
+
 # Zotero MCP: Chat with your Research Library—Local or Web—in Claude, ChatGPT, and more.
 
 <p align="center">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ dev = [
 [project.scripts]
 zotero-cli = "zotero_mcp.cli_standalone:main"
 zotero-mcp = "zotero_mcp.cli:main"
+# Alias matching the PyPI distribution name, so `uvx zotero-mcp-server serve` works
+# without --from. MCP Registry clients derive the command from the package identifier.
+zotero-mcp-server = "zotero_mcp.cli:main"
 
 
 [tool.hatch.version]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.54yyyu/zotero-mcp",
+  "title": "Zotero MCP",
+  "description": "Search, read, annotate, and add to your Zotero research library, local or web.",
+  "version": "0.6.4",
+  "websiteUrl": "https://stevenyuyy.com/zotero-mcp/",
+  "repository": {
+    "url": "https://github.com/54yyyu/zotero-mcp",
+    "source": "github",
+    "id": "953089294"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "zotero-mcp-server",
+      "version": "0.6.4",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "serve",
+          "valueHint": "serve"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "ZOTERO_LOCAL",
+          "description": "Read from the local Zotero desktop app instead of the web API. Requires Zotero 7+ with the local API enabled in Settings > Advanced.",
+          "format": "boolean",
+          "default": "true",
+          "isRequired": false
+        },
+        {
+          "name": "ZOTERO_API_KEY",
+          "description": "Zotero Web API key from https://www.zotero.org/settings/keys. Only needed when ZOTERO_LOCAL is false, or for write operations in hybrid mode.",
+          "format": "string",
+          "isSecret": true,
+          "isRequired": false
+        },
+        {
+          "name": "ZOTERO_LIBRARY_ID",
+          "description": "Zotero user or group library ID. Only needed when ZOTERO_LOCAL is false, or for write operations in hybrid mode.",
+          "format": "string",
+          "isRequired": false
+        },
+        {
+          "name": "ZOTERO_LIBRARY_TYPE",
+          "description": "Whether ZOTERO_LIBRARY_ID refers to a personal or a group library.",
+          "format": "string",
+          "default": "user",
+          "choices": ["user", "group"],
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}

--- a/src/zotero_mcp/_version.py
+++ b/src/zotero_mcp/_version.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"


### PR DESCRIPTION
Cuts 0.6.4 and lists the server in the official MCP Registry as `io.github.54yyyu/zotero-mcp`.

The registry already carries five other Zotero servers and none of them are this one, so anyone browsing it for Zotero currently finds the alternatives.

### Changes

- **`server.json`** — describes the PyPI package, its stdio transport, and the four env vars a client should prompt for (`ZOTERO_LOCAL`, `ZOTERO_API_KEY`, `ZOTERO_LIBRARY_ID`, `ZOTERO_LIBRARY_TYPE`). Repo ID pinned so the entry survives a rename and resurrection attacks are detectable.
- **README `mcp-name:` marker** — how the registry proves package ownership for PyPI. Hidden in an HTML comment, so it renders nowhere.
- **`zotero-mcp-server` console-script alias** — registry clients install by distribution name, not console-script name, so `uvx zotero-mcp-server serve` needs to resolve without `--from`.
- **`publish-registry` job in `release.yml`** — republishes on every tag via GitHub OIDC, so the registry version can't drift from PyPI.

### Verification

- `mcp-publisher validate` passes against the live registry.
- The marker survives the build into the wheel's `METADATA` description (verbatim what PyPI serves as `info.description`), checked with a port of the registry's own boundary-anchored token matcher. Worth checking rather than assuming: that matcher rejects the token when it's glued to a trailing server-name character, and the `-->` closing the comment starts with one. It's special-cased.
- `zotero-mcp-server serve --help` works from a clean venv install of the built wheel.
- A live `mcp-publisher publish` against the production registry got past auth and namespace checks to package validation, failing only on `version '0.6.4' was not found` — which this release fixes.

The workflow waits for the release to land on PyPI before publishing to the registry: validation hits the version-specific metadata endpoint and rejects a version it can't see yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)