### PR TITLE
refactor: move embedding functions into an embeddings provider package

### DIFF
--- a/src/zotero_mcp/chroma_client.py
+++ b/src/zotero_mcp/chroma_client.py
@@ -1,8 +1,14 @@
 """
 ChromaDB client for semantic search functionality.
 
-This module provides persistent vector database storage and embedding functions
-for semantic search over Zotero libraries.
+This module provides persistent vector database storage for semantic search
+over Zotero libraries.
+
+The embedding functions themselves now live in :mod:`zotero_mcp.embeddings`.
+They are re-exported below because ``zotero_mcp.chroma_client`` is where every
+caller — and every existing test — imports them from, and because ChromaDB's
+registry maps a persisted collection's embedding-function name to a specific
+class object, so the re-exported name has to *be* the registered class.
 """
 
 import json
@@ -12,533 +18,28 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+# Re-exported for backward compatibility; see the module docstring.
+from zotero_mcp.embeddings.providers import (  # noqa: F401
+    CUSTOM_EMBEDDING_FUNCTIONS,
+    GeminiEmbeddingFunction,
+    HuggingFaceEmbeddingFunction,
+    OllamaEmbeddingFunction,
+    OpenAIEmbeddingFunction,
+    ensure_embedding_functions_registered,
+)
+from zotero_mcp.embeddings.registry import create_embedding_function, merge_env_config
 from zotero_mcp.utils import install_hint, suppress_stdout
 
 try:
     import chromadb
     from chromadb import Documents, EmbeddingFunction, Embeddings
     from chromadb.config import Settings
-    from chromadb.utils.embedding_functions import register_embedding_function
 except ImportError as e:
     raise ImportError(
         f"chromadb is required for semantic search. {install_hint('semantic')}"
     ) from e
 
 logger = logging.getLogger(__name__)
-
-
-@register_embedding_function
-class OpenAIEmbeddingFunction(EmbeddingFunction):
-    """Custom OpenAI embedding function for ChromaDB.
-
-    Registered under the name "openai" so ChromaDB rebuilds it (rather than its
-    own incompatible built-in of the same name) when reloading a persisted
-    collection's config. ChromaDB >=1.x reconstructs the embedding function by
-    name from the stored config during upsert; without registration the name
-    collides with the built-in, whose build_from_config rejects our
-    {model_name, base_url} config.
-    """
-
-    max_input_tokens = 8000  # text-embedding-3-* limit is 8191
-
-    # Per-request input-list cap. OpenAI allows up to 2048 items but many
-    # OpenAI-compatible providers are stricter (SiliconFlow is 64 for
-    # /v1/embeddings, Mistral is 512, etc.). Defaulting to 64 keeps the code
-    # portable; real OpenAI users can raise embedding_config.request_batch_size.
-    DEFAULT_REQUEST_BATCH_SIZE = 64
-
-    def __init__(self, model_name: str = "text-embedding-3-small", api_key: str | None = None,
-                 base_url: str | None = None, request_batch_size: int | None = None,
-                 rate_limit_rps: float | None = None):
-        import threading
-        self.model_name = model_name
-        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
-        self.base_url = base_url or os.getenv("OPENAI_BASE_URL")
-        self.request_batch_size = int(request_batch_size) if request_batch_size else self.DEFAULT_REQUEST_BATCH_SIZE
-        self.rate_limit_rps: float | None = float(rate_limit_rps) if rate_limit_rps else None
-        self._rate_lock = threading.Lock()
-        self._last_request_ts: float = 0.0
-        if not self.api_key:
-            raise ValueError("OpenAI API key is required")
-
-        try:
-            import openai
-            client_kwargs = {"api_key": self.api_key}
-            if self.base_url:
-                client_kwargs["base_url"] = self.base_url
-            self.client = openai.OpenAI(**client_kwargs)
-        except ImportError:
-            raise ImportError("openai package is required for OpenAI embeddings")
-
-    @staticmethod
-    def name() -> str:
-        return "openai"
-
-    def get_config(self) -> dict[str, Any]:
-        return {
-            "model_name": self.model_name,
-            "base_url": self.base_url,
-            "request_batch_size": self.request_batch_size,
-            "rate_limit_rps": self.rate_limit_rps,
-            # ChromaDB's built-in EF of the same registered name rebuilds from
-            # {api_key_env_var, model_name, api_base, ...} and asserts ("This
-            # code should not be reached") when those are missing. Persisting
-            # its spellings too keeps the stored config buildable by whichever
-            # class wins the registry lookup (issue #382).
-            "api_key_env_var": "OPENAI_API_KEY",
-            "api_base": self.base_url,
-        }
-
-    @staticmethod
-    def build_from_config(config: dict[str, Any]) -> "OpenAIEmbeddingFunction":
-        # Accept either key spelling so a config written by ChromaDB's built-in
-        # (api_base / api_key_env_var) rebuilds here too.
-        api_key = config.get("api_key")
-        if not api_key and config.get("api_key_env_var"):
-            api_key = os.getenv(config["api_key_env_var"])
-        return OpenAIEmbeddingFunction(
-            model_name=config.get("model_name", "text-embedding-3-small"),
-            api_key=api_key,
-            base_url=config.get("base_url") or config.get("api_base"),
-            request_batch_size=config.get("request_batch_size"),
-            rate_limit_rps=config.get("rate_limit_rps"),
-        )
-
-    def _wait_for_rate_limit(self) -> None:
-        """Sleep as needed so successive embedding requests stay under
-        ``rate_limit_rps``. Applied per HTTP request (including each sub-batch)
-        so rate-limited providers see a steady cadence regardless of how many
-        inputs the caller passed. The lock keeps parallel threads honest.
-        """
-        rps = self.rate_limit_rps
-        if not rps or rps <= 0:
-            return
-        import time
-        with self._rate_lock:
-            min_interval = 1.0 / rps
-            wait = min_interval - (time.monotonic() - self._last_request_ts)
-            if wait > 0:
-                time.sleep(wait)
-            self._last_request_ts = time.monotonic()
-
-    def __call__(self, input: Documents) -> Embeddings:
-        """Generate embeddings using the OpenAI-compatible API.
-
-        ``encoding_format="float"`` is set explicitly. The OpenAI SDK otherwise
-        negotiates base64 by default, which OpenRouter's Gemini embedding
-        providers (e.g. ``google/gemini-embedding-001``) do not return reliably —
-        the SDK then raises "No embedding data received" intermittently. Forcing
-        float makes every OpenAI-compatible backend, native OpenAI included,
-        respond deterministically.
-        """
-        batch_size = self.request_batch_size or self.DEFAULT_REQUEST_BATCH_SIZE
-        vecs: Embeddings = []
-        for i in range(0, len(input), batch_size):
-            sub = input[i:i + batch_size]
-            self._wait_for_rate_limit()
-            response = self.client.embeddings.create(
-                model=self.model_name,
-                input=sub,
-                encoding_format="float",
-            )
-            vecs.extend(data.embedding for data in response.data)
-        return vecs
-
-    def embed_query(self, text: str) -> list[float]:
-        """Embed a query string. No special handling needed for OpenAI."""
-        return self.__call__([text])[0]
-
-    def truncate(self, text: str, max_tokens: int) -> str:
-        """Truncate using tiktoken cl100k_base (correct for OpenAI models)."""
-        try:
-            import tiktoken
-            if not hasattr(self, '_tokenizer'):
-                self._tokenizer = tiktoken.get_encoding("cl100k_base")
-            tokens = self._tokenizer.encode(text, disallowed_special=())
-            if len(tokens) > max_tokens:
-                tokens = tokens[:max_tokens]
-                text = self._tokenizer.decode(tokens)
-        except ImportError:
-            max_chars = max_tokens * 3
-            if len(text) > max_chars:
-                text = text[:max_chars]
-        return text
-
-
-@register_embedding_function
-class GeminiEmbeddingFunction(EmbeddingFunction):
-    """Custom Gemini embedding function for ChromaDB using google-genai.
-
-    Registered under the name "gemini" so ChromaDB can rebuild it from a
-    persisted collection's config (see OpenAIEmbeddingFunction for details).
-    """
-
-    # gemini-embedding-2-* models ignore the task_type config field (the API
-    # silently drops it). Google's recommended alternative is to embed the
-    # task instruction in the prompt text itself, which empirically shifts
-    # the embedding space (cos ~0.84 vs raw baseline) and preserves asymmetric
-    # doc/query tuning (cos ~0.94 between doc-prefix and query-prefix).
-    # These are the canonical prefixes; __call__ and embed_query prepend them
-    # to every v2 input. They MUST stay in sync with V2_PREFIX_TOKEN_BUDGET
-    # below: if you lengthen a prefix, bump the budget so truncation still
-    # leaves room for it under the model's hard cap.
-    V2_DOC_PREFIX = "Represent this document for retrieval:\n\n"
-    V2_QUERY_PREFIX = "Represent this query for retrieval:\n\n"
-
-    # Token reservation for the v2 prefix above. The longest prefix is
-    # V2_DOC_PREFIX at 42 chars ~= 11 tokens with typical English tokenization.
-    # We reserve 20 tokens (11 actual + 9 slack) so that truncate() leaves
-    # room for the prefix without ever producing a post-prefix payload that
-    # exceeds the model's 8192 hard cap even on dense text.
-    V2_PREFIX_TOKEN_BUDGET = 20
-
-    # Default for gemini-embedding-001 (hard cap 2048 tokens). Per-instance
-    # override in __init__ for models with larger context windows. NOTE: for
-    # v2 models this value means "effective budget for the TEXT BODY" —
-    # prefix tokens are reserved separately (see V2_PREFIX_TOKEN_BUDGET).
-    max_input_tokens = 2000
-
-    def __init__(self, model_name: str = "gemini-embedding-001", api_key: str | None = None, base_url: str | None = None):
-        self.model_name = model_name
-        # Model-aware token limit. For v2 models, derive from:
-        #   hard_cap (8192) - safety_margin (192, for char-based truncation
-        #   imprecision) - V2_PREFIX_TOKEN_BUDGET (20, reserved for the
-        #   in-prompt task instruction prepended in __call__/embed_query).
-        # Net effective budget for text body: 8192 - 192 - 20 = 7980 tokens.
-        # This guarantees post-prefix payload <= hard cap even at the
-        # truncation limit, formally closing the cap-enforcement gap.
-        if "gemini-embedding-2" in model_name:
-            self.max_input_tokens = 8000 - self.V2_PREFIX_TOKEN_BUDGET
-        self.api_key = api_key or os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
-        self.base_url = base_url or os.getenv("GEMINI_BASE_URL")
-        if not self.api_key:
-            raise ValueError("Gemini API key is required")
-
-        try:
-            from google import genai
-            from google.genai import types
-            client_kwargs = {"api_key": self.api_key}
-            if self.base_url:
-                http_options = types.HttpOptions(baseUrl=self.base_url)
-                client_kwargs["http_options"] = http_options
-            self.client = genai.Client(**client_kwargs)
-            self.types = types
-        except ImportError:
-            raise ImportError("google-genai package is required for Gemini embeddings")
-
-    @staticmethod
-    def name() -> str:
-        return "gemini"
-
-    def get_config(self) -> dict[str, Any]:
-        return {"model_name": self.model_name, "base_url": self.base_url}
-
-    @staticmethod
-    def build_from_config(config: dict[str, Any]) -> "GeminiEmbeddingFunction":
-        return GeminiEmbeddingFunction(
-            model_name=config.get("model_name", "gemini-embedding-001"),
-            api_key=config.get("api_key"),
-            base_url=config.get("base_url"),
-        )
-
-    # Gemini's embed_content API caps at 100 items per batch (verified
-    # empirically: batch=100 OK, batch=250 → 400 INVALID_ARGUMENT with
-    # "at most 100 requests can be in one batch").
-    GEMINI_MAX_BATCH = 100
-
-    def _is_v2(self) -> bool:
-        # gemini-embedding-2-* does not support the task_type config field
-        # (it is silently ignored by the API). Google's guidance is to put
-        # the task hint in the prompt text instead.
-        return "gemini-embedding-2" in self.model_name
-
-    def __call__(self, input: Documents) -> Embeddings:
-        """Generate embeddings using Gemini API, batching up to 100 per call."""
-        is_v2 = self._is_v2()
-        # Materialize once so we can slice regardless of input iterable type.
-        texts = list(input)
-        if is_v2:
-            # v2 models: task instruction goes in the prompt, no config.
-            # V2_PREFIX_TOKEN_BUDGET is already reserved from max_input_tokens
-            # in __init__, so upstream truncation guarantees the combined
-            # payload stays under the model's hard cap.
-            prepared = [f"{self.V2_DOC_PREFIX}{t}" for t in texts]
-        else:
-            prepared = texts
-
-        embeddings: list = []
-        for start in range(0, len(prepared), self.GEMINI_MAX_BATCH):
-            batch = prepared[start:start + self.GEMINI_MAX_BATCH]
-            if is_v2:
-                response = self.client.models.embed_content(
-                    model=self.model_name,
-                    contents=batch,
-                )
-            else:
-                response = self.client.models.embed_content(
-                    model=self.model_name,
-                    contents=batch,
-                    config=self.types.EmbedContentConfig(
-                        task_type="retrieval_document",
-                        title="Zotero library document",
-                    ),
-                )
-            embeddings.extend(e.values for e in response.embeddings)
-        return embeddings
-
-    def embed_query(self, text: str) -> list[float]:
-        """Embed a query string using retrieval_query task type."""
-        # Truncate before any prefix prepending. For v2 models max_input_tokens
-        # already excludes V2_PREFIX_TOKEN_BUDGET (reserved in __init__), so
-        # the post-prefix payload stays under the model's hard cap. For v1
-        # models truncation prevents API errors on pathological queries that
-        # the upstream pipeline does not pre-truncate (queries bypass the
-        # _process_item_batch truncate_text path that documents go through).
-        text = self.truncate(text, self.max_input_tokens)
-        if self._is_v2():
-            prompt_text = f"{self.V2_QUERY_PREFIX}{text}"
-            response = self.client.models.embed_content(
-                model=self.model_name,
-                contents=[prompt_text],
-            )
-        else:
-            response = self.client.models.embed_content(
-                model=self.model_name,
-                contents=[text],
-                config=self.types.EmbedContentConfig(
-                    task_type="retrieval_query",
-                ),
-            )
-        return response.embeddings[0].values
-
-    def truncate(self, text: str, max_tokens: int) -> str:
-        """Truncate using character-based estimation for Gemini (~4 chars/token)."""
-        max_chars = max_tokens * 4
-        if len(text) > max_chars:
-            text = text[:max_chars]
-        return text
-
-
-@register_embedding_function
-class HuggingFaceEmbeddingFunction(EmbeddingFunction):
-    """Custom HuggingFace embedding function for ChromaDB using sentence-transformers.
-
-    Registered under the name "huggingface" so ChromaDB rebuilds it (rather than
-    its own incompatible built-in of the same name) when reloading a persisted
-    collection's config (see OpenAIEmbeddingFunction for details).
-    """
-
-    def __init__(self, model_name: str = "Qwen/Qwen3-Embedding-0.6B"):
-        self.model_name = model_name
-
-        try:
-            from sentence_transformers import SentenceTransformer
-            logger.info(f"Loading embedding model: {model_name}")
-            self.model = SentenceTransformer(model_name, trust_remote_code=True)
-        except ImportError:
-            raise ImportError("sentence-transformers package is required for HuggingFace embeddings. Install with: pip install sentence-transformers")
-
-        # Read limit from model metadata; conservative fallback
-        self.max_input_tokens = getattr(self.model, "max_seq_length", 500)
-
-    @staticmethod
-    def name() -> str:
-        return "huggingface"
-
-    def get_config(self) -> dict[str, Any]:
-        return {
-            "model_name": self.model_name,
-            # ChromaDB's built-in "huggingface" EF requires api_key_env_var in
-            # addition to model_name and asserts without it. Persisting the key
-            # keeps the config buildable by either class (issue #382); our own
-            # build_from_config ignores it (we embed locally, no API key).
-            "api_key_env_var": "HUGGINGFACE_API_KEY",
-        }
-
-    @staticmethod
-    def build_from_config(config: dict[str, Any]) -> "HuggingFaceEmbeddingFunction":
-        return HuggingFaceEmbeddingFunction(
-            model_name=config.get("model_name", "Qwen/Qwen3-Embedding-0.6B"),
-        )
-
-    def __call__(self, input: Documents) -> Embeddings:
-        """Generate embeddings using HuggingFace model."""
-        embeddings = self.model.encode(input, convert_to_numpy=True)
-        return embeddings.tolist()
-
-    def embed_query(self, text: str) -> list[float]:
-        """Embed a query string. No special handling needed for HuggingFace."""
-        return self.__call__([text])[0]
-
-    def truncate(self, text: str, max_tokens: int) -> str:
-        """Truncate using the model's own tokenizer."""
-        tokenizer = getattr(self.model, 'tokenizer', None)
-        if tokenizer is not None:
-            encoded = tokenizer.encode(text, add_special_tokens=False)
-            if len(encoded) > max_tokens:
-                encoded = encoded[:max_tokens]
-                text = tokenizer.decode(encoded)
-        else:
-            max_chars = max_tokens * 2
-            if len(text) > max_chars:
-                text = text[:max_chars]
-        return text
-
-
-@register_embedding_function
-class OllamaEmbeddingFunction(EmbeddingFunction):
-    """Custom Ollama embedding function for ChromaDB.
-
-    Uses Ollama's local HTTP API. Registered under the name ``ollama`` so
-    ChromaDB can rebuild persisted collections that were created with this
-    embedding function.
-    """
-
-    # Ollama models vary; use a conservative, char-based fallback budget.
-    max_input_tokens = 8000
-
-    # HTTP timeout (seconds) for /api/embed. Persisted in get_config() because
-    # ChromaDB's built-in ollama EF requires a ``timeout`` key.
-    DEFAULT_TIMEOUT = 120
-
-    # Documents per /api/embed request. The indexer hands us a whole item
-    # batch, which with chunking enabled is (items × max_chunks_per_item)
-    # documents — up to thousands. Sending that as one request makes a single
-    # HTTP call that has to outlast the entire GPU pass, which is what pushed
-    # runs past any sane timeout (#423). Chunking the request keeps each call
-    # short; Ollama processes sequentially either way, so on a local server
-    # the extra round trips cost approximately nothing.
-    DEFAULT_REQUEST_BATCH_SIZE = 64
-
-    def __init__(self, model_name: str = "qwen3-embedding", base_url: str | None = None,
-                 url: str | None = None, timeout: int | None = None,
-                 request_batch_size: int | None = None):
-        self.model_name = model_name
-        # ``url`` is ChromaDB's built-in spelling of ``base_url``; accept both
-        # so a config written by either class rebuilds here (issue #382).
-        self.base_url = (
-            base_url or url or os.getenv("OLLAMA_BASE_URL") or "http://localhost:11434"
-        ).rstrip("/")
-        # Mirror the attribute under the built-in's name as well.
-        self.url = self.base_url
-        self.timeout = int(timeout) if timeout else self.DEFAULT_TIMEOUT
-        self.request_batch_size = (
-            int(request_batch_size) if request_batch_size else self.DEFAULT_REQUEST_BATCH_SIZE
-        )
-
-    @staticmethod
-    def name() -> str:
-        return "ollama"
-
-    def get_config(self) -> dict[str, Any]:
-        return {
-            "model_name": self.model_name,
-            "base_url": self.base_url,
-            # ChromaDB ships its own OllamaEmbeddingFunction registered under
-            # the same name "ollama". Whichever class wins the registry lookup
-            # gets this dict when the persisted collection config is rebuilt at
-            # query time; the built-in reads url/model_name/timeout and asserts
-            # "This code should not be reached" when any is missing (#382).
-            # Carrying both spellings makes the config valid for both classes.
-            "url": self.base_url,
-            "timeout": self.timeout,
-            # Extra keys are ignored by the built-in (it reads only
-            # url/model_name/timeout via .get()), so carrying ours is safe.
-            "request_batch_size": self.request_batch_size,
-        }
-
-    @staticmethod
-    def build_from_config(config: dict[str, Any]) -> "OllamaEmbeddingFunction":
-        return OllamaEmbeddingFunction(
-            model_name=config.get("model_name", "qwen3-embedding"),
-            base_url=config.get("base_url") or config.get("url"),
-            timeout=config.get("timeout"),
-            request_batch_size=config.get("request_batch_size"),
-        )
-
-    def __call__(self, input: Documents) -> Embeddings:
-        """Generate embeddings using Ollama's /api/embed endpoint.
-
-        Unlike the deprecated /api/embeddings route (single ``prompt`` -> single
-        ``embedding``), /api/embed accepts a batch via ``input`` and returns a
-        list under ``embeddings``, so several documents go out per request.
-
-        The caller's list is split into ``request_batch_size`` chunks so one
-        request never has to cover an unbounded amount of GPU work; see that
-        attribute for why. Vectors are concatenated back in input order.
-        """
-        try:
-            import requests
-        except ImportError:
-            raise ImportError("requests package is required for Ollama embeddings")
-
-        texts = list(input)
-        if not texts:
-            return []
-
-        endpoint = f"{self.base_url}/api/embed"
-        embeddings: list = []
-        for start in range(0, len(texts), self.request_batch_size):
-            window = texts[start : start + self.request_batch_size]
-            response = requests.post(
-                endpoint,
-                json={"model": self.model_name, "input": window},
-                timeout=self.timeout,
-            )
-            response.raise_for_status()
-            data = response.json()
-            vectors = data.get("embeddings")
-            if vectors is None:
-                raise ValueError(
-                    f"Ollama /api/embed returned no 'embeddings' field: {data}"
-                )
-            if len(vectors) != len(window):
-                # A short response would silently misalign every vector after
-                # it with the wrong document, poisoning the index in a way that
-                # only shows up as bad search results much later.
-                raise ValueError(
-                    f"Ollama /api/embed returned {len(vectors)} embeddings for "
-                    f"{len(window)} inputs"
-                )
-            embeddings.extend(vectors)
-        return embeddings
-
-    def embed_query(self, text: str) -> list[float]:
-        """Embed a query string. No special handling needed for Ollama."""
-        return self.__call__([text])[0]
-
-    def truncate(self, text: str, max_tokens: int) -> str:
-        """Truncate using character-based estimation for local Ollama models."""
-        max_chars = max_tokens * 4
-        if len(text) > max_chars:
-            text = text[:max_chars]
-        return text
-
-
-#: Our embedding functions, in registration order. Three of the four names
-#: ("openai", "huggingface", "ollama") collide with ChromaDB built-ins.
-CUSTOM_EMBEDDING_FUNCTIONS = (
-    OpenAIEmbeddingFunction,
-    GeminiEmbeddingFunction,
-    HuggingFaceEmbeddingFunction,
-    OllamaEmbeddingFunction,
-)
-
-
-def ensure_embedding_functions_registered() -> None:
-    """(Re-)claim our embedding-function names in ChromaDB's registry.
-
-    ``known_embedding_functions`` is a plain last-write-wins dict, so import
-    order decides whether a colliding name resolves to our class or to
-    ChromaDB's built-in. Re-registering immediately before a collection is
-    opened means a built-in that got imported after this module still cannot
-    shadow us and mis-handle our persisted config (issue #382).
-    """
-    for cls in CUSTOM_EMBEDDING_FUNCTIONS:
-        try:
-            register_embedding_function(cls)
-        except Exception as e:  # pragma: no cover - registry API change
-            logger.debug(f"Could not re-register {cls.__name__}: {e}")
 
 
 class ChromaClient:
@@ -641,50 +142,13 @@ class ChromaClient:
                     raise
 
     def _create_embedding_function(self) -> EmbeddingFunction:
-        """Create the appropriate embedding function based on configuration."""
-        if self.embedding_model == "openai":
-            model_name = self.embedding_config.get("model_name", "text-embedding-3-small")
-            api_key = self.embedding_config.get("api_key")
-            base_url = self.embedding_config.get("base_url")
-            return OpenAIEmbeddingFunction(
-                model_name=model_name, api_key=api_key, base_url=base_url,
-                request_batch_size=self.embedding_config.get("request_batch_size"),
-                rate_limit_rps=self.embedding_config.get("rate_limit_rps"),
-            )
+        """Create the appropriate embedding function based on configuration.
 
-        elif self.embedding_model == "gemini":
-            model_name = self.embedding_config.get("model_name", "gemini-embedding-001")
-            api_key = self.embedding_config.get("api_key")
-            base_url = self.embedding_config.get("base_url")
-            return GeminiEmbeddingFunction(model_name=model_name, api_key=api_key, base_url=base_url)
-
-        elif self.embedding_model == "ollama":
-            model_name = self.embedding_config.get("model_name", "qwen3-embedding")
-            base_url = self.embedding_config.get("base_url")
-            return OllamaEmbeddingFunction(
-                model_name=model_name,
-                base_url=base_url,
-                timeout=self.embedding_config.get("timeout"),
-                request_batch_size=self.embedding_config.get("request_batch_size"),
-            )
-
-        elif self.embedding_model == "qwen":
-            model_name = self.embedding_config.get("model_name", "Qwen/Qwen3-Embedding-0.6B")
-            return HuggingFaceEmbeddingFunction(model_name=model_name)
-
-        elif self.embedding_model == "embeddinggemma":
-            model_name = self.embedding_config.get("model_name", "google/embeddinggemma-300m")
-            return HuggingFaceEmbeddingFunction(model_name=model_name)
-
-        elif self.embedding_model not in ["default", "openai", "gemini", "ollama"]:
-            # Treat any other value as a HuggingFace model name
-            return HuggingFaceEmbeddingFunction(model_name=self.embedding_model)
-
-        else:
-            # Use ChromaDB's default embedding function (all-MiniLM-L6-v2)
-            ef = chromadb.utils.embedding_functions.DefaultEmbeddingFunction()
-            ef.max_input_tokens = 256  # all-MiniLM-L6-v2 max_seq_length
-            return ef
+        The provider registry owns the model-string -> embedding-function
+        mapping; see :func:`zotero_mcp.embeddings.registry.resolve_provider`
+        for the resolution rules.
+        """
+        return create_embedding_function(self.embedding_model, self.embedding_config)
 
     @property
     def embedding_max_tokens(self) -> int:
@@ -1096,49 +560,11 @@ def create_chroma_client(config_path: str | None = None) -> ChromaClient:
     # Previous code unconditionally REPLACED config["embedding_config"] with env
     # values, silently dropping model_name from config.json whenever any
     # provider env var (e.g. GOOGLE_API_KEY leaked from another tool) was set.
-    if config["embedding_model"] == "openai":
-        ec = dict(config.get("embedding_config") or {})
-        if not ec.get("api_key"):
-            env_key = os.getenv("OPENAI_API_KEY")
-            if env_key:
-                ec["api_key"] = env_key
-        if not ec.get("model_name"):
-            ec["model_name"] = os.getenv(
-                "OPENAI_EMBEDDING_MODEL", "text-embedding-3-small"
-            )
-        if not ec.get("base_url"):
-            env_base = os.getenv("OPENAI_BASE_URL")
-            if env_base:
-                ec["base_url"] = env_base
-        if ec.get("api_key"):
-            config["embedding_config"] = ec
-
-    elif config["embedding_model"] == "gemini":
-        ec = dict(config.get("embedding_config") or {})
-        if not ec.get("api_key"):
-            env_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
-            if env_key:
-                ec["api_key"] = env_key
-        if not ec.get("model_name"):
-            ec["model_name"] = os.getenv(
-                "GEMINI_EMBEDDING_MODEL", "gemini-embedding-001"
-            )
-        if not ec.get("base_url"):
-            env_base = os.getenv("GEMINI_BASE_URL")
-            if env_base:
-                ec["base_url"] = env_base
-        if ec.get("api_key"):
-            config["embedding_config"] = ec
-
-    elif config["embedding_model"] == "ollama":
-        ec = dict(config.get("embedding_config") or {})
-        if not ec.get("model_name"):
-            ec["model_name"] = os.getenv("OLLAMA_EMBEDDING_MODEL", "qwen3-embedding")
-        if not ec.get("base_url"):
-            env_base = os.getenv("OLLAMA_BASE_URL")
-            if env_base:
-                ec["base_url"] = env_base
-        config["embedding_config"] = ec
+    # Which variables each provider reads, and whether the merged result is
+    # kept, is declared by its EnvSpec in the provider registry.
+    config["embedding_config"] = merge_env_config(
+        config["embedding_model"], config.get("embedding_config")
+    )
 
     return ChromaClient(
         collection_name=config["collection_name"],

--- a/src/zotero_mcp/embeddings/__init__.py
+++ b/src/zotero_mcp/embeddings/__init__.py
@@ -1,0 +1,22 @@
+"""Embedding functions and the provider registry for semantic search.
+
+Layout:
+
+- ``base.py`` — :class:`~zotero_mcp.embeddings.base.BaseEmbeddingFunction`, the
+  small amount of behaviour shared by every provider.
+- ``providers/`` — one module per concrete embedding function, each registering
+  itself with ChromaDB on import.
+- ``registry.py`` — the provider registry that maps a configured
+  ``embedding_model`` string to a constructed embedding function. Reached
+  directly as ``zotero_mcp.embeddings.registry``; deliberately not re-exported
+  here, so importing this package never has to build the registry.
+
+Importing this package imports ``providers``, which is enough to register every
+embedding function with ChromaDB.
+"""
+
+# Imported for the @register_embedding_function side effects.
+from zotero_mcp.embeddings import providers  # noqa: F401
+from zotero_mcp.embeddings.base import BaseEmbeddingFunction
+
+__all__ = ["BaseEmbeddingFunction"]

--- a/src/zotero_mcp/embeddings/base.py
+++ b/src/zotero_mcp/embeddings/base.py
@@ -1,0 +1,62 @@
+"""Provider-agnostic base class for zotero-mcp's embedding functions.
+
+This holds only the two method bodies that were already byte-identical across
+the concrete providers when they lived in ``chroma_client.py``:
+
+- ``embed_query`` -> ``self.__call__([text])[0]``. OpenAI, HuggingFace and
+  Ollama each carried their own copy of exactly this. Gemini still overrides
+  it, because its query path uses a different task type (v1) or prompt prefix
+  (v2) than its document path.
+- a character-ratio ``truncate``. Gemini and Ollama each carried their own copy
+  at 4 chars/token. OpenAI overrides it with tiktoken and HuggingFace with the
+  model's own tokenizer.
+
+Deliberately *not* here: request pacing, retries, sub-batching, parallelism.
+Every provider keeps its own ``__call__`` exactly as it was, because unifying
+those loops is a behaviour change; it belongs with the streaming and adaptive
+rate-limiting work, not with this move.
+
+This class is not registered with ChromaDB — it has no ``name()``,
+``get_config()`` or ``build_from_config()``, so it can never be resolved by
+name when a persisted collection's config is rebuilt. Only the concrete
+subclasses are registered.
+
+``chars_per_token`` is read as a class attribute rather than an instance one on
+purpose: several tests construct providers via ``Cls.__new__(Cls)``, setting
+only the handful of instance attributes the assertion needs, so anything this
+class touches has to resolve without ``__init__`` having run.
+"""
+
+from zotero_mcp.utils import install_hint
+
+try:
+    from chromadb import EmbeddingFunction
+except ImportError as e:
+    raise ImportError(
+        f"chromadb is required for semantic search. {install_hint('semantic')}"
+    ) from e
+
+
+class BaseEmbeddingFunction(EmbeddingFunction):
+    """Shared behaviour for the zotero-mcp embedding functions."""
+
+    #: Characters per token, for the estimate-based :meth:`truncate` below.
+    chars_per_token = 4
+
+    def embed_query(self, text: str) -> list[float]:
+        """Embed a query string via the document path.
+
+        Correct for any provider that does not tune queries and documents
+        differently; Gemini overrides this.
+        """
+        return self.__call__([text])[0]
+
+    def truncate(self, text: str, max_tokens: int) -> str:
+        """Truncate using character-based estimation (``chars_per_token``).
+
+        The fallback for providers with no tokenizer of their own to consult.
+        """
+        max_chars = max_tokens * self.chars_per_token
+        if len(text) > max_chars:
+            text = text[:max_chars]
+        return text

--- a/src/zotero_mcp/embeddings/providers/__init__.py
+++ b/src/zotero_mcp/embeddings/providers/__init__.py
@@ -1,0 +1,66 @@
+"""The concrete embedding function classes, one module per provider.
+
+Each submodule defines exactly one embedding function decorated with
+``@register_embedding_function``, so importing a submodule has the side effect
+of claiming that provider's name in ChromaDB's own embedding-function registry.
+Importing this package imports all four at once.
+
+Note the two distinct registries in play, which are easy to confuse:
+
+- ChromaDB's ``known_embedding_functions`` — a name -> class map used to rebuild
+  an embedding function from a *persisted collection's* config. That is what
+  the decorator and :func:`ensure_embedding_functions_registered` below feed.
+- zotero-mcp's own provider registry in :mod:`zotero_mcp.embeddings.registry` —
+  a name -> :class:`~zotero_mcp.embeddings.registry.ProviderSpec` map used to
+  turn a *user's configured* ``embedding_model`` string into a constructed
+  embedding function.
+
+These modules depend only on :mod:`zotero_mcp.embeddings.base`, never on
+``chroma_client`` or on the provider registry, so neither import direction can
+cycle.
+"""
+
+import logging
+
+from chromadb.utils.embedding_functions import register_embedding_function
+
+from zotero_mcp.embeddings.providers.gemini import GeminiEmbeddingFunction
+from zotero_mcp.embeddings.providers.huggingface import HuggingFaceEmbeddingFunction
+from zotero_mcp.embeddings.providers.ollama import OllamaEmbeddingFunction
+from zotero_mcp.embeddings.providers.openai import OpenAIEmbeddingFunction
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CUSTOM_EMBEDDING_FUNCTIONS",
+    "GeminiEmbeddingFunction",
+    "HuggingFaceEmbeddingFunction",
+    "OllamaEmbeddingFunction",
+    "OpenAIEmbeddingFunction",
+    "ensure_embedding_functions_registered",
+]
+
+#: Our embedding functions, in registration order. Three of the four names
+#: ("openai", "huggingface", "ollama") collide with ChromaDB built-ins.
+CUSTOM_EMBEDDING_FUNCTIONS = (
+    OpenAIEmbeddingFunction,
+    GeminiEmbeddingFunction,
+    HuggingFaceEmbeddingFunction,
+    OllamaEmbeddingFunction,
+)
+
+
+def ensure_embedding_functions_registered() -> None:
+    """(Re-)claim our embedding-function names in ChromaDB's registry.
+
+    ``known_embedding_functions`` is a plain last-write-wins dict, so import
+    order decides whether a colliding name resolves to our class or to
+    ChromaDB's built-in. Re-registering immediately before a collection is
+    opened means a built-in that got imported after this module still cannot
+    shadow us and mis-handle our persisted config (issue #382).
+    """
+    for cls in CUSTOM_EMBEDDING_FUNCTIONS:
+        try:
+            register_embedding_function(cls)
+        except Exception as e:  # pragma: no cover - registry API change
+            logger.debug(f"Could not re-register {cls.__name__}: {e}")

--- a/src/zotero_mcp/embeddings/providers/gemini.py
+++ b/src/zotero_mcp/embeddings/providers/gemini.py
@@ -1,0 +1,156 @@
+"""Gemini embedding function, backed by the google-genai SDK."""
+
+import os
+from typing import Any
+
+from chromadb import Documents, Embeddings
+from chromadb.utils.embedding_functions import register_embedding_function
+
+from zotero_mcp.embeddings.base import BaseEmbeddingFunction
+
+
+@register_embedding_function
+class GeminiEmbeddingFunction(BaseEmbeddingFunction):
+    """Custom Gemini embedding function for ChromaDB using google-genai.
+
+    Registered under the name "gemini" so ChromaDB can rebuild it from a
+    persisted collection's config (see OpenAIEmbeddingFunction for details).
+    """
+
+    # gemini-embedding-2-* models ignore the task_type config field (the API
+    # silently drops it). Google's recommended alternative is to embed the
+    # task instruction in the prompt text itself, which empirically shifts
+    # the embedding space (cos ~0.84 vs raw baseline) and preserves asymmetric
+    # doc/query tuning (cos ~0.94 between doc-prefix and query-prefix).
+    # These are the canonical prefixes; __call__ and embed_query prepend them
+    # to every v2 input. They MUST stay in sync with V2_PREFIX_TOKEN_BUDGET
+    # below: if you lengthen a prefix, bump the budget so truncation still
+    # leaves room for it under the model's hard cap.
+    V2_DOC_PREFIX = "Represent this document for retrieval:\n\n"
+    V2_QUERY_PREFIX = "Represent this query for retrieval:\n\n"
+
+    # Token reservation for the v2 prefix above. The longest prefix is
+    # V2_DOC_PREFIX at 42 chars ~= 11 tokens with typical English tokenization.
+    # We reserve 20 tokens (11 actual + 9 slack) so that truncate() leaves
+    # room for the prefix without ever producing a post-prefix payload that
+    # exceeds the model's 8192 hard cap even on dense text.
+    V2_PREFIX_TOKEN_BUDGET = 20
+
+    # Default for gemini-embedding-001 (hard cap 2048 tokens). Per-instance
+    # override in __init__ for models with larger context windows. NOTE: for
+    # v2 models this value means "effective budget for the TEXT BODY" —
+    # prefix tokens are reserved separately (see V2_PREFIX_TOKEN_BUDGET).
+    max_input_tokens = 2000
+
+    def __init__(self, model_name: str = "gemini-embedding-001", api_key: str | None = None, base_url: str | None = None):
+        self.model_name = model_name
+        # Model-aware token limit. For v2 models, derive from:
+        #   hard_cap (8192) - safety_margin (192, for char-based truncation
+        #   imprecision) - V2_PREFIX_TOKEN_BUDGET (20, reserved for the
+        #   in-prompt task instruction prepended in __call__/embed_query).
+        # Net effective budget for text body: 8192 - 192 - 20 = 7980 tokens.
+        # This guarantees post-prefix payload <= hard cap even at the
+        # truncation limit, formally closing the cap-enforcement gap.
+        if "gemini-embedding-2" in model_name:
+            self.max_input_tokens = 8000 - self.V2_PREFIX_TOKEN_BUDGET
+        self.api_key = api_key or os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+        self.base_url = base_url or os.getenv("GEMINI_BASE_URL")
+        if not self.api_key:
+            raise ValueError("Gemini API key is required")
+
+        try:
+            from google import genai
+            from google.genai import types
+            client_kwargs = {"api_key": self.api_key}
+            if self.base_url:
+                http_options = types.HttpOptions(baseUrl=self.base_url)
+                client_kwargs["http_options"] = http_options
+            self.client = genai.Client(**client_kwargs)
+            self.types = types
+        except ImportError:
+            raise ImportError("google-genai package is required for Gemini embeddings")
+
+    @staticmethod
+    def name() -> str:
+        return "gemini"
+
+    def get_config(self) -> dict[str, Any]:
+        return {"model_name": self.model_name, "base_url": self.base_url}
+
+    @staticmethod
+    def build_from_config(config: dict[str, Any]) -> "GeminiEmbeddingFunction":
+        return GeminiEmbeddingFunction(
+            model_name=config.get("model_name", "gemini-embedding-001"),
+            api_key=config.get("api_key"),
+            base_url=config.get("base_url"),
+        )
+
+    # Gemini's embed_content API caps at 100 items per batch (verified
+    # empirically: batch=100 OK, batch=250 → 400 INVALID_ARGUMENT with
+    # "at most 100 requests can be in one batch").
+    GEMINI_MAX_BATCH = 100
+
+    def _is_v2(self) -> bool:
+        # gemini-embedding-2-* does not support the task_type config field
+        # (it is silently ignored by the API). Google's guidance is to put
+        # the task hint in the prompt text instead.
+        return "gemini-embedding-2" in self.model_name
+
+    def __call__(self, input: Documents) -> Embeddings:
+        """Generate embeddings using Gemini API, batching up to 100 per call."""
+        is_v2 = self._is_v2()
+        # Materialize once so we can slice regardless of input iterable type.
+        texts = list(input)
+        if is_v2:
+            # v2 models: task instruction goes in the prompt, no config.
+            # V2_PREFIX_TOKEN_BUDGET is already reserved from max_input_tokens
+            # in __init__, so upstream truncation guarantees the combined
+            # payload stays under the model's hard cap.
+            prepared = [f"{self.V2_DOC_PREFIX}{t}" for t in texts]
+        else:
+            prepared = texts
+
+        embeddings: list = []
+        for start in range(0, len(prepared), self.GEMINI_MAX_BATCH):
+            batch = prepared[start:start + self.GEMINI_MAX_BATCH]
+            if is_v2:
+                response = self.client.models.embed_content(
+                    model=self.model_name,
+                    contents=batch,
+                )
+            else:
+                response = self.client.models.embed_content(
+                    model=self.model_name,
+                    contents=batch,
+                    config=self.types.EmbedContentConfig(
+                        task_type="retrieval_document",
+                        title="Zotero library document",
+                    ),
+                )
+            embeddings.extend(e.values for e in response.embeddings)
+        return embeddings
+
+    def embed_query(self, text: str) -> list[float]:
+        """Embed a query string using retrieval_query task type."""
+        # Truncate before any prefix prepending. For v2 models max_input_tokens
+        # already excludes V2_PREFIX_TOKEN_BUDGET (reserved in __init__), so
+        # the post-prefix payload stays under the model's hard cap. For v1
+        # models truncation prevents API errors on pathological queries that
+        # the upstream pipeline does not pre-truncate (queries bypass the
+        # _process_item_batch truncate_text path that documents go through).
+        text = self.truncate(text, self.max_input_tokens)
+        if self._is_v2():
+            prompt_text = f"{self.V2_QUERY_PREFIX}{text}"
+            response = self.client.models.embed_content(
+                model=self.model_name,
+                contents=[prompt_text],
+            )
+        else:
+            response = self.client.models.embed_content(
+                model=self.model_name,
+                contents=[text],
+                config=self.types.EmbedContentConfig(
+                    task_type="retrieval_query",
+                ),
+            )
+        return response.embeddings[0].values

--- a/src/zotero_mcp/embeddings/providers/huggingface.py
+++ b/src/zotero_mcp/embeddings/providers/huggingface.py
@@ -1,0 +1,73 @@
+"""Local HuggingFace embedding function, backed by sentence-transformers."""
+
+import logging
+from typing import Any
+
+from chromadb import Documents, Embeddings
+from chromadb.utils.embedding_functions import register_embedding_function
+
+from zotero_mcp.embeddings.base import BaseEmbeddingFunction
+
+logger = logging.getLogger(__name__)
+
+
+@register_embedding_function
+class HuggingFaceEmbeddingFunction(BaseEmbeddingFunction):
+    """Custom HuggingFace embedding function for ChromaDB using sentence-transformers.
+
+    Registered under the name "huggingface" so ChromaDB rebuilds it (rather than
+    its own incompatible built-in of the same name) when reloading a persisted
+    collection's config (see OpenAIEmbeddingFunction for details).
+    """
+
+    def __init__(self, model_name: str = "Qwen/Qwen3-Embedding-0.6B"):
+        self.model_name = model_name
+
+        try:
+            from sentence_transformers import SentenceTransformer
+            logger.info(f"Loading embedding model: {model_name}")
+            self.model = SentenceTransformer(model_name, trust_remote_code=True)
+        except ImportError:
+            raise ImportError("sentence-transformers package is required for HuggingFace embeddings. Install with: pip install sentence-transformers")
+
+        # Read limit from model metadata; conservative fallback
+        self.max_input_tokens = getattr(self.model, "max_seq_length", 500)
+
+    @staticmethod
+    def name() -> str:
+        return "huggingface"
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "model_name": self.model_name,
+            # ChromaDB's built-in "huggingface" EF requires api_key_env_var in
+            # addition to model_name and asserts without it. Persisting the key
+            # keeps the config buildable by either class (issue #382); our own
+            # build_from_config ignores it (we embed locally, no API key).
+            "api_key_env_var": "HUGGINGFACE_API_KEY",
+        }
+
+    @staticmethod
+    def build_from_config(config: dict[str, Any]) -> "HuggingFaceEmbeddingFunction":
+        return HuggingFaceEmbeddingFunction(
+            model_name=config.get("model_name", "Qwen/Qwen3-Embedding-0.6B"),
+        )
+
+    def __call__(self, input: Documents) -> Embeddings:
+        """Generate embeddings using HuggingFace model."""
+        embeddings = self.model.encode(input, convert_to_numpy=True)
+        return embeddings.tolist()
+
+    def truncate(self, text: str, max_tokens: int) -> str:
+        """Truncate using the model's own tokenizer."""
+        tokenizer = getattr(self.model, 'tokenizer', None)
+        if tokenizer is not None:
+            encoded = tokenizer.encode(text, add_special_tokens=False)
+            if len(encoded) > max_tokens:
+                encoded = encoded[:max_tokens]
+                text = tokenizer.decode(encoded)
+        else:
+            max_chars = max_tokens * 2
+            if len(text) > max_chars:
+                text = text[:max_chars]
+        return text

--- a/src/zotero_mcp/embeddings/providers/ollama.py
+++ b/src/zotero_mcp/embeddings/providers/ollama.py
@@ -1,0 +1,128 @@
+"""Ollama embedding function, backed by Ollama's local HTTP API."""
+
+import os
+from typing import Any
+
+from chromadb import Documents, Embeddings
+from chromadb.utils.embedding_functions import register_embedding_function
+
+from zotero_mcp.embeddings.base import BaseEmbeddingFunction
+
+
+@register_embedding_function
+class OllamaEmbeddingFunction(BaseEmbeddingFunction):
+    """Custom Ollama embedding function for ChromaDB.
+
+    Uses Ollama's local HTTP API. Registered under the name ``ollama`` so
+    ChromaDB can rebuild persisted collections that were created with this
+    embedding function.
+    """
+
+    # Ollama models vary; use a conservative, char-based fallback budget.
+    max_input_tokens = 8000
+
+    # HTTP timeout (seconds) for /api/embed. Persisted in get_config() because
+    # ChromaDB's built-in ollama EF requires a ``timeout`` key.
+    DEFAULT_TIMEOUT = 120
+
+    # Documents per /api/embed request. The indexer hands us a whole item
+    # batch, which with chunking enabled is (items × max_chunks_per_item)
+    # documents — up to thousands. Sending that as one request makes a single
+    # HTTP call that has to outlast the entire GPU pass, which is what pushed
+    # runs past any sane timeout (#423). Chunking the request keeps each call
+    # short; Ollama processes sequentially either way, so on a local server
+    # the extra round trips cost approximately nothing.
+    DEFAULT_REQUEST_BATCH_SIZE = 64
+
+    def __init__(self, model_name: str = "qwen3-embedding", base_url: str | None = None,
+                 url: str | None = None, timeout: int | None = None,
+                 request_batch_size: int | None = None):
+        self.model_name = model_name
+        # ``url`` is ChromaDB's built-in spelling of ``base_url``; accept both
+        # so a config written by either class rebuilds here (issue #382).
+        self.base_url = (
+            base_url or url or os.getenv("OLLAMA_BASE_URL") or "http://localhost:11434"
+        ).rstrip("/")
+        # Mirror the attribute under the built-in's name as well.
+        self.url = self.base_url
+        self.timeout = int(timeout) if timeout else self.DEFAULT_TIMEOUT
+        self.request_batch_size = (
+            int(request_batch_size) if request_batch_size else self.DEFAULT_REQUEST_BATCH_SIZE
+        )
+
+    @staticmethod
+    def name() -> str:
+        return "ollama"
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "model_name": self.model_name,
+            "base_url": self.base_url,
+            # ChromaDB ships its own OllamaEmbeddingFunction registered under
+            # the same name "ollama". Whichever class wins the registry lookup
+            # gets this dict when the persisted collection config is rebuilt at
+            # query time; the built-in reads url/model_name/timeout and asserts
+            # "This code should not be reached" when any is missing (#382).
+            # Carrying both spellings makes the config valid for both classes.
+            "url": self.base_url,
+            "timeout": self.timeout,
+            # Extra keys are ignored by the built-in (it reads only
+            # url/model_name/timeout via .get()), so carrying ours is safe.
+            "request_batch_size": self.request_batch_size,
+        }
+
+    @staticmethod
+    def build_from_config(config: dict[str, Any]) -> "OllamaEmbeddingFunction":
+        return OllamaEmbeddingFunction(
+            model_name=config.get("model_name", "qwen3-embedding"),
+            base_url=config.get("base_url") or config.get("url"),
+            timeout=config.get("timeout"),
+            request_batch_size=config.get("request_batch_size"),
+        )
+
+    def __call__(self, input: Documents) -> Embeddings:
+        """Generate embeddings using Ollama's /api/embed endpoint.
+
+        Unlike the deprecated /api/embeddings route (single ``prompt`` -> single
+        ``embedding``), /api/embed accepts a batch via ``input`` and returns a
+        list under ``embeddings``, so several documents go out per request.
+
+        The caller's list is split into ``request_batch_size`` chunks so one
+        request never has to cover an unbounded amount of GPU work; see that
+        attribute for why. Vectors are concatenated back in input order.
+        """
+        try:
+            import requests
+        except ImportError:
+            raise ImportError("requests package is required for Ollama embeddings")
+
+        texts = list(input)
+        if not texts:
+            return []
+
+        endpoint = f"{self.base_url}/api/embed"
+        embeddings: list = []
+        for start in range(0, len(texts), self.request_batch_size):
+            window = texts[start : start + self.request_batch_size]
+            response = requests.post(
+                endpoint,
+                json={"model": self.model_name, "input": window},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+            vectors = data.get("embeddings")
+            if vectors is None:
+                raise ValueError(
+                    f"Ollama /api/embed returned no 'embeddings' field: {data}"
+                )
+            if len(vectors) != len(window):
+                # A short response would silently misalign every vector after
+                # it with the wrong document, poisoning the index in a way that
+                # only shows up as bad search results much later.
+                raise ValueError(
+                    f"Ollama /api/embed returned {len(vectors)} embeddings for "
+                    f"{len(window)} inputs"
+                )
+            embeddings.extend(vectors)
+        return embeddings

--- a/src/zotero_mcp/embeddings/providers/openai.py
+++ b/src/zotero_mcp/embeddings/providers/openai.py
@@ -1,0 +1,143 @@
+"""OpenAI (and OpenAI-compatible) embedding function."""
+
+import os
+from typing import Any
+
+from chromadb import Documents, Embeddings
+from chromadb.utils.embedding_functions import register_embedding_function
+
+from zotero_mcp.embeddings.base import BaseEmbeddingFunction
+
+
+@register_embedding_function
+class OpenAIEmbeddingFunction(BaseEmbeddingFunction):
+    """Custom OpenAI embedding function for ChromaDB.
+
+    Registered under the name "openai" so ChromaDB rebuilds it (rather than its
+    own incompatible built-in of the same name) when reloading a persisted
+    collection's config. ChromaDB >=1.x reconstructs the embedding function by
+    name from the stored config during upsert; without registration the name
+    collides with the built-in, whose build_from_config rejects our
+    {model_name, base_url} config.
+    """
+
+    max_input_tokens = 8000  # text-embedding-3-* limit is 8191
+
+    # Per-request input-list cap. OpenAI allows up to 2048 items but many
+    # OpenAI-compatible providers are stricter (SiliconFlow is 64 for
+    # /v1/embeddings, Mistral is 512, etc.). Defaulting to 64 keeps the code
+    # portable; real OpenAI users can raise embedding_config.request_batch_size.
+    DEFAULT_REQUEST_BATCH_SIZE = 64
+
+    def __init__(self, model_name: str = "text-embedding-3-small", api_key: str | None = None,
+                 base_url: str | None = None, request_batch_size: int | None = None,
+                 rate_limit_rps: float | None = None):
+        import threading
+        self.model_name = model_name
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self.base_url = base_url or os.getenv("OPENAI_BASE_URL")
+        self.request_batch_size = int(request_batch_size) if request_batch_size else self.DEFAULT_REQUEST_BATCH_SIZE
+        self.rate_limit_rps: float | None = float(rate_limit_rps) if rate_limit_rps else None
+        self._rate_lock = threading.Lock()
+        self._last_request_ts: float = 0.0
+        if not self.api_key:
+            raise ValueError("OpenAI API key is required")
+
+        try:
+            import openai
+            client_kwargs = {"api_key": self.api_key}
+            if self.base_url:
+                client_kwargs["base_url"] = self.base_url
+            self.client = openai.OpenAI(**client_kwargs)
+        except ImportError:
+            raise ImportError("openai package is required for OpenAI embeddings")
+
+    @staticmethod
+    def name() -> str:
+        return "openai"
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "model_name": self.model_name,
+            "base_url": self.base_url,
+            "request_batch_size": self.request_batch_size,
+            "rate_limit_rps": self.rate_limit_rps,
+            # ChromaDB's built-in EF of the same registered name rebuilds from
+            # {api_key_env_var, model_name, api_base, ...} and asserts ("This
+            # code should not be reached") when those are missing. Persisting
+            # its spellings too keeps the stored config buildable by whichever
+            # class wins the registry lookup (issue #382).
+            "api_key_env_var": "OPENAI_API_KEY",
+            "api_base": self.base_url,
+        }
+
+    @staticmethod
+    def build_from_config(config: dict[str, Any]) -> "OpenAIEmbeddingFunction":
+        # Accept either key spelling so a config written by ChromaDB's built-in
+        # (api_base / api_key_env_var) rebuilds here too.
+        api_key = config.get("api_key")
+        if not api_key and config.get("api_key_env_var"):
+            api_key = os.getenv(config["api_key_env_var"])
+        return OpenAIEmbeddingFunction(
+            model_name=config.get("model_name", "text-embedding-3-small"),
+            api_key=api_key,
+            base_url=config.get("base_url") or config.get("api_base"),
+            request_batch_size=config.get("request_batch_size"),
+            rate_limit_rps=config.get("rate_limit_rps"),
+        )
+
+    def _wait_for_rate_limit(self) -> None:
+        """Sleep as needed so successive embedding requests stay under
+        ``rate_limit_rps``. Applied per HTTP request (including each sub-batch)
+        so rate-limited providers see a steady cadence regardless of how many
+        inputs the caller passed. The lock keeps parallel threads honest.
+        """
+        rps = self.rate_limit_rps
+        if not rps or rps <= 0:
+            return
+        import time
+        with self._rate_lock:
+            min_interval = 1.0 / rps
+            wait = min_interval - (time.monotonic() - self._last_request_ts)
+            if wait > 0:
+                time.sleep(wait)
+            self._last_request_ts = time.monotonic()
+
+    def __call__(self, input: Documents) -> Embeddings:
+        """Generate embeddings using the OpenAI-compatible API.
+
+        ``encoding_format="float"`` is set explicitly. The OpenAI SDK otherwise
+        negotiates base64 by default, which OpenRouter's Gemini embedding
+        providers (e.g. ``google/gemini-embedding-001``) do not return reliably —
+        the SDK then raises "No embedding data received" intermittently. Forcing
+        float makes every OpenAI-compatible backend, native OpenAI included,
+        respond deterministically.
+        """
+        batch_size = self.request_batch_size or self.DEFAULT_REQUEST_BATCH_SIZE
+        vecs: Embeddings = []
+        for i in range(0, len(input), batch_size):
+            sub = input[i:i + batch_size]
+            self._wait_for_rate_limit()
+            response = self.client.embeddings.create(
+                model=self.model_name,
+                input=sub,
+                encoding_format="float",
+            )
+            vecs.extend(data.embedding for data in response.data)
+        return vecs
+
+    def truncate(self, text: str, max_tokens: int) -> str:
+        """Truncate using tiktoken cl100k_base (correct for OpenAI models)."""
+        try:
+            import tiktoken
+            if not hasattr(self, '_tokenizer'):
+                self._tokenizer = tiktoken.get_encoding("cl100k_base")
+            tokens = self._tokenizer.encode(text, disallowed_special=())
+            if len(tokens) > max_tokens:
+                tokens = tokens[:max_tokens]
+                text = self._tokenizer.decode(tokens)
+        except ImportError:
+            max_chars = max_tokens * 3
+            if len(text) > max_chars:
+                text = text[:max_chars]
+        return text

--- a/src/zotero_mcp/embeddings/registry.py
+++ b/src/zotero_mcp/embeddings/registry.py
@@ -1,0 +1,292 @@
+"""One source of truth for "which embedding providers exist, and how are they
+configured and constructed".
+
+This replaces two parallel if/elif chains that had to be kept in agreement by
+hand, both keyed on the same ``embedding_model`` string:
+
+- ``ChromaClient._create_embedding_function`` — string -> constructed embedding
+  function, reproduced here by :func:`resolve_provider` plus each spec's
+  ``ef_factory``.
+- the three near-identical per-provider blocks in
+  ``chroma_client.create_chroma_client`` that merge environment variables into
+  ``embedding_config``, reproduced here by :func:`merge_env_config` driven by
+  each spec's :class:`EnvSpec`.
+
+Provider names are frozen: ChromaDB persists the embedding function's name in a
+collection's config and rebuilds it by name on reload, so renaming one orphans
+every index built with it.
+
+This module imports the provider classes at module scope. That is safe in one
+direction only: provider modules depend on ``embeddings.base`` alone, never on
+this module or on ``chroma_client``.
+"""
+
+import os
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from zotero_mcp.embeddings.providers.gemini import GeminiEmbeddingFunction
+from zotero_mcp.embeddings.providers.huggingface import HuggingFaceEmbeddingFunction
+from zotero_mcp.embeddings.providers.ollama import OllamaEmbeddingFunction
+from zotero_mcp.embeddings.providers.openai import OpenAIEmbeddingFunction
+
+
+@dataclass(frozen=True)
+class EnvSpec:
+    """Which environment variables configure a provider, and how.
+
+    Mirrors one of the per-provider blocks in ``create_chroma_client``:
+
+    - ``api_key_vars`` are tried in order, first non-empty wins. Gemini needs
+      two because ``GOOGLE_API_KEY`` is the more commonly set of the pair.
+    - ``model_var`` / ``base_url_var`` are single variable names, or ``None``
+      when the provider reads none (huggingface and default have no env wiring
+      at all, matching the old chain's lack of a branch for them).
+    - ``requires_api_key`` reproduces the difference between the branches: for
+      openai/gemini the merged config is assigned back only when an api key was
+      actually resolved, for ollama it is assigned back unconditionally.
+    """
+
+    api_key_vars: tuple[str, ...] = ()
+    model_var: str | None = None
+    base_url_var: str | None = None
+    requires_api_key: bool = False
+
+    def reads_environment(self) -> bool:
+        """Whether this spec touches the environment at all.
+
+        False for the providers the old if/elif chain had no branch for, whose
+        ``embedding_config`` must therefore be left exactly as the caller
+        supplied it.
+        """
+        return bool(self.api_key_vars or self.model_var or self.base_url_var)
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """Everything needed to resolve, configure and construct one provider.
+
+    ``model_aliases`` maps a short alias the user may put in
+    ``embedding_model`` (``"qwen"``, ``"embeddinggemma"``) to the concrete
+    model name it stands for.
+    """
+
+    name: str
+    default_model: str | None
+    ef_factory: Callable[[dict[str, Any]], Any]
+    env: EnvSpec = field(default_factory=EnvSpec)
+    model_aliases: Mapping[str, str] = field(default_factory=dict)
+
+
+PROVIDERS: dict[str, ProviderSpec] = {}
+
+
+def register_provider(spec: ProviderSpec) -> ProviderSpec:
+    """Register (or replace) a provider spec by name, returning the spec."""
+    PROVIDERS[spec.name] = spec
+    return spec
+
+
+def _openai_ef_factory(config: dict[str, Any]) -> Any:
+    return OpenAIEmbeddingFunction(
+        model_name=config.get("model_name", "text-embedding-3-small"),
+        api_key=config.get("api_key"),
+        base_url=config.get("base_url"),
+        request_batch_size=config.get("request_batch_size"),
+        rate_limit_rps=config.get("rate_limit_rps"),
+    )
+
+
+def _gemini_ef_factory(config: dict[str, Any]) -> Any:
+    return GeminiEmbeddingFunction(
+        model_name=config.get("model_name", "gemini-embedding-001"),
+        api_key=config.get("api_key"),
+        base_url=config.get("base_url"),
+    )
+
+
+def _ollama_ef_factory(config: dict[str, Any]) -> Any:
+    return OllamaEmbeddingFunction(
+        model_name=config.get("model_name", "qwen3-embedding"),
+        base_url=config.get("base_url"),
+        timeout=config.get("timeout"),
+        request_batch_size=config.get("request_batch_size"),
+    )
+
+
+def _huggingface_ef_factory(config: dict[str, Any]) -> Any:
+    return HuggingFaceEmbeddingFunction(
+        model_name=config.get("model_name", "Qwen/Qwen3-Embedding-0.6B"),
+    )
+
+
+def _default_ef_factory(config: dict[str, Any]) -> Any:
+    from chromadb.utils import embedding_functions
+
+    ef = embedding_functions.DefaultEmbeddingFunction()
+    ef.max_input_tokens = 256  # all-MiniLM-L6-v2 max_seq_length
+    return ef
+
+
+register_provider(
+    ProviderSpec(
+        name="openai",
+        default_model="text-embedding-3-small",
+        ef_factory=_openai_ef_factory,
+        env=EnvSpec(
+            api_key_vars=("OPENAI_API_KEY",),
+            model_var="OPENAI_EMBEDDING_MODEL",
+            base_url_var="OPENAI_BASE_URL",
+            requires_api_key=True,
+        ),
+    )
+)
+
+register_provider(
+    ProviderSpec(
+        name="gemini",
+        default_model="gemini-embedding-001",
+        ef_factory=_gemini_ef_factory,
+        env=EnvSpec(
+            api_key_vars=("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+            model_var="GEMINI_EMBEDDING_MODEL",
+            base_url_var="GEMINI_BASE_URL",
+            requires_api_key=True,
+        ),
+    )
+)
+
+register_provider(
+    ProviderSpec(
+        name="ollama",
+        default_model="qwen3-embedding",
+        ef_factory=_ollama_ef_factory,
+        env=EnvSpec(
+            model_var="OLLAMA_EMBEDDING_MODEL",
+            base_url_var="OLLAMA_BASE_URL",
+            requires_api_key=False,
+        ),
+    )
+)
+
+register_provider(
+    ProviderSpec(
+        name="huggingface",
+        default_model="Qwen/Qwen3-Embedding-0.6B",
+        ef_factory=_huggingface_ef_factory,
+        model_aliases={
+            "qwen": "Qwen/Qwen3-Embedding-0.6B",
+            "embeddinggemma": "google/embeddinggemma-300m",
+        },
+    )
+)
+
+register_provider(
+    ProviderSpec(
+        name="default",
+        default_model=None,
+        ef_factory=_default_ef_factory,
+    )
+)
+
+
+def resolve_provider(
+    embedding_model: str,
+) -> tuple[ProviderSpec, dict[str, Any], dict[str, Any]]:
+    """Map an ``embedding_model`` string to its provider and any config the
+    string itself implies.
+
+    Returns ``(spec, defaults, overrides)``. The caller builds the effective
+    config as ``{**defaults, **embedding_config, **overrides}`` — i.e.
+    ``defaults`` lose to an explicit ``embedding_config`` entry and
+    ``overrides`` beat one. Two dicts rather than one because the old chain
+    resolved the two alias cases in opposite directions, and this is a pure
+    refactor:
+
+    - ``"qwen"`` did ``embedding_config.get("model_name", "Qwen/...")``, so an
+      explicit ``model_name`` won -> a *default*.
+    - a bare HuggingFace model name passed ``self.embedding_model`` straight to
+      the constructor, ignoring ``embedding_config["model_name"]`` entirely ->
+      an *override*.
+
+    The rules, mirroring ``_create_embedding_function``'s chain in order:
+
+    - any registered provider name other than ``"huggingface"``/``"default"``
+      (``"openai"``, ``"gemini"``, ``"ollama"``) -> that provider, no extras.
+      Generalized from the old hardcoded literals, so a provider added later is
+      reachable by its bare name with no change to this function.
+    - ``"qwen"`` / ``"embeddinggemma"`` -> huggingface, with the aliased model
+      name as a default.
+    - anything else that is not ``"default"`` -> huggingface, with the string
+      itself as an override. This preserves the legacy quirk that the literal
+      string ``"huggingface"`` is treated as a *model* name (there is no
+      sentence-transformers model called that, so it fails at load time) rather
+      than selecting the huggingface provider — which is why ``"huggingface"``
+      is excluded from the first rule.
+    - ``"default"`` -> ChromaDB's built-in embedding function.
+    """
+    huggingface_spec = PROVIDERS["huggingface"]
+
+    if embedding_model in PROVIDERS and embedding_model not in ("huggingface", "default"):
+        return PROVIDERS[embedding_model], {}, {}
+
+    if embedding_model in huggingface_spec.model_aliases:
+        return huggingface_spec, {"model_name": huggingface_spec.model_aliases[embedding_model]}, {}
+
+    if embedding_model != "default":
+        return huggingface_spec, {}, {"model_name": embedding_model}
+
+    return PROVIDERS["default"], {}, {}
+
+
+def create_embedding_function(
+    embedding_model: str, embedding_config: dict[str, Any] | None
+) -> Any:
+    """Construct the embedding function for a configured ``embedding_model``."""
+    spec, defaults, overrides = resolve_provider(embedding_model)
+    config = {**defaults, **(embedding_config or {}), **overrides}
+    return spec.ef_factory(config)
+
+
+def merge_env_config(
+    embedding_model: str, embedding_config: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Fill gaps in ``embedding_config`` from the environment.
+
+    Precedence is unchanged from the blocks this replaces: an explicit
+    ``embedding_config`` value wins over an env var, which wins over the
+    provider's hardcoded default. Only *absent or falsy* keys are filled, so a
+    stray provider env var (a ``GOOGLE_API_KEY`` leaked in from another tool,
+    say) can never displace a value the user configured.
+
+    Returns the config to use. Providers with no env wiring, and — for
+    api-key-requiring providers — the case where no key could be resolved from
+    either source, return ``embedding_config`` untouched, exactly as the old
+    chain left it.
+    """
+    spec = resolve_provider(embedding_model)[0]
+    env = spec.env
+    if not env.reads_environment():
+        return embedding_config
+
+    ec = dict(embedding_config or {})
+
+    if env.api_key_vars and not ec.get("api_key"):
+        for var in env.api_key_vars:
+            env_key = os.getenv(var)
+            if env_key:
+                ec["api_key"] = env_key
+                break
+
+    if env.model_var and not ec.get("model_name"):
+        ec["model_name"] = os.getenv(env.model_var, spec.default_model)
+
+    if env.base_url_var and not ec.get("base_url"):
+        env_base = os.getenv(env.base_url_var)
+        if env_base:
+            ec["base_url"] = env_base
+
+    if env.requires_api_key and not ec.get("api_key"):
+        return embedding_config
+    return ec

--- a/tests/test_embedding_provider_resolution.py
+++ b/tests/test_embedding_provider_resolution.py
@@ -1,0 +1,336 @@
+"""Characterization tests for embedding-provider resolution and env merging.
+
+These pin the two behaviours that used to be spelled out as parallel if/elif
+chains keyed on ``embedding_model``:
+
+- ``ChromaClient._create_embedding_function`` — which class gets built, with
+  which arguments, for a given model string.
+- ``create_chroma_client`` — which environment variables are merged into
+  ``embedding_config``, and when the merged result is kept.
+
+The env-merge half in particular had no coverage at all, which is what made it
+risky to consolidate. Everything here is written against the public surface
+(``chroma_client.ChromaClient`` / ``chroma_client.create_chroma_client``) and
+never imports the registry, so this file passes unchanged both before and after
+the providers moved into ``zotero_mcp.embeddings`` — it describes behaviour, not
+structure.
+
+Construction is intercepted by patching the embedding function class's own
+``__init__`` rather than the name the caller looks up, because those namespaces
+differ between the two implementations while the class object does not. That
+also keeps the tests offline: no sentence-transformers download, no ONNX model
+fetch, no API client.
+"""
+
+import json
+
+import pytest
+
+pytest.importorskip("chromadb")
+
+from zotero_mcp import chroma_client  # noqa: E402
+
+# Every environment variable the code under test consults. Cleared before each
+# test so a developer's real shell (or a leaked GOOGLE_API_KEY) cannot change
+# the outcome.
+_ENV_VARS = (
+    "ZOTERO_EMBEDDING_MODEL",
+    "OPENAI_API_KEY",
+    "OPENAI_EMBEDDING_MODEL",
+    "OPENAI_BASE_URL",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_EMBEDDING_MODEL",
+    "GEMINI_BASE_URL",
+    "OLLAMA_EMBEDDING_MODEL",
+    "OLLAMA_BASE_URL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Which embedding function does a model string build?
+# ---------------------------------------------------------------------------
+
+
+def _client(embedding_model, embedding_config=None):
+    """A ChromaClient without __init__'s on-disk PersistentClient side effects.
+
+    ``_create_embedding_function`` reads only these two attributes.
+    """
+    client = chroma_client.ChromaClient.__new__(chroma_client.ChromaClient)
+    client.embedding_model = embedding_model
+    client.embedding_config = embedding_config or {}
+    return client
+
+
+@pytest.fixture
+def hf_args(monkeypatch):
+    """Capture the arguments HuggingFaceEmbeddingFunction is constructed with.
+
+    Patching ``__init__`` on the class itself (not on a module-level name)
+    intercepts construction no matter which module resolved the class.
+    """
+    seen = {}
+
+    def fake_init(self, model_name="Qwen/Qwen3-Embedding-0.6B"):
+        seen["model_name"] = model_name
+
+    monkeypatch.setattr(
+        chroma_client.HuggingFaceEmbeddingFunction, "__init__", fake_init
+    )
+    return seen
+
+
+def test_qwen_alias_expands_to_the_concrete_model(hf_args):
+    _client("qwen")._create_embedding_function()
+    assert hf_args["model_name"] == "Qwen/Qwen3-Embedding-0.6B"
+
+
+def test_embeddinggemma_alias_expands_to_the_concrete_model(hf_args):
+    _client("embeddinggemma")._create_embedding_function()
+    assert hf_args["model_name"] == "google/embeddinggemma-300m"
+
+
+def test_an_explicit_model_name_overrides_an_alias(hf_args):
+    """For the aliases, embedding_config.model_name wins over the expansion."""
+    _client("qwen", {"model_name": "BAAI/bge-m3"})._create_embedding_function()
+    assert hf_args["model_name"] == "BAAI/bge-m3"
+
+
+def test_a_bare_model_string_beats_an_explicit_model_name(hf_args):
+    """...but for a bare model string the string itself wins.
+
+    The opposite direction from the alias case above. Asymmetric, and only
+    reachable by configuring both at once, but it is the established
+    behaviour, so it is pinned here rather than quietly normalized.
+    """
+    _client(
+        "sentence-transformers/all-mpnet-base-v2", {"model_name": "BAAI/bge-m3"}
+    )._create_embedding_function()
+    assert hf_args["model_name"] == "sentence-transformers/all-mpnet-base-v2"
+
+
+def test_the_literal_string_huggingface_is_treated_as_a_model_name(hf_args):
+    """A legacy quirk: "huggingface" does not select the provider generically.
+
+    It falls through to the bare-model-string rule, so it is passed to
+    sentence-transformers as a model name (where it fails to load). Preserved
+    deliberately — changing it would alter behaviour, not just structure.
+    """
+    _client("huggingface")._create_embedding_function()
+    assert hf_args["model_name"] == "huggingface"
+
+
+def test_default_uses_chromadbs_builtin_capped_at_256_tokens(monkeypatch):
+    from chromadb.utils import embedding_functions
+
+    class _FakeDefaultEF:
+        pass
+
+    monkeypatch.setattr(
+        embedding_functions, "DefaultEmbeddingFunction", _FakeDefaultEF
+    )
+
+    ef = _client("default")._create_embedding_function()
+
+    assert isinstance(ef, _FakeDefaultEF)
+    # all-MiniLM-L6-v2's max_seq_length; the pipeline truncates against it.
+    assert ef.max_input_tokens == 256
+
+
+def test_openai_receives_every_configured_knob():
+    pytest.importorskip("openai")
+
+    ef = _client(
+        "openai",
+        {
+            "model_name": "text-embedding-3-large",
+            "api_key": "test-key-no-network",
+            "base_url": "https://example.invalid/v1",
+            "request_batch_size": 8,
+            "rate_limit_rps": 2.5,
+        },
+    )._create_embedding_function()
+
+    assert isinstance(ef, chroma_client.OpenAIEmbeddingFunction)
+    assert ef.model_name == "text-embedding-3-large"
+    assert ef.api_key == "test-key-no-network"
+    assert ef.base_url == "https://example.invalid/v1"
+    assert ef.request_batch_size == 8
+    assert ef.rate_limit_rps == 2.5
+
+
+def test_openai_falls_back_to_its_default_model(monkeypatch):
+    pytest.importorskip("openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key-no-network")
+
+    ef = _client("openai")._create_embedding_function()
+
+    assert ef.model_name == "text-embedding-3-small"
+    assert ef.request_batch_size == (
+        chroma_client.OpenAIEmbeddingFunction.DEFAULT_REQUEST_BATCH_SIZE
+    )
+    assert ef.rate_limit_rps is None
+
+
+# ---------------------------------------------------------------------------
+# Which environment variables reach embedding_config?
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def built_config(monkeypatch, tmp_path):
+    """Run create_chroma_client and return the kwargs it passed to ChromaClient."""
+    captured = {}
+
+    class _RecordingChromaClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(chroma_client, "ChromaClient", _RecordingChromaClient)
+
+    def run(semantic_search):
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps({"semantic_search": semantic_search}))
+        chroma_client.create_chroma_client(str(path))
+        return captured
+
+    return run
+
+
+def test_openai_env_fills_every_gap(monkeypatch, built_config):
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    monkeypatch.setenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-large")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://env.invalid/v1")
+
+    config = built_config({"embedding_model": "openai"})
+
+    assert config["embedding_config"] == {
+        "api_key": "env-key",
+        "model_name": "text-embedding-3-large",
+        "base_url": "https://env.invalid/v1",
+    }
+
+
+def test_config_json_wins_over_the_environment(monkeypatch, built_config):
+    """A stale env var must never displace an explicitly configured value."""
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    monkeypatch.setenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-large")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://env.invalid/v1")
+
+    config = built_config(
+        {
+            "embedding_model": "openai",
+            "embedding_config": {
+                "api_key": "file-key",
+                "model_name": "text-embedding-3-small",
+                "base_url": "https://file.invalid/v1",
+            },
+        }
+    )
+
+    assert config["embedding_config"] == {
+        "api_key": "file-key",
+        "model_name": "text-embedding-3-small",
+        "base_url": "https://file.invalid/v1",
+    }
+
+
+def test_openai_model_name_defaults_when_no_env_var_is_set(built_config):
+    """The api key is still required for the merged config to be kept..."""
+    config = built_config(
+        {"embedding_model": "openai", "embedding_config": {"api_key": "file-key"}}
+    )
+
+    assert config["embedding_config"]["model_name"] == "text-embedding-3-small"
+    assert "base_url" not in config["embedding_config"]
+
+
+def test_openai_without_any_api_key_leaves_the_config_untouched(built_config):
+    """...and without one, the merge is discarded rather than half-applied.
+
+    No api key means the embedding function will refuse to construct anyway;
+    the point is that the defaulted model_name is not silently written back.
+    """
+    config = built_config(
+        {"embedding_model": "openai", "embedding_config": {"chunk_size": 512}}
+    )
+
+    assert config["embedding_config"] == {"chunk_size": 512}
+
+
+def test_gemini_prefers_gemini_api_key_over_google_api_key(monkeypatch, built_config):
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-key")
+
+    config = built_config({"embedding_model": "gemini"})
+
+    assert config["embedding_config"]["api_key"] == "gemini-key"
+    assert config["embedding_config"]["model_name"] == "gemini-embedding-001"
+
+
+def test_gemini_falls_back_to_google_api_key(monkeypatch, built_config):
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-key")
+
+    config = built_config({"embedding_model": "gemini"})
+
+    assert config["embedding_config"]["api_key"] == "google-key"
+
+
+def test_ollama_merges_without_needing_an_api_key(monkeypatch, built_config):
+    """Ollama keeps the merged config unconditionally — it has no api key."""
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://gpu:11434")
+
+    config = built_config({"embedding_model": "ollama"})
+
+    assert config["embedding_config"] == {
+        "model_name": "qwen3-embedding",
+        "base_url": "http://gpu:11434",
+    }
+
+
+def test_ollama_model_name_defaults_with_no_env_at_all(built_config):
+    config = built_config({"embedding_model": "ollama"})
+
+    assert config["embedding_config"] == {"model_name": "qwen3-embedding"}
+
+
+@pytest.mark.parametrize(
+    "embedding_model", ["default", "qwen", "embeddinggemma", "BAAI/bge-m3"]
+)
+def test_providers_without_env_wiring_ignore_the_environment(
+    monkeypatch, built_config, embedding_model
+):
+    """The local providers had no branch in the old chain, and still read nothing.
+
+    A leaked OPENAI_API_KEY/GOOGLE_API_KEY from another tool must not seep into
+    a locally-embedded configuration.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-key")
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://gpu:11434")
+
+    config = built_config(
+        {"embedding_model": embedding_model, "embedding_config": {"chunk_size": 512}}
+    )
+
+    assert config["embedding_config"] == {"chunk_size": 512}
+
+
+def test_env_model_only_fills_in_when_config_is_left_at_default(
+    monkeypatch, built_config
+):
+    """ZOTERO_EMBEDDING_MODEL must not downgrade an explicitly configured provider."""
+    monkeypatch.setenv("ZOTERO_EMBEDDING_MODEL", "default")
+
+    config = built_config(
+        {"embedding_model": "ollama", "embedding_config": {"model_name": "bge-m3"}}
+    )
+
+    assert config["embedding_model"] == "ollama"

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,0 +1,140 @@
+"""Unit tests for the embedding provider registry itself.
+
+Behavioural equivalence with the if/elif chains this registry replaced is
+covered in ``test_embedding_provider_resolution.py``, which is deliberately
+written against ``chroma_client`` only. This file tests the registry's own API:
+the shape ``resolve_provider`` returns, and the invariants a new provider has
+to respect.
+"""
+
+import pytest
+
+pytest.importorskip("chromadb")
+
+from zotero_mcp.embeddings.registry import (  # noqa: E402
+    PROVIDERS,
+    EnvSpec,
+    ProviderSpec,
+    merge_env_config,
+    register_provider,
+    resolve_provider,
+)
+
+
+def _effective_config(embedding_model, embedding_config):
+    """Apply the merge rule that ``create_embedding_function`` uses."""
+    _, defaults, overrides = resolve_provider(embedding_model)
+    return {**defaults, **embedding_config, **overrides}
+
+
+@pytest.mark.parametrize("name", ["openai", "gemini", "ollama", "huggingface", "default"])
+def test_every_expected_provider_is_registered(name):
+    """These names are persisted in collection configs and cannot be renamed."""
+    assert name in PROVIDERS
+    assert PROVIDERS[name].name == name
+
+
+@pytest.mark.parametrize("name", ["openai", "gemini", "ollama"])
+def test_a_provider_name_resolves_to_itself_with_no_extras(name):
+    spec, defaults, overrides = resolve_provider(name)
+
+    assert spec is PROVIDERS[name]
+    assert defaults == {}
+    assert overrides == {}
+
+
+def test_aliases_resolve_to_huggingface_as_a_default():
+    """An alias supplies model_name as a *default*, so config still wins."""
+    spec, defaults, overrides = resolve_provider("qwen")
+
+    assert spec is PROVIDERS["huggingface"]
+    assert defaults == {"model_name": "Qwen/Qwen3-Embedding-0.6B"}
+    assert overrides == {}
+    assert _effective_config("qwen", {"model_name": "x"})["model_name"] == "x"
+
+
+def test_a_bare_model_string_resolves_as_an_override():
+    """A bare model string supplies model_name as an *override*, beating config.
+
+    The asymmetry against the alias case above is why resolve_provider returns
+    two dicts instead of one.
+    """
+    spec, defaults, overrides = resolve_provider("BAAI/bge-m3")
+
+    assert spec is PROVIDERS["huggingface"]
+    assert defaults == {}
+    assert overrides == {"model_name": "BAAI/bge-m3"}
+    assert _effective_config("BAAI/bge-m3", {"model_name": "x"})["model_name"] == "BAAI/bge-m3"
+
+
+def test_default_resolves_to_the_builtin_spec():
+    spec, defaults, overrides = resolve_provider("default")
+
+    assert spec is PROVIDERS["default"]
+    assert (defaults, overrides) == ({}, {})
+
+
+def test_local_providers_declare_no_environment_wiring():
+    for name in ("huggingface", "default"):
+        assert not PROVIDERS[name].env.reads_environment()
+
+
+def test_merge_env_config_is_identity_for_providers_without_env_wiring():
+    original = {"chunk_size": 512}
+
+    assert merge_env_config("default", original) is original
+    assert merge_env_config("qwen", original) is original
+
+
+def test_a_newly_registered_provider_is_reachable_by_its_bare_name():
+    """Adding a provider must not require editing resolve_provider.
+
+    This is the extensibility the registry exists to buy: PR 3 and PR 4 both
+    add providers, and neither should have to touch the resolution logic.
+    """
+    sentinel = object()
+    spec = ProviderSpec(
+        name="test-provider",
+        default_model="test-model",
+        ef_factory=lambda config: sentinel,
+        env=EnvSpec(api_key_vars=("TEST_PROVIDER_API_KEY",), requires_api_key=True),
+    )
+    try:
+        register_provider(spec)
+
+        resolved, defaults, overrides = resolve_provider("test-provider")
+
+        assert resolved is spec
+        assert (defaults, overrides) == ({}, {})
+    finally:
+        del PROVIDERS["test-provider"]
+
+    # ...and once unregistered it falls back to being a HuggingFace model name.
+    assert resolve_provider("test-provider")[0] is PROVIDERS["huggingface"]
+
+
+def test_merge_env_config_reads_api_key_vars_in_order(monkeypatch):
+    spec = ProviderSpec(
+        name="test-provider",
+        default_model="test-model",
+        ef_factory=lambda config: None,
+        env=EnvSpec(
+            api_key_vars=("TEST_FIRST_KEY", "TEST_SECOND_KEY"),
+            model_var="TEST_MODEL",
+            requires_api_key=True,
+        ),
+    )
+    try:
+        register_provider(spec)
+        monkeypatch.delenv("TEST_FIRST_KEY", raising=False)
+        monkeypatch.setenv("TEST_SECOND_KEY", "second")
+        monkeypatch.delenv("TEST_MODEL", raising=False)
+
+        merged = merge_env_config("test-provider", {})
+
+        assert merged == {"api_key": "second", "model_name": "test-model"}
+
+        monkeypatch.setenv("TEST_FIRST_KEY", "first")
+        assert merge_env_config("test-provider", {})["api_key"] == "first"
+    finally:
+        del PROVIDERS["test-provider"]


### PR DESCRIPTION
This is the second of the staged PRs splitting up #397. It is a pure refactor: no
behaviour change, no new features, no new dependencies. It exists to give the
streaming/rate-limiting and Gemini Batch PRs a place to land without either of
them having to also restructure `chroma_client.py`.

Independent of #440 — both branch from `main` and touch disjoint files.

## The problem

`chroma_client.py` was 1243 lines, and roughly half of it was embedding
functions rather than ChromaDB client code. Four provider classes
(OpenAI, Gemini, HuggingFace, Ollama) sat in the same module as the client that
uses them.

Worse, two separate if/elif chains keyed on the same `embedding_model` string
had to be kept in agreement by hand:

- `ChromaClient._create_embedding_function` — which class to build, with which
  arguments.
- `create_chroma_client` — three near-identical blocks merging provider
  environment variables into `embedding_config`.

Adding a provider meant remembering to edit both, in two different parts of the
file. #423 was in part a symptom of that split: the ollama branch of the first
chain silently dropped `timeout` while the second chain happily accepted it.

## What changed

```
src/zotero_mcp/embeddings/
├── base.py                  BaseEmbeddingFunction
├── providers/
│   ├── openai.py            OpenAIEmbeddingFunction
│   ├── gemini.py            GeminiEmbeddingFunction
│   ├── huggingface.py       HuggingFaceEmbeddingFunction
│   └── ollama.py            OllamaEmbeddingFunction
└── registry.py              ProviderSpec / EnvSpec / resolve_provider
```

`chroma_client.py` goes from 1243 lines to 669 (+29/-603) and re-exports the
four classes. Both chains become one call each:

```python
def _create_embedding_function(self) -> EmbeddingFunction:
    return create_embedding_function(self.embedding_model, self.embedding_config)
```

```python
config["embedding_config"] = merge_env_config(
    config["embedding_model"], config.get("embedding_config")
)
```

A provider is now one `ProviderSpec`: its default model, its factory, and an
`EnvSpec` declaring which environment variables it reads and whether the merged
config is kept when no API key resolves. Adding one no longer requires touching
resolution logic — there is a test for exactly that.

## Why the classes were not copied from the #397 branch

The `feature/batch-semantic-search` provider files predate fixes that have since
landed on `main` — most importantly `OllamaEmbeddingFunction`'s `DEFAULT_TIMEOUT`,
its configurable `timeout`, and the per-request chunking from #423. Porting them
forward would have silently reverted that fix.

So the classes here are moved from **current `main`**, not from the branch. Only
the branch's *structure* was reused.

## Behaviour preservation

Class bodies are unchanged apart from two mechanical edits, and nothing else:

1. The base class is now `BaseEmbeddingFunction` instead of ChromaDB's
   `EmbeddingFunction` (which `BaseEmbeddingFunction` itself subclasses).
2. Five duplicated method bodies moved to that base — three identical copies of
   `embed_query` (OpenAI, HuggingFace, Ollama) and two identical copies of the
   4-chars-per-token `truncate` (Gemini, Ollama). The specialised overrides stay
   put: OpenAI's tiktoken `truncate`, HuggingFace's tokenizer `truncate`,
   Gemini's `embed_query`.

That is the complete diff of the moved code — 42 changed lines across the four
classes: the four base-class declarations, and 34 lines of removed duplication.
Nothing was added to any class body.

`BaseEmbeddingFunction` holds *only* those two methods. No rate limiting, no
retries, no sub-batching, no parallelism: each provider keeps its own `__call__`
exactly as it was. Unifying those loops is a behaviour change and belongs with
the streaming work, not with this move.

### Tests

The three existing test files covering this code pass **unmodified**:

```
$ git status --short tests/          # nothing modified
$ pytest tests/test_ollama_timeout_config.py \
         tests/test_ollama_embedding.py \
         tests/test_embedding_function_registration.py
26 passed
```

That last one matters most: it asserts
`known_embedding_functions["openai"] is chroma_client.OpenAIEmbeddingFunction`
by *identity*, so it only passes if the re-exported name is the very class
ChromaDB has registered. It also builds instances via `Cls.__new__(Cls)` with
only a subset of attributes set, which is why `BaseEmbeddingFunction` reads
`chars_per_token` as a class attribute rather than assuming `__init__` ran.

Full suite: **1694 passed**, up from 1658, with no test file modified.

### Characterization tests for the env merge

The env-merge blocks had **no test coverage at all**, which is what made
consolidating them risky. `tests/test_embedding_provider_resolution.py` (new)
pins the behaviour first: precedence (`config.json` > env var > default), the
`GEMINI_API_KEY`-before-`GOOGLE_API_KEY` order, ollama merging without an API
key while openai/gemini discard the merge without one, and local providers
ignoring the environment entirely.

It is written against `chroma_client`'s public surface and never imports the
registry, **so it passes unchanged against `main` as well as against this
branch** — verified by checking out `main`'s `chroma_client.py` over this one
and re-running:

```
$ git checkout upstream/main -- src/zotero_mcp/chroma_client.py
$ pytest tests/test_embedding_provider_resolution.py
21 passed
```

Same 21 tests, same file, both implementations. That is the equivalence
argument, and it is reproducible rather than a claim.

Two quirks turned up while writing it and are pinned rather than quietly fixed:

- For the `qwen` / `embeddinggemma` aliases an explicit `model_name` in
  `embedding_config` wins, but for a bare HuggingFace model string the string
  itself wins. This asymmetry is why `resolve_provider` returns *two* dicts
  (`defaults`, `overrides`) instead of one.
- The literal string `"huggingface"` is treated as a model *name*, not as a
  provider selector, so it fails at load time. Preserved as-is.

Both are only reachable by configuring two things at once, and both are
documented at the point of the code that implements them.

## Review notes

- The diff reads as bulk motion. `src/zotero_mcp/embeddings/providers/*.py`
  against the corresponding class in `main`'s `chroma_client.py` is the useful
  comparison; the two mechanical edits above are the entire delta.
- `chroma_client.py`'s re-export block is load-bearing, not tidiness — ChromaDB
  resolves persisted collections' embedding functions by name to a class object,
  and the existing tests check that identity.
- Provider names (`"openai"`, `"gemini"`, `"huggingface"`, `"ollama"`) are frozen:
  they are persisted in every existing collection's config and rebuilt by name on
  reload. Renaming one would orphan users' indexes.
- No public API is removed. Everything importable from `zotero_mcp.chroma_client`
  before this PR is still importable from it.
