### PR TITLE
chore: enable GitHub Sponsors button and refresh Support section

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: [54yyyu]
 buy_me_a_coffee: stevenyuyy

--- a/README.md
+++ b/README.md
@@ -804,7 +804,7 @@ A 45-point live integration test plan is included at `docs/integration-test-plan
 
 ## ☕ Support
 
-Zotero MCP is MIT-licensed and free, and will stay that way — no paywalled features.
+Zotero MCP is free and MIT-licensed.
 
 If it saves you or your lab time, sponsoring helps cover the unglamorous parts: Windows and WSL2 edge
 cases, Zotero schema changes, group-library support, and the embedding/search infrastructure.

--- a/README.md
+++ b/README.md
@@ -804,11 +804,20 @@ A 45-point live integration test plan is included at `docs/integration-test-plan
 
 ## ☕ Support
 
-If you find Zotero MCP useful, consider buying me a coffee!
+Zotero MCP is MIT-licensed and free, and will stay that way — no paywalled features.
 
+If it saves you or your lab time, sponsoring helps cover the unglamorous parts: Windows and WSL2 edge
+cases, Zotero schema changes, group-library support, and the embedding/search infrastructure.
+
+<a href="https://github.com/sponsors/54yyyu">
+  <img src="https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-ea4aaa?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="Sponsor on GitHub">
+</a>
 <a href="https://buymeacoffee.com/stevenyuyy">
   <img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee">
 </a>
+
+**Labs and institutions:** the $50 and $200 tiers are meant to be expensable, and include priority
+triage on the issues affecting your workflow.
 
 ## 📄 License
 


### PR DESCRIPTION
Turns on the **Sponsor button** at the top of the repository — the highest-traffic placement available (~6,500 unique visitors/month).

### Changes

- `.github/FUNDING.yml` — adds `github: [54yyyu]` alongside the existing Buy Me a Coffee entry.
- `README.md` — Support section now says what sponsorship funds (Windows/WSL2 edge cases, Zotero schema changes, group libraries, embedding infrastructure) rather than just asking, and adds a line pointing labs/institutions at the expensable tiers.

The Support section states that the project is free and MIT-licensed today, and deliberately makes **no forward-looking commitment** about future licensing — so an optional paid or hosted offering later would not contradict anything promised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)