### PR TITLE
feat: export annotations as structured JSON (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Structured JSON annotation export.** `zotero_get_annotations(format="json")` returns normalized annotation records with paper and attachment keys, page metadata, text, comments, color, tags, timestamps, and source. `zotero_synthesize_annotations(format="json")` returns the same records grouped by paper alongside structured notes and summary counts. The standalone CLI exposes this as `zotero-cli annotations list --format json` (#215). Records are normalized across all three annotation sources: `page` is always the page label, `page_index` always 0-based (Better BibTeX and direct PDF extraction report 1-based pages internally), and `color_category` is derived for every source rather than only the Better BibTeX one.
+
+### Changed
+- `zotero_synthesize_annotations` groups its digest by item key instead of by title, so two distinct papers that share a title are no longer merged into one section. Markdown headings are qualified with the item key when a title collides.
+
 ## [0.6.4] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -495,7 +495,8 @@ zotero-cli edit ABC123 --add-tags "reviewed,important" --date "2024"
 zotero-cli notes list ABC123
 zotero-cli notes create --item-key ABC123 --text "My note" --tags "idea"
 zotero-cli notes create --item-key ABC123 --text -   # read from stdin
-zotero-cli ann list ABC123                    # annotations (short alias)
+zotero-cli ann list --item-key ABC123         # annotations (short alias)
+zotero-cli ann list --item-key ABC123 --format json  # structured export
 zotero-cli ann search "highlight text"
 
 # Add items
@@ -614,7 +615,8 @@ zotero_remove_item_relation(
 - `zotero_get_item_children`: Get attachments and notes
 
 ### 📝 Annotation & Notes Tools
-- `zotero_get_annotations`: Get annotations (including direct PDF extraction)
+- `zotero_get_annotations`: Get annotations (including direct PDF extraction); use `format="json"` for normalized records suitable for scripts and other MCP tools
+- `zotero_synthesize_annotations`: Build a per-paper annotation/note digest; supports `format="json"` for structured grouped output
 - `zotero_get_notes`: Retrieve notes from your Zotero library
 - `zotero_search_notes`: Search in notes and annotations (including PDF-extracted)
 - `zotero_create_note`: Create a new note for an item (beta feature)

--- a/src/zotero_mcp/cli_standalone.py
+++ b/src/zotero_mcp/cli_standalone.py
@@ -179,7 +179,7 @@ def cmd_annotations(args):
         print(annotations.get_annotations(
             item_key=getattr(args, "item_key", None),
             use_pdf_extraction=args.pdf_extraction,
-            limit=args.limit, ctx=ctx,
+            limit=args.limit, format=args.format, ctx=ctx,
         ))
     elif args.subcommand == "create":
         print(annotations.create_annotation(
@@ -644,6 +644,7 @@ def build_parser() -> argparse.ArgumentParser:
     al.add_argument("--item-key")
     al.add_argument("--pdf-extraction", action="store_true")
     al.add_argument("--limit", type=int, default=100)
+    al.add_argument("--format", choices=["markdown", "json"], default="markdown")
     ac = a_sub.add_parser("create", help="Create an annotation on a PDF/EPUB")
     ac.add_argument("--attachment-key", required=True)
     ac.add_argument("--page", required=True, type=int)

--- a/src/zotero_mcp/tools/annotations.py
+++ b/src/zotero_mcp/tools/annotations.py
@@ -4,14 +4,16 @@ import json
 import os
 import tempfile
 import uuid
+from typing import Literal
 
 import requests
 
-from zotero_mcp._context import Context
-from zotero_mcp._app import mcp
 from zotero_mcp import client as _client
-from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp import utils as _utils
+from zotero_mcp._app import mcp
+from zotero_mcp._context import Context
+from zotero_mcp.better_bibtex_client import get_color_category
+from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp.tools import _helpers
 
 _WEB_API_ENV_VARS = (
@@ -19,6 +21,88 @@ _WEB_API_ENV_VARS = (
     "- ZOTERO_LIBRARY_ID: Your library ID\n"
     "- ZOTERO_LIBRARY_TYPE: 'user' or 'group'"
 )
+
+
+def _page_index(data: dict) -> int | None:
+    """Return the 0-based page index of an annotation, whatever its source.
+
+    ``_pdf_page`` (Better BibTeX, direct PDF extraction) is a 1-based page
+    number, while the Zotero API's ``annotationPosition.pageIndex`` is already
+    0-based. Both are normalized to 0-based here so the field means the same
+    thing no matter which source produced the annotation.
+    """
+    pdf_page = data.get("_pdf_page")
+    if pdf_page is not None:
+        try:
+            return max(int(pdf_page) - 1, 0)
+        except (TypeError, ValueError):
+            return None
+
+    position = data.get("annotationPosition")
+    if isinstance(position, str):
+        try:
+            position = json.loads(position)
+        except json.JSONDecodeError:
+            return None
+    if isinstance(position, dict):
+        index = position.get("pageIndex")
+        return index if isinstance(index, int) else None
+    return None
+
+
+def _annotation_to_record(
+    annotation: dict,
+    parent_context: dict[str, str | None] | None = None,
+) -> dict:
+    """Normalize an annotation from any supported source into a JSON record."""
+    data = annotation.get("data", {})
+    context = parent_context or {}
+
+    # page is always the human-facing label string, page_index always the
+    # 0-based number — downstream tooling can rely on both types.
+    page_index = _page_index(data)
+    page = data.get("_pageLabel") or data.get("annotationPageLabel") or None
+    if page is None and page_index is not None:
+        page = str(page_index + 1)
+
+    color = data.get("annotationColor") or ""
+
+    if data.get("_from_better_bibtex"):
+        source = "better_bibtex"
+    elif data.get("_from_pdf_extraction"):
+        source = "pdf_extraction"
+    else:
+        source = "zotero"
+
+    tags = [
+        tag["tag"]
+        for tag in _helpers._normalize_item_tags(data.get("tags"))
+    ]
+
+    return {
+        "annotation_key": annotation.get("key") or None,
+        "item_key": context.get("item_key"),
+        "attachment_key": context.get("attachment_key"),
+        "parent_title": context.get("parent_title"),
+        "attachment_title": (
+            context.get("attachment_title")
+            or data.get("_attachment_title")
+            or None
+        ),
+        "type": data.get("annotationType") or None,
+        "page": page,
+        "page_index": page_index,
+        "text": data.get("annotationText") or "",
+        "comment": data.get("annotationComment") or "",
+        "color": color or None,
+        # Only the Better BibTeX path precomputes this; derive it for the
+        # other sources so the field isn't null for most records.
+        "color_category": data.get("_color_category") or get_color_category(color) or None,
+        "tags": tags,
+        "created": data.get("dateAdded") or None,
+        "modified": data.get("dateModified") or None,
+        "source": source,
+    }
 
 
 def _download_attachment_for_processing(
@@ -88,8 +172,11 @@ def _get_note_write_client(op_description: str):
         "use_pdf_extraction=True falls back to direct PDF parsing when the "
         "Zotero API has no stored annotation record — useful for "
         "annotations made outside Zotero desktop. limit: cap on annotations "
-        "returned; None (default) returns all. Uses Better BibTeX when "
-        "Zotero desktop is running locally, otherwise the Zotero web API. "
+        "returned; None (default) returns all. format='markdown' (default) "
+        "returns a readable list; format='json' returns normalized records "
+        "with stable keys for downstream scripts and other MCP tools. "
+        "Uses Better BibTeX when Zotero desktop is running locally, "
+        "otherwise the Zotero web API. "
         "Example: zotero_get_annotations(item_key='ABC12345') → every "
         "highlight/note on that paper."
     )
@@ -99,6 +186,7 @@ def get_annotations(
     item_key: str | None = None,
     use_pdf_extraction: bool = False,
     limit: int | str | None = None,
+    format: Literal["markdown", "json"] = "markdown",
     *,
     ctx: Context
 ) -> str:
@@ -109,10 +197,12 @@ def get_annotations(
         item_key: Optional Zotero item key/ID to filter annotations by parent item
         use_pdf_extraction: Whether to attempt direct PDF extraction as a fallback
         limit: Maximum number of annotations to return
+        format: ``markdown`` for human-readable output or ``json`` for
+            normalized structured records.
         ctx: MCP context
 
     Returns:
-        Markdown-formatted list of annotations
+        Markdown-formatted annotations or a JSON array of normalized records.
     """
     try:
         # Initialize Zotero client
@@ -159,7 +249,6 @@ def get_annotations(
                     from zotero_mcp.better_bibtex_client import (
                         ZoteroBetterBibTexAPI,
                         process_annotation,
-                        get_color_category
                     )
 
                     # Initialize Better BibTeX client
@@ -232,13 +321,22 @@ def get_annotations(
                                                     "annotationText": processed.get("annotatedText", ""),
                                                     "annotationComment": processed.get("comment", ""),
                                                     "annotationColor": processed.get("color", ""),
-                                                    "parentItem": item_key,
+                                                    "parentItem": (
+                                                        attachment.get("itemKey")
+                                                        or attachment.get("key")
+                                                        or item_key
+                                                    ),
                                                     # Better BibTeX hands tags back as
                                                     # bare strings; normalize to Zotero's
                                                     # {"tag": ...} shape so they render (#377).
                                                     "tags": _helpers._normalize_item_tags(
                                                         processed.get("tags") or anno.get("tags")
                                                     ),
+                                                    # Carry timestamps through so
+                                                    # JSON records aren't null-dated
+                                                    # on the local BBT path.
+                                                    "dateAdded": anno.get("dateAdded", ""),
+                                                    "dateModified": anno.get("dateModified", ""),
                                                     "_pdf_page": processed.get("page", 0),
                                                     "_pageLabel": processed.get("pageLabel", ""),
                                                     "_attachment_title": attachment.get("title", ""),
@@ -335,10 +433,11 @@ def get_annotations(
                                                 "annotationText": ext.get("annotatedText", ""),
                                                 "annotationComment": ext.get("comment", ""),
                                                 "annotationColor": ext.get("color", ""),
-                                                "parentItem": item_key,
+                                                "parentItem": att_key,
                                                 # pdfannots2json only emits tags for some
                                                 # annotation kinds; carry them when present (#377).
                                                 "tags": _helpers._normalize_item_tags(ext.get("tags")),
+                                                "dateModified": ext.get("date", ""),
                                                 "_pdf_page": ext.get("page", 0),
                                                 "_from_pdf_extraction": True,
                                                 "_attachment_title": attachment.get("data", {}).get("title", "PDF")
@@ -366,18 +465,51 @@ def get_annotations(
 
         # Handle no annotations found
         if not annotations:
+            if format == "json":
+                return "[]"
             return f"No annotations found{f' for item: {parent_title}' if item_key else ''}."
 
-        # Batch-resolve parent titles for library-wide retrieval (Fix 2+5)
-        parent_titles = {}
-        if not item_key:
-            parent_keys = set()
+        # Structured output and library-wide Markdown need attachment -> paper
+        # context. Item-scoped Markdown keeps its existing no-extra-lookup path.
+        parent_keys = set()
+        if format == "json" or not item_key:
+            parent_keys = {
+                parent_key
+                for anno in annotations
+                if (parent_key := anno.get("data", {}).get("parentItem"))
+            }
+        parent_contexts = (
+            _batch_resolve_annotation_contexts(zot, parent_keys, ctx)
+            if parent_keys
+            else {}
+        )
+        parent_titles = {
+            key: context["parent_title"] or f"(parent key: {key})"
+            for key, context in parent_contexts.items()
+        }
+
+        if format == "json":
+            def _fallback_context(parent_key: str | None) -> dict[str, str | None]:
+                """Context for an attachment we couldn't re-resolve.
+
+                Falls back to what the caller already told us rather than
+                passing the attachment key off as the paper key.
+                """
+                return {
+                    "item_key": parent_item_key if item_key else None,
+                    "attachment_key": parent_key,
+                    "parent_title": parent_title if item_key else None,
+                    "attachment_title": None,
+                }
+
+            records = []
             for anno in annotations:
-                pk = anno.get("data", {}).get("parentItem")
-                if pk:
-                    parent_keys.add(pk)
-            if parent_keys:
-                parent_titles = _batch_resolve_grandparent_titles(zot, parent_keys, ctx)
+                parent_key = anno.get("data", {}).get("parentItem")
+                context = (
+                    parent_contexts.get(parent_key) or _fallback_context(parent_key)
+                )
+                records.append(_annotation_to_record(anno, context))
+            return json.dumps(records, ensure_ascii=False, indent=2)
 
         # Generate markdown output
         output = [f"# Annotations{f' for: {parent_title}' if item_key else ''}", ""]
@@ -626,14 +758,15 @@ def _batch_resolve_parent_titles(
 
 
 @with_zotero_api_lock
-def _batch_resolve_grandparent_titles(
+def _batch_resolve_annotation_contexts(
     zot, parent_keys: set[str], ctx: Context
-) -> dict[str, str]:
-    """Resolve annotation parent keys to their grandparent (paper) titles.
+) -> dict[str, dict[str, str | None]]:
+    """Resolve annotation parent keys to paper and attachment metadata.
 
     Annotations are children of PDF attachments, which are children of papers.
-    This does a two-hop lookup: annotation → attachment → paper.
-    Returns a dict mapping the ATTACHMENT key to the PAPER title.
+    This does a two-hop lookup: annotation → attachment → paper. Parents that
+    aren't attachments degrade to a one-hop context; parents that couldn't be
+    fetched at all are omitted so the caller can supply its own fallback.
     """
     BATCH_SIZE = 50
 
@@ -692,17 +825,46 @@ def _batch_resolve_grandparent_titles(
         except Exception:
             pass
 
-    # Step 3: Map attachment keys to paper titles
-    result: dict[str, str] = {}
-    for att_key, att_item in attachment_data.items():
-        gp_key = att_item.get("data", {}).get("parentItem")
-        if gp_key and gp_key in grandparent_titles:
-            result[att_key] = grandparent_titles[gp_key]
+    # Step 3: Map immediate parent keys to stable paper/attachment context.
+    # Keys we couldn't fetch are left out so callers can apply their own
+    # fallback instead of receiving a placeholder that looks resolved.
+    result: dict[str, dict[str, str | None]] = {}
+    for parent_key, parent_item in attachment_data.items():
+        data = parent_item.get("data", {})
+        is_attachment = data.get("itemType") == "attachment"
+        gp_key = data.get("parentItem") if is_attachment else None
+        if gp_key:
+            result[parent_key] = {
+                "item_key": gp_key,
+                "attachment_key": parent_key,
+                "parent_title": (
+                    grandparent_titles.get(gp_key)
+                    or data.get("title")
+                    or f"(key: {gp_key})"
+                ),
+                "attachment_title": data.get("title") or None,
+            }
         else:
-            # Fallback to attachment title (e.g., "Full Text PDF")
-            result[att_key] = att_item.get("data", {}).get("title", f"(key: {att_key})")
+            result[parent_key] = {
+                "item_key": parent_key,
+                "attachment_key": parent_key if is_attachment else None,
+                "parent_title": data.get("title") or f"(key: {parent_key})",
+                "attachment_title": data.get("title") if is_attachment else None,
+            }
 
     return result
+
+
+@with_zotero_api_lock
+def _batch_resolve_grandparent_titles(
+    zot, parent_keys: set[str], ctx: Context
+) -> dict[str, str]:
+    """Backward-compatible title-only view of annotation parent contexts."""
+    contexts = _batch_resolve_annotation_contexts(zot, parent_keys, ctx)
+    return {
+        key: context["parent_title"] or f"(parent key: {key})"
+        for key, context in contexts.items()
+    }
 
 
 @with_zotero_api_lock

--- a/src/zotero_mcp/tools/synthesis.py
+++ b/src/zotero_mcp/tools/synthesis.py
@@ -6,6 +6,8 @@ drop formatted references into a manuscript. They do NOT call an LLM
 themselves; they only collect and format.
 """
 
+import json
+from collections import Counter
 from typing import Literal
 
 from zotero_mcp import client as _client
@@ -14,10 +16,15 @@ from zotero_mcp._app import mcp
 from zotero_mcp._context import Context
 from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp.tools import _helpers
+from zotero_mcp.tools.annotations import _annotation_to_record
 
 
-def _resolve_paper_title(zot, parent_key: str, cache: dict[str, str]) -> str:
-    """Resolve an annotation/note parent key to its paper title.
+def _resolve_paper_context(
+    zot,
+    parent_key: str,
+    cache: dict[str, dict[str, str | None]],
+) -> dict[str, str | None]:
+    """Resolve an annotation/note parent key to its paper context.
 
     Annotations are children of PDF/EPUB attachments, which are children of
     the paper (two hops: annotation.parentItem -> attachment ->
@@ -28,25 +35,37 @@ def _resolve_paper_title(zot, parent_key: str, cache: dict[str, str]) -> str:
     if parent_key in cache:
         return cache[parent_key]
 
-    title = parent_key
+    context: dict[str, str | None] = {
+        "item_key": parent_key or None,
+        "attachment_key": None,
+        "parent_title": parent_key or "(unknown source)",
+        "attachment_title": None,
+    }
     try:
         parent = zot.item(parent_key)
         data = parent.get("data", {}) if parent else {}
         if data.get("itemType") == "attachment" and data.get("parentItem"):
             gp_key = data["parentItem"]
+            attachment_title = data.get("title") or None
             try:
                 grandparent = zot.item(gp_key)
                 gp_data = grandparent.get("data", {}) if grandparent else {}
-                title = gp_data.get("title") or data.get("title") or parent_key
+                title = gp_data.get("title") or attachment_title or parent_key
             except Exception:
-                title = data.get("title") or parent_key
+                title = attachment_title or parent_key
+            context = {
+                "item_key": gp_key,
+                "attachment_key": parent_key,
+                "parent_title": title,
+                "attachment_title": attachment_title,
+            }
         else:
-            title = data.get("title") or parent_key
+            context["parent_title"] = data.get("title") or parent_key
     except Exception:
-        title = parent_key
+        pass
 
-    cache[parent_key] = title
-    return title
+    cache[parent_key] = context
+    return context
 
 
 @mcp.tool(
@@ -65,7 +84,10 @@ def _resolve_paper_title(zot, parent_key: str, cache: dict[str, str]) -> str:
         "string, a JSON list, or a list). "
         "limit: cap on annotations/notes scanned (default 200) to keep the "
         "call tractable. "
-        "Output: markdown grouped by paper — each paper heading followed by "
+        "format='markdown' (default) groups the digest by paper; "
+        "format='json' returns the same highlights and notes as structured "
+        "records for downstream processing. Markdown output has each paper "
+        "heading followed by "
         "its highlights (with attached comments) and any note excerpts — "
         "plus a top summary line counting papers, highlights, and notes. "
         "Use this before writing a thematic review so you can spot themes "
@@ -78,6 +100,7 @@ def synthesize_annotations(
     collection_key: str | None = None,
     tag: list[str] | str | None = None,
     limit: int | str | None = 200,
+    format: Literal["markdown", "json"] = "markdown",
     *,
     ctx: Context,
 ) -> str:
@@ -87,10 +110,12 @@ def synthesize_annotations(
         collection_key: Optional collection to restrict the digest to.
         tag: Optional tag filter (string, JSON list, or list).
         limit: Maximum annotations/notes to scan.
+        format: ``markdown`` for a readable digest or ``json`` for structured
+            per-paper annotation and note records.
         ctx: MCP context.
 
     Returns:
-        Markdown digest grouped by paper.
+        Markdown digest or a JSON object containing summary counts and papers.
     """
     try:
         ctx.info("Gathering annotations and notes for synthesis")
@@ -131,15 +156,28 @@ def synthesize_annotations(
             notes = []
 
         if not annotations and not notes:
+            if format == "json":
+                return json.dumps({
+                    "summary": {"papers": 0, "highlights": 0, "notes": 0},
+                    "papers": [],
+                }, indent=2)
             scope = f" in collection {collection_key}" if collection_key else ""
             return f"No annotations or notes found{scope}."
 
-        # Group by resolved paper title.
-        title_cache: dict[str, str] = {}
+        # Group by resolved paper key so same-title papers stay distinct.
+        context_cache: dict[str, dict[str, str | None]] = {}
         papers: dict[str, dict] = {}
 
-        def _bucket(title: str) -> dict:
-            return papers.setdefault(title, {"highlights": [], "notes": []})
+        def _bucket(context: dict[str, str | None]) -> dict:
+            item_key = context.get("item_key")
+            title = context.get("parent_title") or "(unknown source)"
+            bucket_key = item_key or title
+            return papers.setdefault(bucket_key, {
+                "item_key": item_key,
+                "title": title,
+                "highlights": [],
+                "notes": [],
+            })
 
         def _in_scope(parent_key: str) -> bool:
             if allowed_keys is None:
@@ -167,8 +205,21 @@ def synthesize_annotations(
                 continue
             if parent_key and not _in_scope(parent_key):
                 continue
-            title = _resolve_paper_title(zot, parent_key, title_cache) if parent_key else "(unknown source)"
-            _bucket(title)["highlights"].append((text, comment))
+            context = (
+                _resolve_paper_context(zot, parent_key, context_cache)
+                if parent_key
+                else {
+                    "item_key": None,
+                    "attachment_key": None,
+                    "parent_title": "(unknown source)",
+                    "attachment_title": None,
+                }
+            )
+            record = _annotation_to_record(anno, context)
+            # Preserve this tool's existing whitespace-trimming behaviour.
+            record["text"] = text
+            record["comment"] = comment
+            _bucket(context)["highlights"].append(record)
             highlight_count += 1
 
         note_count = 0
@@ -181,15 +232,51 @@ def synthesize_annotations(
                 continue
             if parent_key and not _in_scope(parent_key):
                 continue
-            title = _resolve_paper_title(zot, parent_key, title_cache) if parent_key else "(standalone note)"
+            context = (
+                _resolve_paper_context(zot, parent_key, context_cache)
+                if parent_key
+                else {
+                    "item_key": None,
+                    "attachment_key": None,
+                    "parent_title": "(standalone note)",
+                    "attachment_title": None,
+                }
+            )
             if len(text) > 400:
                 text = text[:400] + "..."
-            _bucket(title)["notes"].append(text)
+            _bucket(context)["notes"].append({
+                "note_key": note.get("key") or None,
+                "item_key": context.get("item_key"),
+                "parent_title": context.get("parent_title"),
+                "text": text,
+                "tags": [
+                    item["tag"]
+                    for item in _helpers._normalize_item_tags(data.get("tags"))
+                ],
+                "created": data.get("dateAdded") or None,
+                "modified": data.get("dateModified") or None,
+            })
             note_count += 1
 
         if not papers:
+            if format == "json":
+                return json.dumps({
+                    "summary": {"papers": 0, "highlights": 0, "notes": 0},
+                    "papers": [],
+                }, indent=2)
             scope = f" in collection {collection_key}" if collection_key else ""
             return f"No annotations or notes found{scope}."
+
+        sorted_papers = sorted(papers.values(), key=lambda paper: paper["title"])
+        if format == "json":
+            return json.dumps({
+                "summary": {
+                    "papers": len(papers),
+                    "highlights": highlight_count,
+                    "notes": note_count,
+                },
+                "papers": sorted_papers,
+            }, ensure_ascii=False, indent=2)
 
         output = [
             "# Annotation & Note Digest",
@@ -198,20 +285,27 @@ def synthesize_annotations(
             "",
         ]
 
-        for title in sorted(papers):
-            bucket = papers[title]
-            output.append(f"## {title}")
+        # Buckets are keyed by item key, so two distinct papers can share a
+        # title — qualify the heading with the key when that happens.
+        title_counts = Counter(paper["title"] for paper in sorted_papers)
+        for bucket in sorted_papers:
+            heading = bucket["title"]
+            if title_counts[heading] > 1 and bucket["item_key"]:
+                heading = f"{heading} ({bucket['item_key']})"
+            output.append(f"## {heading}")
             if bucket["highlights"]:
                 output.append("**Highlights:**")
-                for text, comment in bucket["highlights"]:
+                for highlight in bucket["highlights"]:
+                    text = highlight["text"]
+                    comment = highlight["comment"]
                     line = f"- {text}" if text else "- (comment only)"
                     if comment:
                         line += f" — *{comment}*"
                     output.append(line)
             if bucket["notes"]:
                 output.append("**Notes:**")
-                for note_text in bucket["notes"]:
-                    output.append(f"- {note_text}")
+                for note in bucket["notes"]:
+                    output.append(f"- {note['text']}")
             output.append("")
 
         output.append(

--- a/tests/test_cli_standalone.py
+++ b/tests/test_cli_standalone.py
@@ -1,22 +1,21 @@
 """Tests for the standalone CLI module (zotero-cli entry point)."""
 
-import sys
 from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
 import zotero_mcp.tools.write as write_tools
+from zotero_mcp._context import Context
 from zotero_mcp.cli_standalone import (
     CLIContext,
     build_parser,
     cmd_add,
+    cmd_annotations,
     cmd_edit,
     cmd_notes,
     cmd_search,
     main,
 )
-from zotero_mcp._context import Context
-
 
 # ---------------------------------------------------------------------------
 # CLIContext
@@ -125,6 +124,10 @@ class TestParser:
         assert args.command in ("annotations", "ann")
         assert args.subcommand == "list"
 
+    def test_annotations_list_json_format(self):
+        args = self.parser.parse_args(["annotations", "list", "--format", "json"])
+        assert args.format == "json"
+
     def test_collections_alias_coll(self):
         args = self.parser.parse_args(["coll", "search", "my collection"])
         assert args.command in ("collections", "coll")
@@ -216,6 +219,29 @@ class TestParser:
 # ---------------------------------------------------------------------------
 # main() dispatch
 # ---------------------------------------------------------------------------
+
+
+def test_cmd_annotations_passes_json_format(capsys):
+    args = MagicMock(
+        subcommand="list",
+        item_key="PAPER001",
+        pdf_extraction=False,
+        limit=100,
+        format="json",
+        verbose=False,
+    )
+    mock_annotations = MagicMock()
+    mock_annotations.get_annotations.return_value = "[]"
+
+    with patch("zotero_mcp.cli_standalone.setup_zotero_environment"):
+        with patch(
+            "zotero_mcp.cli_standalone._import_tools",
+            return_value=(MagicMock(), MagicMock(), mock_annotations, MagicMock(), MagicMock()),
+        ):
+            cmd_annotations(args)
+
+    assert mock_annotations.get_annotations.call_args.kwargs["format"] == "json"
+    assert capsys.readouterr().out.strip() == "[]"
 
 class TestMain:
     def test_no_command_prints_help_and_exits_0(self, capsys):

--- a/tests/test_server_get_annotations.py
+++ b/tests/test_server_get_annotations.py
@@ -2,7 +2,11 @@
 to find annotations (which in Zotero's data model are children of the
 PDF attachment, not of the parent paper)."""
 
+import json
+
 from zotero_mcp import server
+from zotero_mcp.better_bibtex_client import process_annotation
+from zotero_mcp.tools.annotations import _annotation_to_record
 
 
 class DummyContext:
@@ -83,6 +87,183 @@ def test_get_annotations_descends_through_attachment(monkeypatch):
     assert "ANNO0003" in result
     assert "first highlight" in result
     assert "No annotations found" not in result
+
+
+def test_get_annotations_json_returns_stable_structured_records(monkeypatch):
+    """JSON output normalizes Zotero annotation metadata for downstream tools."""
+    parents = {
+        "PAPER001": {"key": "PAPER001", "data": {
+            "title": "A Paper", "itemType": "journalArticle",
+        }},
+        "ATTACH01": {"key": "ATTACH01", "data": {
+            "title": "Full Text PDF", "itemType": "attachment",
+            "parentItem": "PAPER001",
+        }},
+    }
+    annotation = _annotation(
+        "ANNO0001",
+        "ATTACH01",
+        "structured highlight",
+        tags=[{"tag": "method", "type": 1}, {"tag": "to-read"}],
+    )
+    annotation["data"].update({
+        "annotationComment": "important claim",
+        "annotationColor": "#ffd400",
+        "annotationPageLabel": "7",
+        "annotationPosition": json.dumps({"pageIndex": 6, "rects": []}),
+        "dateAdded": "2026-04-10T12:00:00Z",
+        "dateModified": "2026-04-11T12:00:00Z",
+    })
+    children = {
+        "PAPER001": [{"key": "ATTACH01", "data": {
+            "itemType": "attachment", "contentType": "application/pdf",
+        }}],
+        "ATTACH01": [annotation],
+    }
+    fake = FakeZoteroForAnnotations(parents, children)
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setenv("ZOTERO_LOCAL", "")
+
+    result = server.get_annotations(
+        item_key="PAPER001", format="json", ctx=DummyContext()
+    )
+
+    assert json.loads(result) == [{
+        "annotation_key": "ANNO0001",
+        "item_key": "PAPER001",
+        "attachment_key": "ATTACH01",
+        "parent_title": "A Paper",
+        "attachment_title": "Full Text PDF",
+        "type": "highlight",
+        "page": "7",
+        "page_index": 6,
+        "text": "structured highlight",
+        "comment": "important claim",
+        "color": "#ffd400",
+        "color_category": "Yellow",
+        "tags": ["method", "to-read"],
+        "created": "2026-04-10T12:00:00Z",
+        "modified": "2026-04-11T12:00:00Z",
+        "source": "zotero",
+    }]
+
+
+def test_get_annotations_json_library_wide_resolves_paper_context(monkeypatch):
+    annotation = _annotation("ANNO0001", "ATTACH01", "library highlight")
+    parents = {
+        "PAPER001": {"key": "PAPER001", "data": {
+            "title": "A Paper", "itemType": "journalArticle",
+        }},
+        "ATTACH01": {"key": "ATTACH01", "data": {
+            "title": "Full Text PDF", "itemType": "attachment",
+            "parentItem": "PAPER001",
+        }},
+    }
+
+    class _LibraryFake(FakeZoteroForAnnotations):
+        def items(self, start=0, limit=100, itemType=None, itemKey=None, **_kwargs):
+            if itemKey:
+                keys = itemKey.split(",")
+                return [self._parents[key] for key in keys if key in self._parents]
+            if itemType == "annotation":
+                return [annotation][start:start + limit]
+            return []
+
+    fake = _LibraryFake(parents, {})
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setenv("ZOTERO_LOCAL", "")
+
+    records = json.loads(server.get_annotations(format="json", ctx=DummyContext()))
+
+    assert records[0]["item_key"] == "PAPER001"
+    assert records[0]["attachment_key"] == "ATTACH01"
+    assert records[0]["parent_title"] == "A Paper"
+    assert records[0]["attachment_title"] == "Full Text PDF"
+
+
+def test_get_annotations_json_falls_back_to_caller_context(monkeypatch):
+    """An unresolvable attachment must not be passed off as the paper key.
+
+    Trashed/unsynced attachments can't be re-fetched, but the caller already
+    told us which paper it asked about — use that instead of a placeholder.
+    """
+    parents = {
+        "PAPER001": {"key": "PAPER001", "data": {
+            "title": "Known Good Title", "itemType": "journalArticle",
+        }},
+    }
+    children = {
+        "PAPER001": [{"key": "ATTACH01", "data": {
+            "itemType": "attachment", "contentType": "application/pdf",
+        }}],
+        "ATTACH01": [_annotation("ANNO0001", "ATTACH01", "orphaned highlight")],
+    }
+
+    class _UnresolvableAttachment(FakeZoteroForAnnotations):
+        def item(self, key):
+            if key == "ATTACH01":
+                raise RuntimeError("404 attachment not found")
+            return super().item(key)
+
+        def items(self, itemKey=None, **_kwargs):
+            keys = (itemKey or "").split(",")
+            return [self._parents[k] for k in keys if k in self._parents]
+
+    fake = _UnresolvableAttachment(parents, children)
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setenv("ZOTERO_LOCAL", "")
+
+    record = json.loads(server.get_annotations(
+        item_key="PAPER001", format="json", ctx=DummyContext()
+    ))[0]
+
+    assert record["item_key"] == "PAPER001"
+    assert record["parent_title"] == "Known Good Title"
+    assert record["attachment_key"] == "ATTACH01"
+
+
+def test_annotation_record_normalizes_page_across_sources():
+    """All three sources must describe the same physical page identically.
+
+    ``_pdf_page`` (Better BibTeX, direct PDF extraction) is 1-based while the
+    Zotero API's ``pageIndex`` is 0-based, and only Better BibTeX precomputes
+    a colour category. The record has to hide both differences, otherwise a
+    downstream script silently reads a different page depending on whether
+    Zotero desktop happened to be running.
+    """
+    raw = {
+        "key": "ANNO0001",
+        "annotationType": "highlight",
+        "annotationText": "same highlight",
+        "annotationColor": "#ffd400",
+        "annotationPageLabel": "7",
+        "annotationPosition": json.dumps({"pageIndex": 6, "rects": []}),
+    }
+    # Built exactly as get_annotations builds them, from one raw annotation.
+    processed = process_annotation(raw, {"itemKey": "ATTACH01"})
+    by_source = {
+        "zotero": dict(raw, itemType="annotation"),
+        "better_bibtex": {
+            "annotationText": raw["annotationText"],
+            "annotationColor": raw["annotationColor"],
+            "_pdf_page": processed["page"],
+            "_pageLabel": processed["pageLabel"],
+            "_from_better_bibtex": True,
+        },
+        "pdf_extraction": {
+            "annotationText": raw["annotationText"],
+            "annotationColor": raw["annotationColor"],
+            "_pdf_page": 7,  # pdfannots2json is 1-based, and emits no label
+            "_from_pdf_extraction": True,
+        },
+    }
+
+    for source, data in by_source.items():
+        record = _annotation_to_record({"key": "ANNO0001", "data": data})
+        assert record["source"] == source
+        assert record["page"] == "7", source
+        assert record["page_index"] == 6, source
+        assert record["color_category"] == "Yellow", source
 
 
 def test_get_annotations_accepts_attachment_key(monkeypatch):
@@ -172,6 +353,21 @@ def test_get_annotations_reports_none_when_empty(monkeypatch):
 
     assert "No annotations found" in result
     assert "Bare Paper" in result
+
+
+def test_get_annotations_json_empty_result_is_an_array(monkeypatch):
+    parents = {
+        "PAPER001": {"data": {"title": "Bare Paper", "itemType": "journalArticle"}},
+    }
+    fake = FakeZoteroForAnnotations(parents, {"PAPER001": []})
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake)
+    monkeypatch.setenv("ZOTERO_LOCAL", "")
+
+    result = server.get_annotations(
+        item_key="PAPER001", format="json", ctx=DummyContext()
+    )
+
+    assert json.loads(result) == []
 
 
 def test_get_annotations_surfaces_tags(monkeypatch):

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -1,5 +1,7 @@
 """Tests for the synthesis tool module (digest + bibliography export)."""
 
+import json
+
 from conftest import DummyContext, FakeZotero
 
 import zotero_mcp.client as zotero_client
@@ -90,12 +92,86 @@ def test_synthesize_annotations_groups_by_paper(monkeypatch):
     assert "1 notes" in out
 
 
+def test_synthesize_annotations_markdown_disambiguates_same_title(monkeypatch):
+    """Two distinct papers sharing a title get distinguishable headings."""
+    fake = _DigestZotero()
+    fake._title_map["PAPER002"] = "Attention Is All You Need"
+    monkeypatch.setattr(zotero_client, "get_zotero_client", lambda: fake)
+
+    out = synthesis.synthesize_annotations(ctx=DummyContext())
+
+    assert "## Attention Is All You Need (PAPER001)" in out
+    assert "## Attention Is All You Need (PAPER002)" in out
+    # Still two papers, and each keeps its own highlight.
+    assert "2 papers" in out
+    assert "Self-attention scales to long sequences" in out
+    assert "Residual connections ease optimization" in out
+
+
+def test_synthesize_annotations_json_groups_structured_records_by_paper(monkeypatch):
+    fake = _DigestZotero()
+    monkeypatch.setattr(zotero_client, "get_zotero_client", lambda: fake)
+
+    payload = json.loads(
+        synthesis.synthesize_annotations(format="json", ctx=DummyContext())
+    )
+
+    assert payload["summary"] == {
+        "papers": 2,
+        "highlights": 2,
+        "notes": 1,
+    }
+    papers = {paper["item_key"]: paper for paper in payload["papers"]}
+    assert papers["PAPER001"]["title"] == "Attention Is All You Need"
+    assert papers["PAPER001"]["highlights"][0] == {
+        "annotation_key": "ANN1",
+        "item_key": "PAPER001",
+        "attachment_key": "ATTACH01",
+        "parent_title": "Attention Is All You Need",
+        "attachment_title": "Full Text PDF",
+        "type": None,
+        "page": None,
+        "page_index": None,
+        "text": "Self-attention scales to long sequences",
+        "comment": "key claim",
+        "color": None,
+        "color_category": None,
+        "tags": [],
+        "created": None,
+        "modified": None,
+        "source": "zotero",
+    }
+    assert papers["PAPER001"]["notes"] == [{
+        "note_key": "NOTE1",
+        "item_key": "PAPER001",
+        "parent_title": "Attention Is All You Need",
+        "text": "Transformers remove recurrence entirely.",
+        "tags": [],
+        "created": None,
+        "modified": None,
+    }]
+
+
 def test_synthesize_annotations_empty(monkeypatch):
     fake = FakeZotero()  # items() returns [] for every itemType
     monkeypatch.setattr(zotero_client, "get_zotero_client", lambda: fake)
 
     out = synthesis.synthesize_annotations(ctx=DummyContext())
     assert "No annotations or notes found" in out
+
+
+def test_synthesize_annotations_json_empty_result_is_structured(monkeypatch):
+    fake = FakeZotero()
+    monkeypatch.setattr(zotero_client, "get_zotero_client", lambda: fake)
+
+    payload = json.loads(
+        synthesis.synthesize_annotations(format="json", ctx=DummyContext())
+    )
+
+    assert payload == {
+        "summary": {"papers": 0, "highlights": 0, "notes": 0},
+        "papers": [],
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds format="json" to zotero_get_annotations and
zotero_synthesize_annotations, and exposes it as
`zotero-cli annotations list --format json`. Markdown remains the default, so existing callers are unaffected.

Records are normalized across all three annotation sources (Zotero web API, Better BibTeX, direct PDF extraction), which do not agree on page numbering or metadata completeness:

- `page` is always the human-facing label string, `page_index` always a 0-based int. `_pdf_page` (Better BibTeX, direct PDF extraction) is 1-based while the API's `annotationPosition.pageIndex` is 0-based, so without this a downstream script read a different page depending on whether Zotero desktop happened to be running.
- `color_category` is derived from the colour for every source instead of only the Better BibTeX path, which precomputes it.
- Better BibTeX and PDF-extraction annotations carry their timestamps through, so `created`/`modified` aren't null outside the web API.
- Annotations from Better BibTeX and PDF extraction now record their real attachment key as `parentItem`, so attachment -> paper resolution works for them too.

Attachment -> paper resolution is shared by both tools. When an attachment can't be re-fetched (trashed, unsynced, another library) the record falls back to the paper the caller asked about rather than passing the attachment key off as the paper key; library-wide scans report null instead of a wrong key.

`zotero_synthesize_annotations` now groups by item key rather than title, so two distinct papers sharing a title are no longer merged. Markdown headings are qualified with the item key when a title collides.