### PR TITLE
chore: pin fastmcp<4 and declare httpx ahead of the FastMCP 4 migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-timeout fastmcp pyzotero python-dotenv markitdown[pdf] chromadb unidecode bibtexparser tiktoken pymupdf
+          python -m pip install pytest pytest-timeout "fastmcp<4" pyzotero python-dotenv markitdown[pdf] chromadb unidecode bibtexparser tiktoken pymupdf
           python -m pip install -e . --no-deps
       - name: Run tests
         run: pytest --ignore=tests/test_lifespan.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`fastmcp` is pinned to `<4`, and `httpx` is now a declared dependency.** FastMCP 4 (currently `4.0.0b1`) targets the stateless `2026-07-28` MCP revision and is a breaking upgrade for this server: it removes `ctx.sample()`/`ctx.list_roots()`/`ctx.elicit()`, raises the `pydantic` floor to 2.12, and replaces `httpx` with `httpx2` throughout. That last change is the reason `httpx` moves into the dependency list — `client.py` imports it directly for the HTTP/1.1-pinned local Zotero transport, and until now relied on it arriving transitively through FastMCP. The CI test job installed `fastmcp` unpinned, so it would have picked up the 4.0 stable release on its next scheduled run and failed without a commit to this repo; it is pinned to match. The `mcp` dependency is dropped: nothing in `src/` imports it, and FastMCP already pins the SDK version it needs. The FastMCP 4 migration is tracked separately and will not ship until 4.0 leaves beta.
+
 ### Fixed
 - **OpenAI Batch API imports no longer fail on large libraries.** `ChromaClient.upsert_documents` already split upserts into chunks of `client.get_max_batch_size()` to stay under ChromaDB's batch limit, but `upsert_embeddings` — the method the batch-import path uses to write precomputed vectors — upserted the whole payload in a single call, so any import larger than ChromaDB's `max_batch_size` (~5461) failed outright (e.g. "Batch size of 6312 is greater than max batch size of 5461"). `upsert_embeddings` now chunks the same way (#410).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,17 @@ classifiers = [
 ]
 dependencies = [
     "pyzotero>=1.8.0",
-    "mcp>=1.2.0",
     "python-dotenv>=1.0.0",
     "markitdown[pdf]",
     "pydantic>=2.0.0",
     "requests>=2.28.0",
-    "fastmcp>=2.14.0",
+    # <4 until the FastMCP 4 migration: FastMCP 4 targets the stateless
+    # 2026-07-28 MCP revision, drops ctx.sample/list_roots/elicit, and swaps
+    # httpx for httpx2. It is still a beta (4.0.0b1) as of this pin.
+    "fastmcp>=2.14.0,<4",
+    # client.py imports httpx directly rather than relying on it arriving
+    # transitively through fastmcp (which replaces it with httpx2 in v4).
+    "httpx>=0.27",
     "unidecode>=1.3.0",
     "bibtexparser>=1.4,<2",
 ]


### PR DESCRIPTION
Defensive dependency work ahead of the FastMCP 4 / MCP `2026-07-28` migration. No behaviour change.

FastMCP 4 (`4.0.0b1`, released the same day as the spec) targets the stateless `2026-07-28` MCP revision and is a breaking upgrade for this server: it removes `ctx.sample()` / `ctx.list_roots()` / `ctx.elicit()`, raises the `pydantic` floor to 2.12, and replaces `httpx` with `httpx2` throughout.

Three things follow:

- **`pyproject` pins `fastmcp<4`** so a `uvx zotero-mcp` install cannot resolve into the new major before the migration lands.
- **CI pins it too.** The test job installed `fastmcp` unpinned, so it would have broken on its own on the next scheduled run after 4.0 goes stable, with no commit to this repo.
- **`httpx` becomes a declared dependency.** `client.py:13` imports it directly for the HTTP/1.1-pinned local Zotero transport and until now relied on it arriving transitively through FastMCP, which v4 no longer provides.

Also drops the `mcp` dependency: nothing in `src/` imports it, and FastMCP already constrains the SDK version it needs.

The FastMCP 4 migration itself is deliberately not in this PR and will not ship until 4.0 leaves beta. Notable work it will carry: dual-era serving must be preserved (a `2026-07-28`-only server cannot talk to any current client — the spec's compatibility matrix has legacy-client/modern-server as an outright failure), and the 248 `ctx.info()` call sites need to move to stderr logging (Logging is deprecated in the new revision, and those calls are currently silent no-ops — `Context.info` is async and none of them are awaited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)