### PR TITLE
fix(local_db): exclude trashed attachments and prefer PDFs in _iter_parent_attachments

### DIFF
--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -302,7 +302,14 @@ class LocalZoteroReader:
         return None
 
     def _iter_parent_attachments(self, parent_item_id: int):
-        """Yield tuples (attachment_key, path, content_type) for a parent item."""
+        """Yield tuples (attachment_key, path, content_type) for a parent item.
+
+        Explicitly trashed attachment rows (the attachment itself is in
+        deletedItems; parent-trash inheritance is not checked) are excluded,
+        and PDFs are yielded before other content types — otherwise a leftover
+        HTML snapshot's .zotero-ft-cache would win over the PDF's in
+        _extract_fulltext_for_item.
+        """
         conn = self._get_connection()
         query = (
             """
@@ -313,7 +320,9 @@ class LocalZoteroReader:
                    att.key as attachmentKey
             FROM itemAttachments ia
             JOIN items att ON att.itemID = ia.itemID
-            WHERE ia.parentItemID = ?
+            LEFT JOIN deletedItems d ON d.itemID = ia.itemID
+            WHERE ia.parentItemID = ? AND d.itemID IS NULL
+            ORDER BY (ia.contentType = 'application/pdf') DESC, ia.itemID
             """
         )
         for row in conn.execute(query, (parent_item_id,)):

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -437,6 +437,111 @@ def test_get_key_group_map_includes_trashed_items_with_their_library(tmp_path):
     assert "DELETEDKEY1" not in result.excluded_keys
 
 
+# ---------------------------------------------------------------------------
+# _iter_parent_attachments: trashed attachments excluded, PDFs first
+# ---------------------------------------------------------------------------
+
+
+def _create_attachment_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE items (
+            itemID INTEGER PRIMARY KEY,
+            key TEXT,
+            libraryID INT
+        );
+        CREATE TABLE itemAttachments (
+            itemID INTEGER PRIMARY KEY,
+            parentItemID INT,
+            path TEXT,
+            contentType TEXT
+        );
+        CREATE TABLE deletedItems (
+            itemID INTEGER PRIMARY KEY
+        );
+        """
+    )
+    conn.execute("INSERT INTO items (itemID, key, libraryID) VALUES (1, 'PARENT1', 1)")
+    conn.commit()
+    conn.close()
+
+
+def _add_attachment(db_path, item_id, key, parent_id, path, content_type, trashed=False):
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO items (itemID, key, libraryID) VALUES (?, ?, 1)", (item_id, key)
+    )
+    conn.execute(
+        "INSERT INTO itemAttachments (itemID, parentItemID, path, contentType) "
+        "VALUES (?, ?, ?, ?)",
+        (item_id, parent_id, path, content_type),
+    )
+    if trashed:
+        conn.execute("INSERT INTO deletedItems (itemID) VALUES (?)", (item_id,))
+    conn.commit()
+    conn.close()
+
+
+class TestIterParentAttachments:
+    def _iter(self, db_path):
+        reader = LocalZoteroReader(db_path=str(db_path))
+        try:
+            return list(reader._iter_parent_attachments(1))
+        finally:
+            reader.close()
+
+    def test_trashed_attachment_excluded(self, tmp_path):
+        """A trashed HTML snapshot must not shadow the live PDF (its stale
+        .zotero-ft-cache would otherwise win the fulltext fallback)."""
+        db_path = tmp_path / "zotero.sqlite"
+        _create_attachment_db(db_path)
+        _add_attachment(db_path, 10, "HTMLKEY", 1, "storage:page.html", "text/html", trashed=True)
+        _add_attachment(db_path, 11, "PDFKEY", 1, "storage:paper.pdf", "application/pdf")
+        result = self._iter(db_path)
+        assert [r[0] for r in result] == ["PDFKEY"]
+
+    def test_pdf_yielded_before_other_types(self, tmp_path):
+        """PDFs come first regardless of insertion order, so the ft-cache
+        fallback in _extract_fulltext_for_item prefers the PDF's cache."""
+        db_path = tmp_path / "zotero.sqlite"
+        _create_attachment_db(db_path)
+        _add_attachment(db_path, 10, "HTMLKEY", 1, "storage:page.html", "text/html")
+        _add_attachment(db_path, 11, "PDFKEY", 1, "storage:paper.pdf", "application/pdf")
+        result = self._iter(db_path)
+        assert [r[0] for r in result] == ["PDFKEY", "HTMLKEY"]
+
+    def test_only_trashed_attachments_yields_nothing(self, tmp_path):
+        db_path = tmp_path / "zotero.sqlite"
+        _create_attachment_db(db_path)
+        _add_attachment(db_path, 10, "GONE1", 1, "storage:a.pdf", "application/pdf", trashed=True)
+        _add_attachment(db_path, 11, "GONE2", 1, "storage:b.html", "text/html", trashed=True)
+        assert self._iter(db_path) == []
+
+    def test_null_content_type_sorts_after_pdf(self, tmp_path):
+        """NULL contentType must neither crash the ORDER BY nor outrank a PDF."""
+        db_path = tmp_path / "zotero.sqlite"
+        _create_attachment_db(db_path)
+        _add_attachment(db_path, 10, "NOCTYPE", 1, "storage:mystery.bin", None)
+        _add_attachment(db_path, 11, "PDFKEY", 1, "storage:paper.pdf", "application/pdf")
+        result = self._iter(db_path)
+        assert [r[0] for r in result] == ["PDFKEY", "NOCTYPE"]
+
+    def test_trashed_parent_does_not_hide_live_attachment(self, tmp_path):
+        """Only the attachment's own deletedItems row is checked; parent-trash
+        inheritance is deliberately out of scope (callers resolve the parent
+        through live-item paths that already exclude trashed parents)."""
+        db_path = tmp_path / "zotero.sqlite"
+        _create_attachment_db(db_path)
+        conn = sqlite3.connect(db_path)
+        conn.execute("INSERT INTO deletedItems (itemID) VALUES (1)")
+        conn.commit()
+        conn.close()
+        _add_attachment(db_path, 10, "PDFKEY", 1, "storage:paper.pdf", "application/pdf")
+        result = self._iter(db_path)
+        assert [r[0] for r in result] == ["PDFKEY"]
+
+
 def test_get_key_group_map_full_key_set_partition(tmp_path):
     """Every key — trashed included — ends up in exactly one of
     groups/excluded_keys."""


### PR DESCRIPTION
Fixes #427.

## Problem

`_iter_parent_attachments` neither filters `deletedItems` nor orders its rows, so in local/hybrid mode `zotero_get_item_fulltext` can return a **trashed HTML snapshot's** `.zotero-ft-cache` (the publisher landing page text) instead of the live PDF's content.

Real-world sequence: save via browser connector (HTML snapshot child gets created and indexed) → attach the real PDF → trash the snapshot. If the PDF can't be parsed or resolved and the ft-cache fallback in `_extract_fulltext_for_item` kicks in, the trashed snapshot's cache wins — it still sits in `storage/<KEY>/` because emptying the trash hasn't happened yet.

## Change

One query, two guards:

- `LEFT JOIN deletedItems d … WHERE d.itemID IS NULL` — trashed attachment rows no longer participate in either the on-disk candidate scan or the ft-cache fallback loop. Every other item-level query in `local_db.py` already excludes `deletedItems`; this iterator was the one exception.
- `ORDER BY (ia.contentType = 'application/pdf') DESC, ia.itemID` — PDFs are yielded first, so when several live attachments have a ft-cache the PDF's flat cache is preferred over an HTML snapshot's, deterministically.

Scope note: only the attachment's *own* trash state is checked. Parent-trash inheritance is deliberately out of scope — callers reach this iterator through live-item paths that already exclude trashed parents (covered by a test documenting that behavior).

## Tests

New `TestIterParentAttachments` in `tests/test_local_db.py`, against a real temp sqlite DB:

- trashed HTML snapshot + live PDF → only the PDF is yielded
- PDF yielded before other types regardless of insertion order
- only trashed attachments → nothing yielded
- `NULL` contentType neither crashes the `ORDER BY` nor outranks a PDF
- trashed parent + live attachment → attachment still yielded (scope note above)

Without the fix, the first four fail; with it, all pass. `tests/test_local_db.py`, `test_local_db_discovery.py`, `test_fulltext_local_mode.py`, `test_fulltext_non_pdf_html.py`, `test_fulltext_display_cap.py` all green (57 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
