### PR TITLE
feat: add tool to set item parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`zotero_set_item_parent` sets or clears an item's parent.** It can parent standalone notes and attachments, move them between parents, or make them top-level again.
+
 ## [0.9.1] - 2026-08-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ After installation, either:
    For **local read-only use**, `ZOTERO_LOCAL: "true"` is all you need — drop the `ZOTERO_API_KEY` and `ZOTERO_LIBRARY_ID` lines entirely.
 
    The local API is fast but read-only, so the MCP server uses the Zotero web API for write operations.
-   
+
    To enable **write mode**:
    - Keep `ZOTERO_LOCAL: "true"` — with API credentials set, the server runs in hybrid mode (fast local reads, web API writes)
    - Click [here](https://www.zotero.org/settings/security#applications) to generate a Zotero API key and replace `YOUR_API_KEY` with it
@@ -757,6 +757,7 @@ Example (Claude Desktop / Claude Code):
 
 All add tools take a `collections` parameter accepting collection keys, names, or `parent/child` paths — resolved and validated before the item is created, so unknown or ambiguous specs fail with suggestions instead of producing an unfiled item. They also take `if_exists` (`"duplicate"` — default — always creates; `"file"` reuses an existing item matching the DOI/arXiv ID/ISBN/URL, filing it into missing collections and adding missing tags; `"skip"` leaves a match untouched) and `create_missing_collections` (create unknown collection specs, including path chains, instead of failing). The `zotero-cli add` commands default to `--if-exists file`.
 - `zotero_attach_file`: Attach a local file or a PDF URL to an existing item by key (no new item created; returns the attachment key; idempotent per filename and content hash)
+- `zotero_set_item_parent`: Set, change, or clear an item's parent (`parent_key=null` makes it top-level)
 - `zotero_create_collection`: Create a new collection (folder/project) in your library
 - `zotero_search_collections`: Search for collections by name to find their keys
 - `zotero_manage_collections`: Add or remove items from collections (accepts keys, names, or `parent/child` paths)

--- a/src/zotero_mcp/tools/__init__.py
+++ b/src/zotero_mcp/tools/__init__.py
@@ -4,6 +4,7 @@ from zotero_mcp.tools import (  # noqa: F401
     annotations,
     connectors,
     discovery,
+    item_parent,
     read_pdf,
     retrieval,
     search,

--- a/src/zotero_mcp/tools/item_parent.py
+++ b/src/zotero_mcp/tools/item_parent.py
@@ -1,0 +1,46 @@
+"""Parent assignment for Zotero items."""
+
+from zotero_mcp._app import mcp
+from zotero_mcp._context import Context
+from zotero_mcp.client import with_zotero_api_lock
+from zotero_mcp.tools import _helpers
+
+
+@mcp.tool(
+    name="zotero_set_item_parent",
+    description=(
+        "Set or clear the parent of a Zotero item. Pass a parent item key to "
+        "assign or change the parent, or null to make the item top-level. "
+        "Zotero validates whether the requested parent-child relationship is allowed."
+    ),
+)
+@with_zotero_api_lock
+def set_item_parent(
+    item_key: str,
+    parent_key: str | None,
+    *,
+    ctx: Context,
+) -> str:
+    """Set ``parentItem`` through Zotero's versioned item-update API."""
+    try:
+        _read_zot, write_zot = _helpers._get_write_client(ctx)
+    except ValueError as e:
+        return str(e)
+
+    try:
+        item = write_zot.item(item_key)
+        payload = {
+            "key": item["key"],
+            "version": item["version"],
+            "parentItem": parent_key if parent_key is not None else False,
+        }
+        response = write_zot.update_item(payload)
+        if not _helpers._handle_write_response(response, ctx):
+            return f"Failed to set parent for item '{item_key}'."
+
+        if parent_key is None:
+            return f"Successfully cleared the parent of item `{item_key}`."
+        return f"Successfully set the parent of item `{item_key}` to `{parent_key}`."
+    except Exception as e:
+        ctx.error(f"Error setting parent for item {item_key}: {e}")
+        return f"Error setting parent for item '{item_key}': {e}"

--- a/tests/test_set_item_parent.py
+++ b/tests/test_set_item_parent.py
@@ -1,0 +1,122 @@
+"""Tests for the item-parent mutation tool."""
+
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+
+import pytest
+from conftest import DummyContext
+
+from zotero_mcp import server
+from zotero_mcp.tools.item_parent import set_item_parent
+
+ITEM_KEY = "CHILD001"
+PARENT_KEY = "PARENT01"
+
+
+def test_schema_requires_an_explicit_nullable_parent_key():
+    tools = {tool.name: tool for tool in asyncio.run(server.mcp.list_tools())}
+    parameters = tools["zotero_set_item_parent"].parameters
+
+    assert "parent_key" in parameters["required"]
+    assert {option["type"] for option in parameters["properties"]["parent_key"]["anyOf"]} == {
+        "string",
+        "null",
+    }
+
+
+class ParentWriteFake:
+    def __init__(self, *, response=True):
+        self.response = response
+        self.item_calls: list[str] = []
+        self.update_calls: list[dict] = []
+        self.raise_on_item: Exception | None = None
+        self.raise_on_update: Exception | None = None
+
+    def item(self, key):
+        self.item_calls.append(key)
+        if self.raise_on_item:
+            raise self.raise_on_item
+        return {"key": key, "version": 7}
+
+    def update_item(self, payload):
+        self.update_calls.append(deepcopy(payload))
+        if self.raise_on_update:
+            raise self.raise_on_update
+        return self.response
+
+
+def _install(monkeypatch, fake):
+    monkeypatch.setattr(
+        "zotero_mcp.tools._helpers._get_write_client",
+        lambda _ctx: (object(), fake),
+    )
+
+
+def _call(parent_key):
+    return set_item_parent(
+        item_key=ITEM_KEY,
+        parent_key=parent_key,
+        ctx=DummyContext(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("parent_key", "api_value", "message"),
+    [
+        (PARENT_KEY, PARENT_KEY, "Successfully set the parent"),
+        (None, False, "Successfully cleared the parent"),
+    ],
+)
+def test_sends_minimal_versioned_parent_update(
+    monkeypatch,
+    parent_key,
+    api_value,
+    message,
+):
+    fake = ParentWriteFake()
+    _install(monkeypatch, fake)
+
+    result = _call(parent_key)
+
+    assert message in result
+    assert fake.item_calls == [ITEM_KEY]
+    assert fake.update_calls == [
+        {
+            "key": ITEM_KEY,
+            "version": 7,
+            "parentItem": api_value,
+        }
+    ]
+
+
+def test_surfaces_api_exception(monkeypatch):
+    fake = ParentWriteFake()
+    fake.raise_on_update = RuntimeError("412 Precondition Failed")
+    _install(monkeypatch, fake)
+
+    result = _call(PARENT_KEY)
+
+    assert result == ("Error setting parent for item 'CHILD001': 412 Precondition Failed")
+    assert len(fake.update_calls) == 1
+
+
+def test_reports_unsuccessful_response(monkeypatch):
+    fake = ParentWriteFake(response=False)
+    _install(monkeypatch, fake)
+
+    result = _call(PARENT_KEY)
+
+    assert result == "Failed to set parent for item 'CHILD001'."
+
+
+def test_surfaces_item_fetch_error_without_writing(monkeypatch):
+    fake = ParentWriteFake()
+    fake.raise_on_item = RuntimeError("404 Not Found")
+    _install(monkeypatch, fake)
+
+    result = _call(PARENT_KEY)
+
+    assert result == "Error setting parent for item 'CHILD001': 404 Not Found"
+    assert fake.update_calls == []


### PR DESCRIPTION
## Summary

This adds `zotero_set_item_parent(item_key, parent_key)`, a small tool for changing an existing Zotero item's parent.

It supports the three operations exposed by Zotero's `parentItem` field:

- assigning a parent to a standalone note or attachment;
- moving an item to a different parent;
- making an item top-level by passing `parent_key=null`.

There was previously no MCP tool for this. `zotero_update_item` handles metadata fields and rejects `parentItem`, while the existing attachment and te tools can only set a parent when creating a new item.

## Implementation

The tool fetches the item to obtain its current version, then sends one version-conditioned update containing `key`, `version`, and `parentItem`. tero remains responsible for validating whether the requested parent-child relationship is allowed.

The tests cover the required nullable MCP schema, parent assignment and clearing, version forwarding, and API error handling.

I also tested a live round trip with disposable Zotero records, moving an imported PDF with four annotations to another item and back.

The full test suite passes.

---

🤖 **AI disclosure:** This contribution was developed with AI coding assistance. I directed the design, reviewed the implementation and tests, and validated it through a disposable Zotero round trip.