### PR TITLE
chore: release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-03
+
 **Upgrading:** this release changes tool names. Fifteen tools were merged into six, so saved prompts, permission allowlists, or scripts naming the old tools need updating — see the table below. No back-compat aliases ship, deliberately: an alias re-sends its schema on every request, which is exactly the cost this change exists to remove. Some tools are also now opt-in and absent unless enabled; if you rely on Scite, duplicate detection, feeds, related-items links, or the corpus-level discovery tools, set `ZOTERO_MCP_TOOLSETS` (below).
 
 ### Added

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.54yyyu/zotero-mcp",
   "title": "Zotero MCP",
   "description": "Search, read, annotate, and add to your Zotero research library, local or web.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "websiteUrl": "https://stevenyuyy.com/zotero-mcp/",
   "repository": {
     "url": "https://github.com/54yyyu/zotero-mcp",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "zotero-mcp-server",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -54,6 +54,12 @@
           "format": "string",
           "default": "user",
           "choices": ["user", "group"],
+          "isRequired": false
+        },
+        {
+          "name": "ZOTERO_MCP_TOOLSETS",
+          "description": "Which optional tool groups to expose, as a comma-separated list. Every tool is sent to the model on each request, so optional capabilities are off by default. Use 'all' for the full surface, 'none' for core only, named groups (scite, duplicates, discovery, feeds, relations, libraries, search-admin, pdf-geometry) to add them, or a leading '-' to subtract.",
+          "format": "string",
           "isRequired": false
         }
       ]

--- a/src/zotero_mcp/_version.py
+++ b/src/zotero_mcp/_version.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"


### PR DESCRIPTION
Release prep for **0.9.0**, containing #422 (tool-surface consolidation) and #424 (Ollama timeout + local bibliography fixes), both already merged to `main`.

## Why 0.9.0 and not 0.8.1

The tool surface changes incompatibly, so a patch bump would misrepresent it:

- Fifteen tools were merged into six, with **no back-compat aliases** — an alias re-ships its schema on every request, which is the cost #422 exists to remove.
- Some tools are now **opt-in and genuinely absent** unless `ZOTERO_MCP_TOOLSETS` enables them, so they cannot be called rather than merely being hidden.

Saved prompts, permission allowlists, and scripts naming the old tools need updating. The changelog leads with an **Upgrading** note and a full old → new mapping table.

## Changes in this PR

- `src/zotero_mcp/_version.py`: `0.8.0` → `0.9.0`
- `server.json`: both version fields → `0.9.0`, and a new `ZOTERO_MCP_TOOLSETS` entry so the MCP Registry advertises the setting alongside the existing `ZOTERO_*` vars
- `CHANGELOG.md`: `[Unreleased]` → `[0.9.0] - 2026-08-03`, with a fresh empty `[Unreleased]` above it

The release workflow rewrites both `server.json` version fields from the tag anyway, so bumping them here is belt-and-braces — it keeps the checked-in file from disagreeing with what was published.

## Verification

- **1630 passed, 3 skipped** locally on this branch.
- `python -m build` produces `zotero_mcp_server-0.9.0.tar.gz` and the wheel; confirmed the wheel ships the new `zotero_mcp/toolsets.py`.
- `server.json` parses and carries all five environment variables.

## Note on a flaky Windows job

Merging #422 turned `main` red on `test (windows-latest, 3.12)` — a 30s pytest timeout inside `test_chroma_client_real.py`, stalled on a `tmp_path` write. Re-running the job passed with no code change, and the same commit had already passed Windows as PR #422, so it is flakiness rather than a regression. `conftest.py` already carries a `skip_on_ci` marker documented for "tests that use tmp_path and fail on GitHub Actions"; this test uses `tmp_path` and is not marked. Worth a follow-up — either the marker or a longer per-test timeout — but out of scope for the release.

## After merge

Tagging is deliberately left to you, since pushing `v0.9.0` publishes to PyPI and the MCP Registry and cannot be undone:

```bash
git checkout main && git pull
git tag v0.9.0 && git push origin v0.9.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)