### PR TITLE
perf: parallel attachment extraction and a transient fulltext cache (#390)

### DIFF
--- a/src/zotero_mcp/cli.py
+++ b/src/zotero_mcp/cli.py
@@ -358,6 +358,13 @@ def main():
                                  help="Path to semantic search configuration file")
     update_db_parser.add_argument("--db-path",
                                  help="Path to Zotero database file (zotero.sqlite), overrides config")
+    update_db_parser.add_argument("--extraction-workers", type=int, metavar="N",
+                                 help="Parse N attachments in parallel during --fulltext "
+                                      "(default: semantic_search.extraction.workers, or 1 for "
+                                      "sequential). Capped at the CPU count")
+    update_db_parser.add_argument("--clear-fulltext-cache", action="store_true",
+                                 help="Discard the transient extracted-fulltext cache before "
+                                      "running, forcing every attachment to be re-parsed")
     openai_batch_group = update_db_parser.add_mutually_exclusive_group()
     openai_batch_group.add_argument("--openai-batch", dest="openai_batch", action="store_true",
                                    help="Submit OpenAI embeddings through the asynchronous Batch API")
@@ -574,9 +581,19 @@ def main():
             # Save the db_path to config file for future use
             _save_zotero_db_path_to_config(config_path, db_path)
 
+        if getattr(args, "clear_fulltext_cache", False):
+            from zotero_mcp import fulltext_cache
+
+            removed = fulltext_cache.clear_all(config_path=str(config_path))
+            print(f"Cleared transient fulltext cache ({removed} entries)")
+
         try:
             # Create semantic search instance with optional db_path override
-            search = create_semantic_search(str(config_path), db_path=db_path)
+            search = create_semantic_search(
+                str(config_path),
+                db_path=db_path,
+                extraction_workers=getattr(args, "extraction_workers", None),
+            )
             if args.openai_batch is True and search.chroma_client.embedding_model != "openai":
                 print("Error: --openai-batch requires ZOTERO_EMBEDDING_MODEL=openai", file=sys.stderr)
                 sys.exit(1)

--- a/src/zotero_mcp/fulltext_cache.py
+++ b/src/zotero_mcp/fulltext_cache.py
@@ -1,0 +1,266 @@
+"""Transient on-disk cache for extracted attachment fulltext.
+
+``update-db --fulltext`` runs in two phases: extract text from every changed
+attachment, then embed it. Extraction is cheap per file but not free across a
+library — roughly 100 ms per PDF, so a 16,000-item library spends around half
+an hour in phase one. Embedding is the phase that fails: rate limits, token
+limits, network errors, or the user pressing Ctrl-C. When it does, the
+extracted text is lost and the next run pays for phase one all over again.
+
+This module persists that text to disk so a rerun skips straight to embedding.
+Entries are evicted once their item's embedding has actually landed in
+ChromaDB — the cache exists only to survive the gap between the two phases,
+not as a long-lived store.
+
+Layout under ``~/.config/zotero-mcp/fulltext_cache/``:
+
+- ``index.json`` — maps cache keys to entry metadata (source, item_key, ...)
+- ``<hash>.txt`` — the extracted UTF-8 text, one file per entry
+
+Concurrency
+-----------
+Extraction runs in a :class:`~concurrent.futures.ProcessPoolExecutor` (see
+``extraction_workers``), but **only the parent process touches this cache**.
+Workers receive a file path and return text; the parent writes each entry as
+its future completes. Nothing here needs to be process-safe, and a lock in
+this module would not have provided that anyway — each worker is a separate
+interpreter.
+
+Writing incrementally rather than once at the end is what makes the cache
+useful: a run killed part-way through still leaves every completed extraction
+on disk for the next one. :data:`_INDEX_LOCK` guards against the parent
+mutating the index from more than one thread.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import threading
+from collections.abc import Iterable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_INDEX_LOCK = threading.Lock()
+
+INDEX_VERSION = 1
+
+
+def _private_chmod(path: Path) -> None:
+    """Keep cached text readable only by its owner — it is library content."""
+    try:
+        os.chmod(path, 0o600 if path.is_file() else 0o700)
+    except OSError:
+        pass
+
+
+def get_fulltext_cache_root(config_path: str | None = None) -> Path:
+    """Return the directory used to store cached fulltext, creating it."""
+    if config_path:
+        root = Path(config_path).expanduser().parent / "fulltext_cache"
+    else:
+        root = Path.home() / ".config" / "zotero-mcp" / "fulltext_cache"
+    root.mkdir(parents=True, exist_ok=True)
+    _private_chmod(root)
+    return root
+
+
+def _hash_key(key: str) -> str:
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:32]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _index_path(root: Path) -> Path:
+    return root / "index.json"
+
+
+def _text_path(root: Path, entry_hash: str) -> Path:
+    return root / f"{entry_hash}.txt"
+
+
+def _load_index_unlocked(root: Path) -> dict[str, Any]:
+    path = _index_path(root)
+    if not path.exists():
+        return {"version": INDEX_VERSION, "entries": {}}
+    try:
+        with open(path, encoding="utf-8") as f:
+            index = json.load(f)
+        if not isinstance(index.get("entries"), dict):
+            index["entries"] = {}
+        return index
+    except Exception as e:
+        logger.warning(f"Could not read fulltext cache index ({e}); starting fresh")
+        return {"version": INDEX_VERSION, "entries": {}}
+
+
+def _save_index_unlocked(root: Path, index: dict[str, Any]) -> None:
+    path = _index_path(root)
+    tmp = path.with_suffix(".json.tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(index, f, indent=2)
+    _private_chmod(tmp)
+    os.replace(tmp, path)
+
+
+def put_cached_text(
+    attachment_key: str,
+    mtime_ns: int,
+    size: int,
+    source: str,
+    item_key: str | None,
+    text: str,
+    path: str | None = None,
+    profile: str | None = None,
+    config_path: str | None = None,
+) -> None:
+    """Cache one attachment's extracted text. Parent process only.
+
+    Identity is the attachment key plus the file's mtime and size, so a PDF
+    replaced on disk lands on a different hash and can never serve stale text.
+    A failure here is not fatal — it just means the next run re-extracts.
+    """
+    root = get_fulltext_cache_root(config_path)
+    entry = {
+        "hash": _hash_key(f"{attachment_key}:{mtime_ns}:{size}"),
+        "mtime_ns": mtime_ns,
+        "size": size,
+        "source": source,
+        "item_key": item_key,
+        "path": path,
+        "profile": profile,
+        "cached_at": _utc_now(),
+    }
+    with _INDEX_LOCK:
+        index = _load_index_unlocked(root)
+        old = index["entries"].get(attachment_key)
+        try:
+            _text_path(root, entry["hash"]).write_text(text, encoding="utf-8")
+            _private_chmod(_text_path(root, entry["hash"]))
+        except OSError as e:
+            logger.debug(f"Could not cache fulltext for {attachment_key}: {e}")
+            return
+        index["entries"][attachment_key] = entry
+        _save_index_unlocked(root, index)
+        # Drop superseded text (e.g. the attachment changed on disk).
+        if old and old.get("hash") != entry["hash"]:
+            _text_path(root, old["hash"]).unlink(missing_ok=True)
+
+
+def get_cached_text(
+    attachment_key: str,
+    mtime_ns: int,
+    size: int,
+    profile: str | None = None,
+    config_path: str | None = None,
+) -> tuple[str, str] | None:
+    """Return ``(text, source)`` for an unchanged attachment, or None on miss.
+
+    ``profile`` captures extraction settings that change the output for the
+    same input file — currently the PDF page cap. A mismatch is a miss, so
+    lowering ``pdf_max_pages`` can never serve text extracted under a higher
+    cap. Which *attachment* was chosen does not need to be in the profile:
+    the entry is keyed by attachment key, so a changed
+    ``attachment_priority`` resolves to a different key and misses naturally.
+    """
+    root = get_fulltext_cache_root(config_path)
+    with _INDEX_LOCK:
+        entry = _load_index_unlocked(root)["entries"].get(attachment_key)
+        if (
+            not entry
+            or entry.get("mtime_ns") != mtime_ns
+            or entry.get("size") != size
+            or entry.get("profile") != profile
+        ):
+            return None
+        try:
+            text = _text_path(root, entry["hash"]).read_text(encoding="utf-8")
+        except Exception:
+            return None
+    return text, entry.get("source", "pdf")
+
+
+def evict_many(item_keys: Iterable[str], config_path: str | None = None) -> int:
+    """Remove every cache entry belonging to the given item keys.
+
+    Called once an item's embedding has landed in ChromaDB. Returns the
+    number of entries removed.
+    """
+    keys = {k for k in item_keys if k}
+    if not keys:
+        return 0
+    root = get_fulltext_cache_root(config_path)
+    removed = 0
+    with _INDEX_LOCK:
+        index = _load_index_unlocked(root)
+        entries = index["entries"]
+        for index_key in [k for k, e in entries.items() if e.get("item_key") in keys]:
+            entry = entries.pop(index_key)
+            _text_path(root, entry.get("hash", "")).unlink(missing_ok=True)
+            removed += 1
+        if removed:
+            _save_index_unlocked(root, index)
+    return removed
+
+
+def evict(item_key: str, config_path: str | None = None) -> int:
+    """Remove all cache entries for one item key."""
+    return evict_many([item_key], config_path=config_path)
+
+
+def purge_stale(max_age_days: int = 30, config_path: str | None = None) -> int:
+    """Best-effort cleanup guarding against unbounded growth.
+
+    Removes entries older than ``max_age_days`` (an abandoned run) and entries
+    whose backing attachment file is gone. Also sweeps orphaned ``.txt`` files
+    that no index entry references — the residue of a run that died between a
+    worker's write and the parent's :func:`record_entries`.
+    """
+    root = get_fulltext_cache_root(config_path)
+    removed = 0
+    now = datetime.now(timezone.utc)
+    with _INDEX_LOCK:
+        index = _load_index_unlocked(root)
+        entries = index["entries"]
+        for index_key in list(entries):
+            entry = entries[index_key]
+            stale = False
+            try:
+                cached_at = datetime.fromisoformat(entry.get("cached_at", "").replace("Z", "+00:00"))
+                if (now - cached_at).days >= max_age_days:
+                    stale = True
+            except ValueError:
+                stale = True
+            backing = entry.get("path")
+            if backing and not Path(backing).exists():
+                stale = True
+            if stale:
+                entries.pop(index_key)
+                _text_path(root, entry.get("hash", "")).unlink(missing_ok=True)
+                removed += 1
+        referenced = {e.get("hash") for e in entries.values()}
+        for orphan in root.glob("*.txt"):
+            if orphan.stem not in referenced:
+                orphan.unlink(missing_ok=True)
+        if removed:
+            _save_index_unlocked(root, index)
+    return removed
+
+
+def clear_all(config_path: str | None = None) -> int:
+    """Delete every cache entry. Returns the number of entries removed."""
+    root = get_fulltext_cache_root(config_path)
+    with _INDEX_LOCK:
+        index = _load_index_unlocked(root)
+        removed = len(index["entries"])
+        for orphan in root.glob("*.txt"):
+            orphan.unlink(missing_ok=True)
+        _index_path(root).unlink(missing_ok=True)
+    return removed

--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -11,10 +11,13 @@ import os
 import platform
 import re
 import sqlite3
+from collections.abc import Iterator
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, NamedTuple
 
+from . import fulltext_cache
 from .config import load_config
 from .extract import (
     categorize_attachment,
@@ -174,6 +177,43 @@ class ZoteroItem:
         return "\n\n".join(parts)
 
 
+def _source_for_path(path: Path) -> str:
+    """The ``fulltextSource`` tag recorded for text extracted from ``path``."""
+    suffix = path.suffix.lower()
+    if suffix == ".pdf":
+        return "pdf"
+    if suffix in {".html", ".htm"}:
+        return "html"
+    return "file"
+
+
+def _init_extraction_worker() -> None:
+    """Silence extraction warnings inside a pool worker.
+
+    ``semantic_search`` raises the ``zotero_mcp.extract`` logger to CRITICAL
+    for the duration of an indexing run, because a warning printed mid-scan
+    corrupts the progress line. That setting lives in the parent interpreter
+    and means nothing to a worker process, so without this initializer
+    parallel extraction would print warnings that sequential extraction hides
+    — and roughly 0.4% of real-world PDFs fail to parse, so it is not rare.
+    """
+    logging.getLogger("zotero_mcp.extract").setLevel(logging.CRITICAL)
+    logging.getLogger("pdfminer").setLevel(logging.ERROR)
+
+
+def _extract_worker(path_str: str, max_pages: int) -> str:
+    """Parse one attachment. Runs in a pool worker, so it must be top-level.
+
+    Returns "" rather than raising: a corrupt PDF is ordinary in a real
+    library, and one bad file must not take down a pool worker.
+    """
+    try:
+        doc = extract_file(Path(path_str), max_pages=max_pages)
+        return doc.text if doc else ""
+    except Exception:
+        return ""
+
+
 class LocalZoteroReader:
     """
     Direct SQLite reader for Zotero's local database.
@@ -182,11 +222,21 @@ class LocalZoteroReader:
     without going through the Zotero API.
     """
 
+    # Class-level fallbacks so subclasses that bypass __init__ (test stubs do
+    # this) still work — with the transient fulltext cache OFF, so they can
+    # never write into the user's real cache directory.
+    extraction_workers: int = 1
+    fulltext_cache_enabled: bool = False
+    config_path: str | None = None
+
     def __init__(
         self,
         db_path: str | None = None,
         pdf_max_pages: int | None = None,
         attachment_priority=None,
+        extraction_workers: int = 1,
+        fulltext_cache_enabled: bool = False,
+        config_path: str | None = None,
     ):
         """
         Initialize the local database reader.
@@ -197,6 +247,19 @@ class LocalZoteroReader:
             attachment_priority: Order in which attachment kinds are tried
                 for an item with several readable files. None means the
                 default (PDF > HTML > rest).
+            extraction_workers: How many PDFs :meth:`extract_fulltext_for_items`
+                may parse at once. 1 (the default) keeps the historical fully
+                sequential behaviour. Higher values fan out over a process
+                pool — processes rather than threads because pdf-inspector
+                holds the GIL while parsing, so threads scale at ~1.1x while
+                processes reach ~6x.
+            fulltext_cache_enabled: Whether to read/write the transient
+                plain-text cache (see the :mod:`.fulltext_cache` module).
+                Off by default: callers that extract under a *different* page
+                cap than indexing uses (``zotero_get_item_fulltext`` does)
+                would otherwise poison the cache with truncated text.
+            config_path: Semantic-search config path, used only to locate the
+                fulltext cache directory next to it.
         """
         self.db_path = db_path or self._find_zotero_db()
         self._connection: sqlite3.Connection | None = None
@@ -204,6 +267,9 @@ class LocalZoteroReader:
         self.attachment_priority: tuple[str, ...] = normalize_attachment_priority(
             attachment_priority
         )
+        self.extraction_workers: int = max(1, int(extraction_workers or 1))
+        self.fulltext_cache_enabled: bool = fulltext_cache_enabled
+        self.config_path: str | None = config_path
 
     def _find_zotero_db(self) -> str:
         """
@@ -470,7 +536,123 @@ class LocalZoteroReader:
         # rather than a stub or thumbnail.
         return max(candidates, key=lambda p: p.stat().st_size)
 
-    def _extract_fulltext_for_item(self, item_id: int) -> tuple[str, str] | None:
+    def _resolve_extraction_target(self, item_id: int) -> tuple[Path, str] | None:
+        """Pick the attachment to extract for an item, by configured priority.
+
+        Returns ``(path, attachment_key)``, or None when the item has nothing
+        readable. Deliberately cheap — sqlite plus one ``stat()`` per
+        attachment, no parsing. That is what lets
+        :meth:`extract_fulltext_for_items` resolve every target in the parent
+        process (which owns the sqlite connection) and hand workers nothing
+        but a path.
+        """
+        candidates = []
+        keys: dict[Path, str] = {}
+        for key, path, ctype in self._iter_parent_attachments(item_id):
+            resolved = self._resolve_attachment_path(key, path or "")
+            if not resolved or not resolved.exists():
+                # Filename drift fallback: scan the storage folder.
+                resolved = self._scan_storage_for_attachment(key, ctype)
+                if not resolved or not resolved.exists():
+                    continue
+            category = categorize_attachment(resolved, ctype)
+            if category is None:
+                continue
+            try:
+                size = resolved.stat().st_size
+            except OSError:
+                size = 0
+            candidates.append((category, size, resolved))
+            keys.setdefault(resolved, key)
+
+        target = pick_by_priority(candidates, self.attachment_priority)
+        if target is None:
+            return None
+        return target, keys.get(target, "")
+
+    def _cache_profile(self) -> str:
+        """Extraction settings that change the text produced for one file.
+
+        Only the page cap qualifies. ``attachment_priority`` does not: the
+        cache is keyed by *attachment*, so changing the priority resolves to
+        a different attachment and misses on its own.
+        """
+        return f"maxpages={self._resolve_pdf_max_pages()}"
+
+    def _cache_lookup(self, target: Path, attachment_key: str) -> tuple[str, str] | None:
+        """Transient-cache hit for an unchanged attachment, or None."""
+        if not self.fulltext_cache_enabled or not attachment_key:
+            return None
+        try:
+            st = target.stat()
+        except OSError:
+            return None
+        return fulltext_cache.get_cached_text(
+            attachment_key,
+            st.st_mtime_ns,
+            st.st_size,
+            profile=self._cache_profile(),
+            config_path=self.config_path,
+        )
+
+    def _cache_store(
+        self,
+        target: Path,
+        attachment_key: str,
+        item_key: str | None,
+        text: str,
+        source: str,
+    ) -> None:
+        """Persist freshly extracted text so a failed embed doesn't lose it."""
+        if not self.fulltext_cache_enabled or not attachment_key:
+            return
+        try:
+            st = target.stat()
+        except OSError:
+            return
+        try:
+            fulltext_cache.put_cached_text(
+                attachment_key,
+                st.st_mtime_ns,
+                st.st_size,
+                source=source,
+                item_key=item_key,
+                text=text,
+                path=str(target),
+                profile=self._cache_profile(),
+                config_path=self.config_path,
+            )
+        except Exception as e:  # never let caching break extraction
+            logger.debug(f"Could not cache fulltext for {attachment_key}: {e}")
+
+    def _zotero_ft_cache_fallback(
+        self,
+        item_id: int,
+        chosen: tuple[Path, str] | None = None,
+        item_key: str | None = None,
+    ) -> tuple[str, str] | None:
+        """Read Zotero's own ``.zotero-ft-cache`` for whatever we could not parse.
+
+        When ``chosen`` is given, the result is written to the transient cache
+        against that attachment. This matters more than it looks: an
+        image-only PDF parses to an empty string, so without it every run
+        re-parses the file just to rediscover there is nothing in it — and
+        the files that behave this way are scanned books, the slowest things
+        in a library to parse. Keying on the chosen attachment keeps the
+        entry invalidating normally when the file changes.
+        """
+        for key, _path, _ctype in self._iter_parent_attachments(item_id):
+            cached = self._read_zotero_ft_cache(key)
+            if cached:
+                result = (cached, "zotero-cache")
+                if chosen:
+                    self._cache_store(chosen[0], chosen[1], item_key, cached, "zotero-cache")
+                return result
+        return None
+
+    def _extract_fulltext_for_item(
+        self, item_id: int, item_key: str | None = None
+    ) -> tuple[str, str] | None:
         """Attempt to extract fulltext and source from the item's best attachment.
 
         Preference order:
@@ -490,42 +672,22 @@ class LocalZoteroReader:
         attachment's storage folder for a content-type-matching file before
         giving up (#291, #265).
         """
-        candidates = []
-        for key, path, ctype in self._iter_parent_attachments(item_id):
-            resolved = self._resolve_attachment_path(key, path or "")
-            if not resolved or not resolved.exists():
-                # Filename drift fallback: scan the storage folder.
-                resolved = self._scan_storage_for_attachment(key, ctype)
-                if not resolved or not resolved.exists():
-                    continue
-            category = categorize_attachment(resolved, ctype)
-            if category is None:
-                continue
-            try:
-                size = resolved.stat().st_size
-            except OSError:
-                size = 0
-            candidates.append((category, size, resolved))
+        chosen = self._resolve_extraction_target(item_id)
 
         # 1. Best attachment by the configured priority.
-        target = pick_by_priority(candidates, self.attachment_priority)
-        if target:
+        if chosen:
+            target, attachment_key = chosen
+            hit = self._cache_lookup(target, attachment_key)
+            if hit:
+                return hit
             text = self._extract_text_from_file(target)
             if text:
-                suffix = target.suffix.lower()
-                if suffix == ".pdf":
-                    source = "pdf"
-                elif suffix in {".html", ".htm"}:
-                    source = "html"
-                else:
-                    source = "file"
+                source = _source_for_path(target)
+                self._cache_store(target, attachment_key, item_key, text, source)
                 return (text, source)
 
         # 2. Zotero's own cache, for whatever step 1 could not read.
-        for key, _path, _ctype in self._iter_parent_attachments(item_id):
-            cached = self._read_zotero_ft_cache(key)
-            if cached:
-                return (cached, "zotero-cache")
+        return self._zotero_ft_cache_fallback(item_id, chosen, item_key)
 
         return None
 
@@ -854,8 +1016,79 @@ class LocalZoteroReader:
         return self._get_fulltext_meta_for_item(item_id)
 
     # Public helper to extract fulltext on demand for a specific item
-    def extract_fulltext_for_item(self, item_id: int) -> tuple[str, str] | None:
-        return self._extract_fulltext_for_item(item_id)
+    def extract_fulltext_for_item(
+        self, item_id: int, item_key: str | None = None
+    ) -> tuple[str, str] | None:
+        return self._extract_fulltext_for_item(item_id, item_key)
+
+    def extract_fulltext_for_items(
+        self, items: list[tuple[int, str | None]]
+    ) -> Iterator[tuple[int, tuple[str, str] | None]]:
+        """Extract fulltext for many items, fanning out over ``extraction_workers``.
+
+        Yields ``(item_id, (text, source) | None)`` as results arrive, so a
+        caller can report progress and evict cache entries incrementally
+        rather than waiting for the whole batch. Order is *not* the input
+        order once workers > 1.
+
+        The division of labour is what makes this safe: everything touching
+        sqlite, the filesystem index or the fulltext cache stays in this
+        process, and workers receive only ``(path, max_pages)``. The sqlite
+        connection is never shared, and nothing needs to be picklable except
+        two strings and an int.
+
+        With ``extraction_workers > 1`` this starts a process pool, so on
+        platforms that spawn rather than fork (macOS, Windows) it must be
+        called from inside a function or under an ``if __name__ ==
+        "__main__"`` guard — never at module import time. Every shipped
+        caller reaches it through a CLI command, so this only constrains
+        embedding it in a script.
+        """
+        if self.extraction_workers <= 1:
+            for item_id, item_key in items:
+                yield item_id, self._extract_fulltext_for_item(item_id, item_key)
+            return
+
+        max_pages = self._resolve_pdf_max_pages()
+        pending: dict[Any, tuple[int, str | None, Path, str]] = {}
+        # Resolve targets and serve cache hits up front — both are cheap, and
+        # doing them here keeps the pool busy with parsing alone.
+        deferred: list[tuple[int, str | None, tuple[Path, str] | None]] = []
+        with ProcessPoolExecutor(
+            max_workers=self.extraction_workers, initializer=_init_extraction_worker
+        ) as pool:
+            for item_id, item_key in items:
+                chosen = self._resolve_extraction_target(item_id)
+                if not chosen:
+                    deferred.append((item_id, item_key, None))
+                    continue
+                target, attachment_key = chosen
+                hit = self._cache_lookup(target, attachment_key)
+                if hit:
+                    yield item_id, hit
+                    continue
+                future = pool.submit(_extract_worker, str(target), max_pages)
+                pending[future] = (item_id, item_key, target, attachment_key)
+
+            for future in as_completed(pending):
+                item_id, item_key, target, attachment_key = pending[future]
+                try:
+                    text = future.result()
+                except Exception as e:  # worker died; fall back below
+                    logger.debug(f"Extraction worker failed for item {item_id}: {e}")
+                    text = ""
+                if text:
+                    source = _source_for_path(target)
+                    self._cache_store(target, attachment_key, item_key, text, source)
+                    yield item_id, (text, source)
+                else:
+                    deferred.append((item_id, item_key, (target, attachment_key)))
+
+        # Whatever the parser could not read falls back to Zotero's own
+        # .zotero-ft-cache, exactly as the sequential path does. Cheap file
+        # reads, so there is nothing to gain from parallelising them.
+        for item_id, item_key, chosen in deferred:
+            yield item_id, self._zotero_ft_cache_fallback(item_id, chosen, item_key)
 
     def get_attachment_paths(self, parent_key: str) -> list[dict]:
         """Return resolved filesystem paths for a parent item's attachments.

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -26,7 +26,7 @@ except Exception:
     _tokenizer = None
 
 
-from . import openai_batch
+from . import fulltext_cache, openai_batch
 from .chroma_client import ChromaClient, create_chroma_client
 from .client import get_active_group_id, get_zotero_client
 from .extract import PAGE_SEPARATOR
@@ -166,6 +166,23 @@ _INDEX_SCHEMA_VERSION = 3
 # the next re-embed.
 _MASS_DELETION_MIN_DOCS = 25
 _MASS_DELETION_MIN_FRACTION = 0.25
+
+
+def _extract_fulltext_batch(reader, items):
+    """Yield ``(item_id, (text, source) | None)`` for every item in ``items``.
+
+    Prefers the reader's batch API, which parallelises across a process pool
+    when configured. Falls back to one call per item for readers that do not
+    provide it — the minimal doubles used in tests implement only
+    ``extract_fulltext_for_item(item_id)``, and they should not have to grow
+    a new method just because the real reader gained a faster path.
+    """
+    batch = getattr(reader, "extract_fulltext_for_items", None)
+    if batch is not None:
+        yield from batch(items)
+        return
+    for item_id, _item_key in items:
+        yield item_id, reader.extract_fulltext_for_item(item_id)
 
 
 def load_update_config(config_path: str | None) -> dict[str, Any]:
@@ -441,8 +458,16 @@ def get_cached_reranker(model_name: str) -> CrossEncoderReranker:
 class ZoteroSemanticSearch:
     """Semantic search interface for Zotero libraries using ChromaDB."""
 
+    # Class-level fallback so instances built without __init__ (test doubles
+    # do this) still resolve the attribute — None means "use the config".
+    extraction_workers: int | None = None
+
     def __init__(
-        self, chroma_client: ChromaClient | None = None, config_path: str | None = None, db_path: str | None = None
+        self,
+        chroma_client: ChromaClient | None = None,
+        config_path: str | None = None,
+        db_path: str | None = None,
+        extraction_workers: int | None = None,
     ):
         """
         Initialize semantic search.
@@ -451,11 +476,14 @@ class ZoteroSemanticSearch:
             chroma_client: Optional ChromaClient instance
             config_path: Path to configuration file
             db_path: Optional path to Zotero database (overrides config file)
+            extraction_workers: Optional parallel-extraction worker count
+                (overrides ``semantic_search.extraction.workers`` in config)
         """
         self.chroma_client = chroma_client or create_chroma_client(config_path)
         self.zotero_client = get_zotero_client()
         self.config_path = config_path
         self.db_path = db_path  # CLI override for Zotero database path
+        self.extraction_workers = extraction_workers  # CLI override, None = use config
         # Item keys seen by the most recent local sqlite scan (set by
         # _get_items_from_local_db); used to verify watermark promotion.
         self._last_scan_snapshot_keys: set[str] | None = None
@@ -1146,6 +1174,7 @@ class ZoteroSemanticSearch:
             attachment_priority = None
             zotero_db_path = self.db_path  # CLI override takes precedence
             collection_keys = None
+            config_workers = None
             # If semantic_search config file exists, prefer its setting
             try:
                 if self.config_path and os.path.exists(self.config_path):
@@ -1155,6 +1184,7 @@ class ZoteroSemanticSearch:
                         extraction_cfg = semantic_cfg.get("extraction", {})
                         pdf_max_pages = extraction_cfg.get("pdf_max_pages")
                         attachment_priority = extraction_cfg.get("attachment_priority")
+                        config_workers = extraction_cfg.get("workers")
                         collection_keys = semantic_cfg.get("collection_keys")
                         # Use config db_path only if no CLI override
                         if not zotero_db_path:
@@ -1162,12 +1192,24 @@ class ZoteroSemanticSearch:
             except Exception:
                 pass
 
+            # CLI flag beats config; 1 (fully sequential) when neither is set.
+            # Never exceed the core count — extraction is CPU-bound, so extra
+            # workers only add process-spawn and scheduling overhead.
+            workers = self.extraction_workers or config_workers or 1
+            workers = max(1, min(int(workers), os.cpu_count() or 1))
+
             with (
                 suppress_stdout(),
                 LocalZoteroReader(
                     db_path=zotero_db_path,
                     pdf_max_pages=pdf_max_pages,
                     attachment_priority=attachment_priority,
+                    extraction_workers=workers,
+                    # The indexing path is the one place the transient cache
+                    # is safe to write: it extracts under the *indexing* page
+                    # cap, which is what a later run will want to reuse.
+                    fulltext_cache_enabled=True,
+                    config_path=self.config_path,
                 ) as reader,
             ):
                 # Stamped on every document so a later run can tell that the
@@ -1268,6 +1310,10 @@ class ZoteroSemanticSearch:
                     skipped_existing = 0
                     updated_existing = 0
                     items_to_process = []
+                    # Items whose attachment still needs parsing. Collected
+                    # here rather than parsed inline so the expensive half can
+                    # run as one batch — see the phase 2b loop below.
+                    pending_extraction = []
 
                     total_local = len(local_items)
                     _skipped_failed = []  # Items skipped because extraction previously failed
@@ -1394,19 +1440,41 @@ class ZoteroSemanticSearch:
                                     skipped_existing += 1
 
                         if should_extract:
-                            # Extract fulltext if item doesn't have it yet
+                            # Defer the parse itself — see phase 2b.
                             if not getattr(it, "fulltext", None):
-                                text = reader.extract_fulltext_for_item(it.item_id)
-                                if text:
-                                    it.fulltext, it.fulltext_source = text
-                                else:
-                                    # Nothing readable — mark so the metadata
-                                    # records that we did try.
-                                    it._fulltext_attempted = True
+                                pending_extraction.append(it)
                             extracted += 1
                             items_to_process.append(it)
 
                             # (progress shown inline above via \r)
+
+                    # Phase 2b: parse the chosen attachments. With
+                    # extraction_workers == 1 this is the same sequential walk
+                    # as before; above 1 it fans out over a process pool, and
+                    # results arrive out of order — hence the lookup by id.
+                    if pending_extraction:
+                        by_id = {it.item_id: it for it in pending_extraction}
+                        done = 0
+                        for item_id, result in _extract_fulltext_batch(
+                            reader, [(it.item_id, it.key) for it in pending_extraction]
+                        ):
+                            target = by_id.get(item_id)
+                            if target is None:
+                                continue
+                            if result:
+                                target.fulltext, target.fulltext_source = result
+                            else:
+                                # Nothing readable — mark so the metadata
+                                # records that we did try.
+                                target._fulltext_attempted = True
+                            done += 1
+                            if done % 10 == 0 or done == len(pending_extraction):
+                                try:
+                                    line = f"  Extracting text: {done}/{len(pending_extraction)}"
+                                    sys.stderr.write(f"\r{line}{' ' * 40}")
+                                    sys.stderr.flush()
+                                except Exception:
+                                    pass
 
                     _extract_logger.setLevel(_prev_level)
 
@@ -2533,6 +2601,15 @@ class ZoteroSemanticSearch:
                         stats["updated"] += 1
                     else:
                         stats["added"] += 1
+                # These items are embedded and persisted, so the transient
+                # copy of their extracted text has done its job. Evicting per
+                # batch rather than at the end of the run keeps the cache
+                # roughly proportional to what is still un-embedded, instead
+                # of growing to the size of the whole library.
+                try:
+                    fulltext_cache.evict_many(item_keys_order, config_path=self.config_path)
+                except Exception as e:
+                    logger.debug(f"Fulltext cache eviction failed: {e}")
             except Exception as e:
                 # Batch failed — collect failures for end-of-run retry.
                 # ChromaDB's ONNX tokenizer can fail intermittently in bursts;
@@ -2904,15 +2981,23 @@ class ZoteroSemanticSearch:
             return False
 
 
-def create_semantic_search(config_path: str | None = None, db_path: str | None = None) -> ZoteroSemanticSearch:
+def create_semantic_search(
+    config_path: str | None = None,
+    db_path: str | None = None,
+    extraction_workers: int | None = None,
+) -> ZoteroSemanticSearch:
     """
     Create a ZoteroSemanticSearch instance.
 
     Args:
         config_path: Path to configuration file
         db_path: Optional path to Zotero database (overrides config file)
+        extraction_workers: Optional parallel-extraction worker count
+            (overrides the value in the config file)
 
     Returns:
         Configured ZoteroSemanticSearch instance
     """
-    return ZoteroSemanticSearch(config_path=config_path, db_path=db_path)
+    return ZoteroSemanticSearch(
+        config_path=config_path, db_path=db_path, extraction_workers=extraction_workers
+    )

--- a/src/zotero_mcp/setup_helper.py
+++ b/src/zotero_mcp/setup_helper.py
@@ -409,6 +409,27 @@ def setup_semantic_search(
         except ValueError:
             print("Please enter a valid number")
 
+    print("\nAttachment parsing can run across several CPU cores.")
+    print("1 keeps the classic sequential behaviour; higher values speed up")
+    print("the extraction phase of 'update-db --fulltext' on large libraries.")
+    default_workers = (
+        existing_semantic_config.get("extraction", {}).get("workers", 1)
+        if existing_semantic_config
+        else 1
+    )
+    while True:
+        raw = input(f"Parallel extraction workers [{default_workers}]: ").strip()
+        if raw == "":
+            extraction_workers = default_workers
+            break
+        try:
+            extraction_workers = int(raw)
+            if extraction_workers > 0:
+                break
+            print("Please enter a positive integer")
+        except ValueError:
+            print("Please enter a valid number")
+
     # Configure Zotero database path
     print("\n=== Zotero Database Path ===")
     print("By default, zotero-mcp auto-detects the Zotero database location.")
@@ -441,6 +462,7 @@ def setup_semantic_search(
         (existing_semantic_config or {}).get("extraction") or {}
     )
     extraction_config["pdf_max_pages"] = pdf_max_pages
+    extraction_config["workers"] = extraction_workers
     config["extraction"] = extraction_config
     # Web-API users: index fulltext from Zotero's server-side extraction by
     # default. Users can set this to false to keep the old metadata-only

--- a/tests/test_fulltext_cache.py
+++ b/tests/test_fulltext_cache.py
@@ -1,0 +1,129 @@
+"""Tests for the transient extracted-fulltext cache."""
+
+import json
+
+import pytest
+
+from zotero_mcp import fulltext_cache
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    """A config path whose sibling fulltext_cache/ dir is this test's own."""
+    return str(tmp_path / "config.json")
+
+
+def _put(cfg, key="ATT1", mtime=111, size=22, text="hello", item_key="ITEM1", **kw):
+    fulltext_cache.put_cached_text(
+        key, mtime, size, source=kw.pop("source", "pdf"), item_key=item_key,
+        text=text, config_path=cfg, **kw,
+    )
+
+
+def test_miss_before_anything_is_cached(cfg):
+    assert fulltext_cache.get_cached_text("ATT1", 111, 22, config_path=cfg) is None
+
+
+def test_round_trip_returns_text_and_source(cfg):
+    _put(cfg, text="extracted body", source="pdf")
+    assert fulltext_cache.get_cached_text("ATT1", 111, 22, config_path=cfg) == (
+        "extracted body",
+        "pdf",
+    )
+
+
+def test_changed_mtime_or_size_misses(cfg):
+    """A replaced attachment must never serve the previous file's text."""
+    _put(cfg)
+    assert fulltext_cache.get_cached_text("ATT1", 999, 22, config_path=cfg) is None
+    assert fulltext_cache.get_cached_text("ATT1", 111, 999, config_path=cfg) is None
+
+
+def test_profile_mismatch_misses(cfg):
+    """Lowering pdf_max_pages must not serve text extracted under a higher cap."""
+    _put(cfg, profile="maxpages=50")
+    assert fulltext_cache.get_cached_text(
+        "ATT1", 111, 22, profile="maxpages=10", config_path=cfg
+    ) is None
+    assert fulltext_cache.get_cached_text(
+        "ATT1", 111, 22, profile="maxpages=50", config_path=cfg
+    ) == ("hello", "pdf")
+
+
+def test_superseded_text_file_is_removed(cfg):
+    """Re-caching the same attachment must not leave the old .txt behind."""
+    _put(cfg, mtime=111, text="old")
+    _put(cfg, mtime=222, text="new")
+    root = fulltext_cache.get_fulltext_cache_root(cfg)
+    assert len(list(root.glob("*.txt"))) == 1
+    assert fulltext_cache.get_cached_text("ATT1", 222, 22, config_path=cfg)[0] == "new"
+
+
+def test_eviction_removes_every_entry_for_an_item(cfg):
+    """Eviction is by item key — an item may own several attachments."""
+    _put(cfg, key="ATT1", item_key="ITEM1")
+    _put(cfg, key="ATT2", item_key="ITEM1")
+    _put(cfg, key="ATT3", item_key="OTHER")
+    assert fulltext_cache.evict("ITEM1", config_path=cfg) == 2
+    assert fulltext_cache.get_cached_text("ATT1", 111, 22, config_path=cfg) is None
+    assert fulltext_cache.get_cached_text("ATT3", 111, 22, config_path=cfg) is not None
+
+
+def test_evict_many_ignores_unknown_and_empty_keys(cfg):
+    _put(cfg, item_key="ITEM1")
+    assert fulltext_cache.evict_many([], config_path=cfg) == 0
+    assert fulltext_cache.evict_many(["", None], config_path=cfg) == 0
+    assert fulltext_cache.evict_many(["NOPE"], config_path=cfg) == 0
+    assert fulltext_cache.get_cached_text("ATT1", 111, 22, config_path=cfg) is not None
+
+
+def test_purge_drops_entries_whose_file_is_gone(cfg, tmp_path):
+    backing = tmp_path / "present.pdf"
+    backing.write_bytes(b"%PDF-1.4")
+    _put(cfg, key="KEEP", path=str(backing))
+    _put(cfg, key="GONE", path=str(tmp_path / "missing.pdf"))
+    assert fulltext_cache.purge_stale(config_path=cfg) == 1
+    assert fulltext_cache.get_cached_text("KEEP", 111, 22, config_path=cfg) is not None
+    assert fulltext_cache.get_cached_text("GONE", 111, 22, config_path=cfg) is None
+
+
+def test_purge_sweeps_orphaned_text_files(cfg):
+    """A .txt with no index entry is residue from an interrupted run."""
+    root = fulltext_cache.get_fulltext_cache_root(cfg)
+    (root / "deadbeef.txt").write_text("orphan", encoding="utf-8")
+    _put(cfg)
+    fulltext_cache.purge_stale(config_path=cfg)
+    assert not (root / "deadbeef.txt").exists()
+    assert fulltext_cache.get_cached_text("ATT1", 111, 22, config_path=cfg) is not None
+
+
+def test_clear_all_empties_the_cache(cfg):
+    _put(cfg, key="ATT1")
+    _put(cfg, key="ATT2")
+    assert fulltext_cache.clear_all(config_path=cfg) == 2
+    root = fulltext_cache.get_fulltext_cache_root(cfg)
+    assert list(root.glob("*.txt")) == []
+    assert fulltext_cache.get_cached_text("ATT1", 111, 22, config_path=cfg) is None
+
+
+def test_corrupt_index_is_survivable(cfg):
+    """A truncated index.json must degrade to a miss, not raise."""
+    _put(cfg)
+    root = fulltext_cache.get_fulltext_cache_root(cfg)
+    (root / "index.json").write_text("{not json", encoding="utf-8")
+    assert fulltext_cache.get_cached_text("ATT1", 111, 22, config_path=cfg) is None
+    _put(cfg, text="recovered")
+    assert fulltext_cache.get_cached_text("ATT1", 111, 22, config_path=cfg)[0] == "recovered"
+
+
+def test_cache_root_is_private(cfg):
+    """Cached text is library content and must not be world-readable."""
+    root = fulltext_cache.get_fulltext_cache_root(cfg)
+    assert (root.stat().st_mode & 0o077) == 0
+
+
+def test_index_records_item_key_for_eviction(cfg):
+    _put(cfg, item_key="ITEM42")
+    root = fulltext_cache.get_fulltext_cache_root(cfg)
+    index = json.loads((root / "index.json").read_text(encoding="utf-8"))
+    assert index["entries"]["ATT1"]["item_key"] == "ITEM42"

--- a/tests/test_fulltext_cache.py
+++ b/tests/test_fulltext_cache.py
@@ -1,6 +1,7 @@
 """Tests for the transient extracted-fulltext cache."""
 
 import json
+import os
 
 import pytest
 
@@ -117,7 +118,16 @@ def test_corrupt_index_is_survivable(cfg):
 
 
 def test_cache_root_is_private(cfg):
-    """Cached text is library content and must not be world-readable."""
+    """Cached text is library content and must not be world-readable.
+
+    POSIX-only: Windows implements no mode bits beyond the read-only flag, so
+    ``os.chmod(path, 0o700)`` succeeds there but ``st_mode`` still reports
+    0o777 for the directory. The hardening itself is best-effort on every
+    platform (``_private_chmod`` swallows OSError); only the assertion is
+    POSIX-specific.
+    """
+    if os.name != "posix":
+        pytest.skip("POSIX file permissions only")
     root = fulltext_cache.get_fulltext_cache_root(cfg)
     assert (root.stat().st_mode & 0o077) == 0
 

--- a/tests/test_multicore_extraction.py
+++ b/tests/test_multicore_extraction.py
@@ -1,0 +1,195 @@
+"""Tests for parallel attachment extraction.
+
+Extraction fans out over a *process* pool rather than a thread pool: the
+pdf-inspector parser holds the GIL, so threads scale at roughly 1.1x while
+processes reach ~6x. These tests use plain .txt attachments — the extractor
+handles them through the same ``extract_file`` seam as PDFs, and they keep the
+suite free of binary fixtures.
+"""
+
+import logging
+import os
+
+import pytest
+
+from zotero_mcp import fulltext_cache
+from zotero_mcp.local_db import (
+    LocalZoteroReader,
+    _extract_worker,
+    _init_extraction_worker,
+    _source_for_path,
+)
+
+
+class FakeReader(LocalZoteroReader):
+    """Reader over a directory of files, with no sqlite behind it."""
+
+    def __init__(self, files, cfg=None, workers=1, ft_cache=False):
+        # Deliberately does not call super().__init__ — there is no database.
+        self._files = dict(enumerate(files, start=1))
+        self._connection = None
+        self.db_path = None
+        self.pdf_max_pages = 50
+        self.attachment_priority = ("pdf", "html", "other")
+        self.extraction_workers = workers
+        self.fulltext_cache_enabled = ft_cache
+        self.config_path = cfg
+        self.zotero_ft_cache = {}
+
+    def _resolve_extraction_target(self, item_id):
+        path = self._files.get(item_id)
+        return (path, f"ATT{item_id}") if path else None
+
+    def _iter_parent_attachments(self, item_id):
+        return [(f"ATT{item_id}", None, "text/plain")]
+
+    def _read_zotero_ft_cache(self, attachment_key):
+        return self.zotero_ft_cache.get(attachment_key)
+
+
+@pytest.fixture
+def files(tmp_path):
+    out = []
+    for i in range(12):
+        p = tmp_path / f"doc{i}.txt"
+        p.write_text(f"contents of document {i}\n" * 20, encoding="utf-8")
+        out.append(p)
+    return out
+
+
+def test_worker_extracts_text(tmp_path):
+    p = tmp_path / "a.txt"
+    p.write_text("some words", encoding="utf-8")
+    assert "some words" in _extract_worker(str(p), 50)
+
+
+def test_worker_returns_empty_instead_of_raising(tmp_path):
+    """One unreadable file must never take down a pool worker."""
+    missing = tmp_path / "nope.txt"
+    assert _extract_worker(str(missing), 50) == ""
+    binary = tmp_path / "broken.pdf"
+    binary.write_bytes(b"\x00\x01not a pdf at all")
+    assert _extract_worker(str(binary), 50) == ""
+
+
+def test_worker_initializer_silences_extraction_warnings():
+    """Log suppression is parent-process state; workers must re-apply it.
+
+    Without this, parallel runs print extraction warnings that the sequential
+    path hides — and roughly 0.4% of real-world PDFs fail to parse.
+    """
+    log = logging.getLogger("zotero_mcp.extract")
+    previous = log.level
+    try:
+        log.setLevel(logging.DEBUG)
+        _init_extraction_worker()
+        assert log.level == logging.CRITICAL
+    finally:
+        log.setLevel(previous)
+
+
+def test_source_is_derived_from_suffix(tmp_path):
+    assert _source_for_path(tmp_path / "a.pdf") == "pdf"
+    assert _source_for_path(tmp_path / "a.HTML") == "html"
+    assert _source_for_path(tmp_path / "a.txt") == "file"
+
+
+def test_parallel_matches_sequential(files):
+    """The whole point: more workers must not change what gets indexed."""
+    items = [(i, f"KEY{i}") for i in range(1, len(files) + 1)]
+    sequential = dict(FakeReader(files, workers=1).extract_fulltext_for_items(items))
+    parallel = dict(FakeReader(files, workers=3).extract_fulltext_for_items(items))
+    assert sequential == parallel
+    assert len(parallel) == len(files)
+    assert all(v is not None for v in parallel.values())
+
+
+def test_every_item_is_reported_even_when_unreadable(files, tmp_path):
+    """Callers rely on one result per input to mark extraction as attempted."""
+    files = [*files, tmp_path / "does-not-exist.txt"]
+    items = [(i, f"KEY{i}") for i in range(1, len(files) + 1)]
+    got = dict(FakeReader(files, workers=3).extract_fulltext_for_items(items))
+    assert set(got) == {i for i, _ in items}
+    assert got[len(files)] is None
+
+
+def test_falls_back_to_zotero_ft_cache(files):
+    """An attachment that parses to nothing still yields Zotero's own cache."""
+    reader = FakeReader(files, workers=2)
+    empty = files[0].parent / "empty.txt"
+    empty.write_text("", encoding="utf-8")
+    reader._files[1] = empty
+    reader.zotero_ft_cache["ATT1"] = "text from zotero"
+    got = dict(reader.extract_fulltext_for_items([(1, "KEY1")]))
+    assert got[1] == ("text from zotero", "zotero-cache")
+
+
+@pytest.mark.parametrize("workers", [1, 3])
+def test_results_are_cached_and_reused(files, tmp_path, workers):
+    """A second pass must serve cached text instead of re-parsing.
+
+    Proven by rewriting each file's contents while restoring its mtime and
+    byte count: the cache key still matches, so a hit returns the *original*
+    text, while a re-parse would return the replacement.
+    """
+    cfg = str(tmp_path / "config.json")
+    items = [(i, f"KEY{i}") for i in range(1, len(files) + 1)]
+    reader = FakeReader(files, cfg=cfg, workers=workers, ft_cache=True)
+    first = dict(reader.extract_fulltext_for_items(items))
+
+    root = fulltext_cache.get_fulltext_cache_root(cfg)
+    assert len(list(root.glob("*.txt"))) == len(files)
+
+    for f in files:
+        st = f.stat()
+        f.write_text("X" * st.st_size, encoding="utf-8")
+        os.utime(f, ns=(st.st_atime_ns, st.st_mtime_ns))
+    assert dict(reader.extract_fulltext_for_items(items)) == first
+
+    # ...and once evicted, the replacement text is what comes back.
+    fulltext_cache.evict_many([k for _, k in items], config_path=cfg)
+    second = dict(reader.extract_fulltext_for_items(items))
+    assert second != first
+    assert all(v[0].startswith("X") for v in second.values())
+
+
+def test_unparseable_fallback_is_cached_too(files, tmp_path):
+    """Image-only PDFs parse to nothing and are the slowest files to re-parse.
+
+    Caching the ft-cache fallback is what stops every run paying that cost
+    again just to rediscover the file is empty.
+    """
+    cfg = str(tmp_path / "config.json")
+    reader = FakeReader(files, cfg=cfg, workers=1, ft_cache=True)
+    empty = tmp_path / "scanned.txt"
+    empty.write_text("", encoding="utf-8")
+    reader._files[1] = empty
+    reader.zotero_ft_cache["ATT1"] = "ocr text"
+
+    assert dict(reader.extract_fulltext_for_items([(1, "KEY1")]))[1] == (
+        "ocr text",
+        "zotero-cache",
+    )
+    hit = fulltext_cache.get_cached_text(
+        "ATT1",
+        empty.stat().st_mtime_ns,
+        empty.stat().st_size,
+        profile=reader._cache_profile(),
+        config_path=cfg,
+    )
+    assert hit == ("ocr text", "zotero-cache")
+
+
+def test_cache_is_off_by_default(files, tmp_path):
+    """Callers extracting under a different page cap must not poison the cache."""
+    cfg = str(tmp_path / "config.json")
+    reader = FakeReader(files, cfg=cfg, workers=1)  # ft_cache defaults False
+    dict(reader.extract_fulltext_for_items([(1, "KEY1")]))
+    root = fulltext_cache.get_fulltext_cache_root(cfg)
+    assert list(root.glob("*.txt")) == []
+
+
+def test_worker_count_is_clamped_to_at_least_one():
+    reader = LocalZoteroReader.__new__(LocalZoteroReader)
+    assert LocalZoteroReader.extraction_workers == 1
+    assert reader.fulltext_cache_enabled is False

--- a/tests/test_openai_batch.py
+++ b/tests/test_openai_batch.py
@@ -123,6 +123,7 @@ def test_setup_openai_new_config_defaults_to_batch(monkeypatch):
         "",  # default batch choice: yes for new configs
         "1",  # manual updates
         "",  # default PDF max pages
+        "",  # default extraction workers
         "",  # auto-detect DB path
     ])
     monkeypatch.setattr(builtins, "input", lambda *args: next(answers))


### PR DESCRIPTION
# Parallel attachment extraction and a transient fulltext cache

Closes #390. First of four PRs splitting #397, as requested — this is the pair you said you most wanted. Rebased onto current `main` (0.9.1) rather than carried over from `feature/batch-semantic-search`; the branch's first commit bundles four features across 19 files, so nothing there was cherry-pickable.

**In this PR:** the transient fulltext cache, and parallel attachment extraction.
**Not in this PR:** the provider refactor, streaming/rate limiting, and Gemini Batch — those follow separately.

The test-collection blocker is gone: `consider_namespace_packages` is not here, and neither is `tests/live/`. The suite collects and passes on this branch (1680 passed, 25 new). Only one existing test changed — one line, noted at the bottom.

---

## First, something that changed under the original PR

You resolved #390 differently on `main` while #397 sat open. Extraction no longer shells out to a pdfminer subprocess per file; `extract.py` now calls pdf-inspector in-process. That invalidates the design in #397, which used a **thread** pool on the explicit assumption that "each PDF already runs in its own subprocess". It doesn't any more, and pdf-inspector holds the GIL while parsing, so that implementation would have shipped almost no benefit.

This PR uses processes instead. Measured on 1000 PDFs sampled at random from a 16,586-PDF library (1429 MB, 10 cores), through the production path `extract_file(p, max_pages=50)`, against the pinned pdf-inspector 0.2.6:

| strategy | time | per PDF | speedup |
| :--- | ---: | ---: | ---: |
| sequential | 147.7 s | 147.7 ms | 1.00× |
| threads ×8 | 131.1 s | 131.1 ms | 1.13× |
| processes ×4 | 37.7 s | 37.7 ms | 3.92× |
| processes ×8 | 25.0 s | 25.0 ms | 5.91× |
| processes ×10 | 24.0 s | 24.0 ms | 6.16× |

Extrapolated across that library, the extraction phase goes from **~41 minutes to ~7**.

The GIL diagnosis is measured, not inferred. A pure-Python counter thread running alongside pdf-inspector parsing gets **18.2%** of its solo throughput — against **50.3%** next to a known GIL-holder (a Python busy loop, which splits the lock evenly) and **99.1%** next to `time.sleep` (which releases it). Amdahl with 18% GIL-free time predicts 1.16×/1.19× for 4 and 8 threads; measured was 1.16×/1.17×.

Worth saying plainly: this is a ~6× improvement to one phase, not the "days to minutes" claim in #397. That framing described the old subprocess-per-PDF world and no longer holds.

---

## Parallel extraction

`LocalZoteroReader.extract_fulltext_for_items()` fans parsing out over a `ProcessPoolExecutor`, controlled by `--extraction-workers N` or `semantic_search.extraction.workers`.

**The default stays 1** — byte-for-byte the existing sequential path. Opting in is a deliberate choice rather than a behaviour change for every user; happy to make it default to something higher if you'd prefer, the numbers above support it.

The division of labour keeps the risky parts in one process: sqlite, attachment resolution and the cache all stay in the parent, and workers receive only `(path, max_pages)`. The sqlite connection is never shared and nothing crosses the process boundary but two strings and an int. Target resolution is deliberately cheap — sqlite plus one `stat()` per attachment — so the pool only ever does parsing.

Two details worth flagging for review:

- The pool takes an `initializer` that re-applies the `zotero_mcp.extract` logger suppression. That suppression is parent-process state and means nothing in a worker, so without it parallel runs print extraction warnings that sequential runs hide. It isn't hypothetical: ~0.4% of real-world PDFs fail to parse (corrupt structure, a JPEG named `.pdf`).
- `_extract_worker` returns `""` rather than raising, so one bad file can't take down a worker.

## Transient fulltext cache

Extracted text is persisted under the config directory, keyed by attachment key + mtime + size, so a replaced file can never serve stale text. The page cap is recorded in the entry's profile, so lowering `pdf_max_pages` misses rather than serving over-long text. Attachment priority deliberately isn't in the profile — entries are keyed per attachment, so a changed priority resolves to a different key and misses naturally.

Entries are evicted per batch as embeddings land in ChromaDB, so the cache tracks what is still un-embedded rather than growing to the size of the library. `purge_stale()` sweeps abandoned entries and orphaned text files; `--clear-fulltext-cache` discards everything.

**It is off by default** and only the indexing path opts in. `zotero_get_item_fulltext` extracts under a *display* page cap, and letting it write would poison the index's cache with truncated text.

One behaviour that isn't obvious but matters: the `.zotero-ft-cache` fallback is cached too. An image-only PDF parses to an empty string and falls through to Zotero's own cache — so without this, every run re-parses exactly the files that are slowest to parse, purely to rediscover they're empty. On a 40-item sample this took a warm re-run from 3.6 s to 0.05 s.

---

## Notes for review

**One existing test changed.** `test_setup_openai_new_config_defaults_to_batch` gains a single `""` in its positional answer list, because setup now asks about worker count alongside the existing page-cap question. Nothing else in the suite was touched.

**Test doubles shaped two decisions.** `FakeReader` in `test_failed_marker_retry.py` implements `extract_fulltext_for_item(item_id)` and nothing else, and several tests build `LocalZoteroReader` / `ZoteroSemanticSearch` without `__init__`. Rather than make the doubles grow methods to accommodate a faster path, the batch call goes through a small documented shim in `semantic_search.py` that falls back to per-item calls, and both classes carry class-level attribute defaults. Say the word if you'd rather the doubles were updated instead.

**Verification.** Beyond the suite, parallel output was checked to be identical to sequential across a real library — same text, same `fulltextSource`, for every item — and the cache was verified to serve reruns by rewriting file contents while restoring mtime and byte count, so a hit returns the original text and a re-parse would return the replacement.

`pytest-httpserver` and the `release.yml` dependency list you flagged aren't needed here; they belong with `tests/live/`, which arrives with the rate-limiting PR.
