### PR TITLE
chore: release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-08-05
+
 ### Changed
 - **The pyzotero floor moves from 1.8.0 to 1.13.3, so file attachments upload on the first attempt.** Before 1.13.3, step 0 of the upload handshake sent the caller-supplied path as the stored-file `filename`; 1.13.3 adds `Zupload._outgoing` in `_upload.py` to send `Path(filename).name` instead (upstream urschrei/pyzotero#341). The Zotero API answers a path with 400 "Stored-file filename cannot contain a directory path", and pyzotero returns that payload under `failure` rather than raising, so nothing surfaced as an error: `_attach_and_verify` read the failure and quietly re-ran the whole attach through its two-step create-then-upload fallback (#403). The fallback stays, since an upload can fail for other reasons, but on a current pyzotero it is no longer the path every attach takes. Raised by @feima3333, who traced the swallowed 400 to the pyzotero version in play.
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.54yyyu/zotero-mcp",
   "title": "Zotero MCP",
   "description": "Search, read, annotate, and add to your Zotero research library, local or web.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "websiteUrl": "https://stevenyuyy.com/zotero-mcp/",
   "repository": {
     "url": "https://github.com/54yyyu/zotero-mcp",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "zotero-mcp-server",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/zotero_mcp/_version.py
+++ b/src/zotero_mcp/_version.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"


### PR DESCRIPTION
Patch release. Four fixes, no interface change: the tool surface, the config schema and the CLI are identical to 0.9.0.

- `zotero_get_item_fulltext` could return a trashed HTML snapshot's text in place of the live PDF's, in local and hybrid mode (#427). Reported, diagnosed and fixed by @feima3333.
- The pyzotero floor moves to 1.13.3, so attachment uploads succeed on the first attempt instead of always falling back to the two-step create-then-upload path (#403 fallout). Raised by @feima3333. This is the only change reaching outside our own code, and it only raises a dependency floor.
- `chunking.enabled` was accepted in silence on the OpenAI Batch API path, which indexes item-level and truncates at the embedding limit (#416). Reported by @dbuchber.
- One hung `zotero_get_pdf_outline` call held the process-global Zotero lock across PDF extraction and left every other tool timing out until the server was restarted; separately, concurrent `suppress_stdout` users could leave the server unable to write to stdout at all (#431).

Worth stating plainly: the Windows-specific hang behind #431 is mitigated, not confirmed. The lock scope and the inherited stdin are fixed for certain. Why the extraction subprocess outlived its own 30s timeout is still open with the reporter.

Version is bumped in `_version.py` and both `server.json` fields. The release workflow rewrites them from the tag, but keeping them accurate means the repo never disagrees with what was published.