### PR TITLE
fix: chunk upsert_embeddings to ChromaDB's max_batch_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **OpenAI Batch API imports no longer fail on large libraries.** `ChromaClient.upsert_documents` already split upserts into chunks of `client.get_max_batch_size()` to stay under ChromaDB's batch limit, but `upsert_embeddings` — the method the batch-import path uses to write precomputed vectors — upserted the whole payload in a single call, so any import larger than ChromaDB's `max_batch_size` (~5461) failed outright (e.g. "Batch size of 6312 is greater than max batch size of 5461"). `upsert_embeddings` now chunks the same way (#410).
+
 ## [0.6.4] - 2026-07-28
 
 ### Added

--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -743,12 +743,18 @@ class ChromaClient:
         returned asynchronously without calling the realtime embeddings API.
         """
         try:
-            self.collection.upsert(
-                documents=documents,
-                metadatas=metadatas,
-                ids=ids,
-                embeddings=embeddings,
-            )
+            # Same max_batch_size constraint as upsert_documents.
+            try:
+                max_batch = int(self.client.get_max_batch_size())
+            except Exception:
+                max_batch = 5000
+            for i in range(0, len(ids), max_batch):
+                self.collection.upsert(
+                    documents=documents[i:i + max_batch],
+                    metadatas=metadatas[i:i + max_batch],
+                    ids=ids[i:i + max_batch],
+                    embeddings=embeddings[i:i + max_batch],
+                )
             logger.info(f"Upserted {len(documents)} precomputed embeddings to ChromaDB collection")
         except Exception as e:
             logger.error(f"Error upserting precomputed embeddings to ChromaDB: {e}")

--- a/tests/test_openai_batch.py
+++ b/tests/test_openai_batch.py
@@ -307,6 +307,39 @@ def test_chroma_client_upsert_embeddings_passes_precomputed_vectors():
     }
 
 
+def test_chroma_client_upsert_embeddings_splits_batches_over_max_batch_size():
+    class FakeCollection:
+        def __init__(self):
+            self.calls = []
+
+        def upsert(self, **kwargs):
+            self.calls.append(kwargs)
+
+    class FakeUnderlyingClient:
+        def get_max_batch_size(self):
+            return 2
+
+    client = ChromaClient.__new__(ChromaClient)
+    client.collection = FakeCollection()
+    client.client = FakeUnderlyingClient()
+
+    client.upsert_embeddings(
+        documents=["doc1", "doc2", "doc3", "doc4", "doc5"],
+        metadatas=[{"i": i} for i in range(5)],
+        ids=["ID1", "ID2", "ID3", "ID4", "ID5"],
+        embeddings=[[float(i)] for i in range(5)],
+    )
+
+    assert [call["ids"] for call in client.collection.calls] == [
+        ["ID1", "ID2"],
+        ["ID3", "ID4"],
+        ["ID5"],
+    ]
+    assert client.collection.calls[0]["documents"] == ["doc1", "doc2"]
+    assert client.collection.calls[0]["embeddings"] == [[0.0], [1.0]]
+    assert client.collection.calls[2]["metadatas"] == [{"i": 4}]
+
+
 def test_import_openai_batch_reports_records_missing_from_output(tmp_path, monkeypatch):
     class ImportChromaClient(FakeChromaClient):
         def __init__(self):


### PR DESCRIPTION
## Summary
- `upsert_embeddings` (used by the OpenAI Batch API import path) upserted its whole precomputed-vectors payload in a single call, unlike `upsert_documents` which already chunks to `client.get_max_batch_size()`. Any batch import larger than ChromaDB's `max_batch_size` (~5461) failed outright.
- `upsert_embeddings` now chunks `documents`/`metadatas`/`ids`/`embeddings` together, mirroring `upsert_documents`.
- Added a regression test (`test_chroma_client_upsert_embeddings_splits_batches_over_max_batch_size`) covering the split behavior, which had no prior test coverage.
- Added a CHANGELOG entry under `[Unreleased]`.

Fixes #410

## Test plan
- [x] `pytest tests/test_openai_batch.py -q` — 11 passed
- [x] `ruff check src/zotero_mcp/chroma_client.py tests/test_openai_batch.py` — clean
- [ ] Maintainer to confirm on a real large-library OpenAI batch import