### PR TITLE
chore(deps): require pyzotero >=1.13.3 so attachment_both uploads work first-try

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,12 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "pyzotero>=1.8.0",
+    # 1.13.3 fixes attachment_both() putting the full filesystem path into the
+    # stored filename, which the Zotero API rejects with 400 ("Stored-file
+    # filename cannot contain a directory path") while pyzotero swallows the
+    # error — on older versions every upload silently falls back to the
+    # two-step retry in _attach_and_verify (#403).
+    "pyzotero>=1.13.3",
     "python-dotenv>=1.0.0",
     # PDF text extraction. Rust with prebuilt abi3 wheels for every platform
     # we support and no Python dependencies of its own. Pinned exactly while


### PR DESCRIPTION
## Problem

pyzotero ≤1.13.2 has a bug in `attachment_both()`: it derives the stored filename from the full filesystem path, the Zotero Web API rejects the upload with **400 "Stored-file filename cannot contain a directory path"**, and pyzotero swallows the error, returning the payload in `failure` instead of raising.

Since #403, zotero-mcp detects this (`_describe_attach_failure`) and recovers via the two-step create+upload fallback in `_attach_and_verify` — so files do land and failures are no longer silent. But with the current `pyzotero>=1.8.0` floor, any environment resolving an old pyzotero pays for it on **every** attach (`add_by_url`, `add_by_doi`, arXiv PDFs, `add_from_file`, …): the primary `attachment_both()` call always fails client-side and every upload takes the fallback's extra API round trips.

Before #403 landed, on a stale install this was user-visible as *all* PDF attach operations silently failing while the tool reported success — which is how it was originally noticed (zotero-mcp 0.4.x + pyzotero 1.13.2 in the wild).

## Change

Raise the floor to `pyzotero>=1.13.3` (current PyPI release), where the filename handling is fixed and the primary `attachment_both()` path succeeds first-try. Comment in `pyproject.toml` records why the floor exists so it doesn't get relaxed accidentally.

The #403 fallback stays — it still covers the local-API 404 case and any future client-side rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
