### PR TITLE
perf: import submodules without loading the MCP server

### DIFF
--- a/src/zotero_mcp/__init__.py
+++ b/src/zotero_mcp/__init__.py
@@ -4,12 +4,52 @@ Zotero MCP - Model Context Protocol server for Zotero
 This module provides tools for AI assistants to interact with Zotero libraries.
 """
 
+from typing import TYPE_CHECKING
+
 from ._version import __version__ as __version__
 
-try:
-    from .server import mcp  # noqa: F401
-except ImportError:
-    pass
+if TYPE_CHECKING:  # pragma: no cover - type checkers only
+    from .server import mcp as mcp
+
+__all__ = ["__version__", "mcp"]
+
+
+def __getattr__(name: str):
+    """Import ``mcp`` lazily (PEP 562).
+
+    ``from .server import mcp`` at module scope made *every* import of any
+    submodule pay for the whole server: FastMCP, the MCP SDK, pydantic,
+    pyzotero, bibtexparser and unidecode all get pulled in before the
+    submodule's own code runs. Measured on 0.9.1, ``from
+    zotero_mcp.schema import valid_fields`` cost ~1.45 s and ~1480 modules,
+    of which ``schema`` itself was 8 microseconds -- it is a stdlib-only
+    module whose whole point is offline field resolution.
+
+    That matters for consumers that use this package as a library rather
+    than as a server: schema lookups, DOI normalisation and the CLI's
+    lighter subcommands should not require the server's dependency tree to
+    be importable, let alone imported.
+
+    ``from zotero_mcp import mcp`` keeps working unchanged, and still
+    degrades to AttributeError rather than raising when the server's
+    optional dependencies are missing -- matching the previous
+    ``try/except ImportError`` behaviour.
+    """
+    if name == "mcp":
+        try:
+            from .server import mcp
+        except ImportError as exc:  # optional server deps absent
+            raise AttributeError(
+                "zotero_mcp.mcp is unavailable: the MCP server dependencies "
+                f"are not installed ({exc})."
+            ) from exc
+        return mcp
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
 
 # These modules are not imported by default but are available
 # pdfannots_helper and pdfannots_downloader

--- a/src/zotero_mcp/identifiers.py
+++ b/src/zotero_mcp/identifiers.py
@@ -1,0 +1,61 @@
+"""Public, dependency-free normalisation of scholarly identifiers.
+
+``tools/_helpers.py`` has carried ``_normalize_doi`` since the batch-import
+work, and it is the only canonical DOI handling this package exposes. Two
+problems with leaving it there:
+
+* it is private, in a private module, so downstream consumers that want the
+  same canonicalisation the server uses have to import
+  ``zotero_mcp.tools._helpers._normalize_doi`` and pin themselves to an
+  implementation detail;
+* ``tools/_helpers`` pulls in ``requests``, ``pyzotero`` and the rest of the
+  tool layer, which is a heavy price for ten lines of string handling.
+
+This module is stdlib-only and imports nothing from the rest of the
+package, so ``from zotero_mcp.identifiers import normalize_doi`` stays
+cheap. ``tools/_helpers`` re-exports the private name, so existing callers
+and tests are unaffected.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["normalize_doi"]
+
+#: A well-formed DOI: the ``10.NNNN`` registrant prefix plus a suffix.
+DOI_RE = re.compile(r"^10\.\d{4,9}/\S+$")
+
+_DOI_IN_URL_RE = re.compile(
+    r"doi\.org/(10\.\d{4,9}/[^\s?#]+)", flags=re.IGNORECASE
+)
+
+#: Punctuation that trails a DOI copied out of prose or a reference list.
+_TRAILING_PUNCT = ".,);]"
+
+
+def normalize_doi(raw):
+    """Normalize a DOI string from various input formats.
+
+    Accepts a bare DOI, a ``doi:`` prefixed form, or a ``doi.org`` /
+    ``dx.doi.org`` URL, and strips trailing punctuation picked up from
+    surrounding prose. Returns the canonical bare DOI, or ``None`` when the
+    input is not a DOI.
+
+    Case is preserved: DOIs are case-insensitive for resolution, but some
+    consumers (Scite among them) echo back what they were given.
+    """
+    if not raw:
+        return None
+    s = str(raw).strip()
+    if s.lower().startswith("doi:"):
+        s = s[4:].strip()
+    if s.lower().startswith("http://") or s.lower().startswith("https://"):
+        m = _DOI_IN_URL_RE.search(s)
+        if not m:
+            return None
+        s = m.group(1)
+    s = s.rstrip(_TRAILING_PUNCT)
+    if DOI_RE.match(s):
+        return s
+    return None

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -13,6 +13,7 @@ import requests
 
 from zotero_mcp import client as _client
 from zotero_mcp import utils as _utils
+from zotero_mcp.identifiers import normalize_doi
 from zotero_mcp.utils import _paginate
 
 # ---------------------------------------------------------------------------
@@ -635,22 +636,10 @@ def _collection_not_found_message(zot, spec, paths) -> str:
     return msg
 
 
-def _normalize_doi(raw):
-    """Normalize a DOI string from various input formats."""
-    if not raw:
-        return None
-    s = raw.strip()
-    if s.lower().startswith("doi:"):
-        s = s[4:].strip()
-    if s.lower().startswith("http://") or s.lower().startswith("https://"):
-        m = re.search(r"doi\.org/(10\.\d{4,9}/[^\s?#]+)", s, flags=re.IGNORECASE)
-        if not m:
-            return None
-        s = m.group(1)
-    s = s.rstrip(".,);]")
-    if re.match(r"^10\.\d{4,9}/\S+$", s):
-        return s
-    return None
+#: Compatibility alias. The implementation moved to the public,
+#: stdlib-only :mod:`zotero_mcp.identifiers` so consumers can import it
+#: without pulling in the tool layer. Existing callers keep working.
+_normalize_doi = normalize_doi
 
 
 def _normalize_isbn(raw):

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -1,0 +1,71 @@
+"""Tests for the public identifier helpers.
+
+``normalize_doi`` moved out of ``tools/_helpers`` so downstream consumers
+can import canonical DOI handling without the tool layer. The behaviour is
+unchanged; ``tests/test_shared_helpers.py`` still exercises it through the
+private alias, which is what proves the move is transparent.
+"""
+
+import pytest
+
+from zotero_mcp.identifiers import normalize_doi
+
+
+class TestNormalizeDoi:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("10.1038/nphys1170", "10.1038/nphys1170"),
+            ("  10.1038/nphys1170  ", "10.1038/nphys1170"),
+            ("doi:10.1038/nphys1170", "10.1038/nphys1170"),
+            ("DOI: 10.1038/nphys1170", "10.1038/nphys1170"),
+            ("https://doi.org/10.1038/nphys1170", "10.1038/nphys1170"),
+            ("http://dx.doi.org/10.1038/nphys1170", "10.1038/nphys1170"),
+            ("https://DOI.ORG/10.1038/nphys1170", "10.1038/nphys1170"),
+        ],
+    )
+    def test_accepted_forms(self, raw, expected):
+        assert normalize_doi(raw) == expected
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("10.1038/nphys1170.", "10.1038/nphys1170"),
+            ("10.1038/nphys1170,", "10.1038/nphys1170"),
+            ("10.1038/nphys1170)", "10.1038/nphys1170"),
+            ("10.1038/nphys1170];", "10.1038/nphys1170"),
+        ],
+    )
+    def test_trailing_punctuation_from_prose(self, raw, expected):
+        assert normalize_doi(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            None,
+            "",
+            "   ",
+            "not-a-doi",
+            "10.1/x",                              # registrant prefix too short
+            "11.1038/nphys1170",                   # wrong directory indicator
+            "https://example.com/10.1038/nphys1170",  # not a doi.org URL
+        ],
+    )
+    def test_rejected(self, raw):
+        assert normalize_doi(raw) is None
+
+    def test_case_is_preserved(self):
+        """DOIs resolve case-insensitively, but Scite echoes back what it
+        was given, so normalisation must not lower-case."""
+        assert normalize_doi("10.1038/NPhys1170") == "10.1038/NPhys1170"
+
+    def test_non_string_input_is_coerced(self):
+        assert normalize_doi(12345) is None
+
+
+def test_private_alias_is_the_same_object():
+    """`tools/_helpers._normalize_doi` is kept as a compatibility alias;
+    existing callers and tests must not observe the move."""
+    from zotero_mcp.tools._helpers import _normalize_doi
+
+    assert _normalize_doi is normalize_doi

--- a/tests/test_lightweight_imports.py
+++ b/tests/test_lightweight_imports.py
@@ -1,0 +1,90 @@
+"""Importing a submodule must not drag in the MCP server.
+
+``zotero_mcp/__init__.py`` used to do ``from .server import mcp`` eagerly,
+so any ``import zotero_mcp.<anything>`` pulled in FastMCP, the MCP SDK,
+pydantic, pyzotero, bibtexparser and unidecode first. On 0.9.1 that made
+``from zotero_mcp.schema import valid_fields`` -- a stdlib-only, offline
+field lookup -- cost roughly 1.45 s and ~1480 modules.
+
+These tests pin the lazy behaviour. They run each import in a *subprocess*
+because import cost is only observable on a cold interpreter: by the time
+the test suite is running, ``conftest`` has already imported half the
+package.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = str(Path(__file__).resolve().parents[1] / "src")
+
+# Packages that only the server needs. `schema` and `identifiers` are
+# stdlib-only by design and must not reach any of them.
+SERVER_ONLY_MODULES = ("fastmcp", "mcp", "pydantic", "pyzotero", "bibtexparser")
+
+
+def _modules_after_importing(statement: str) -> set[str]:
+    """Top-level module names loaded by `statement` in a fresh interpreter."""
+    code = (
+        "import sys\n"
+        f"sys.path.insert(0, {SRC!r})\n"
+        f"{statement}\n"
+        "print(' '.join(sorted({m.split('.')[0] for m in sys.modules})))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return set(result.stdout.split())
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "from zotero_mcp.schema import valid_fields",
+        "from zotero_mcp.identifiers import normalize_doi",
+    ],
+)
+def test_stdlib_only_submodules_do_not_import_the_server(statement: str) -> None:
+    loaded = _modules_after_importing(statement)
+    leaked = sorted(set(SERVER_ONLY_MODULES) & loaded)
+    assert not leaked, (
+        f"{statement!r} pulled in server-only dependencies {leaked}. "
+        f"Something re-introduced an eager import in zotero_mcp/__init__.py "
+        f"or in the submodule itself."
+    )
+
+
+def test_version_is_available_without_the_server() -> None:
+    loaded = _modules_after_importing("import zotero_mcp; zotero_mcp.__version__")
+    leaked = sorted(set(SERVER_ONLY_MODULES) & loaded)
+    assert not leaked, (
+        f"`import zotero_mcp` alone pulled in {leaked}; the package root "
+        f"should expose __version__ without loading the server."
+    )
+
+
+def test_mcp_attribute_still_resolves() -> None:
+    """The lazy path must be transparent: `from zotero_mcp import mcp`
+    keeps working, it just happens on first access now."""
+    from zotero_mcp import mcp
+    from zotero_mcp.server import mcp as direct
+
+    assert mcp is direct
+
+
+def test_mcp_is_advertised_by_dir() -> None:
+    import zotero_mcp
+
+    assert "mcp" in dir(zotero_mcp)
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    import zotero_mcp
+
+    with pytest.raises(AttributeError):
+        zotero_mcp.does_not_exist


### PR DESCRIPTION
## Problem

`zotero_mcp/__init__.py` imports the server eagerly:

```python
try:
    from .server import mcp  # noqa: F401
except ImportError:
    pass
```

so *any* `import zotero_mcp.<submodule>` pays for the whole server before the submodule's own code runs — FastMCP, the MCP SDK, pydantic, pyzotero, bibtexparser and unidecode all get pulled in.

Measured on 0.9.1 (`python -X importtime`):

| | cumulative | modules in `sys.modules` |
|---|---|---|
| `from zotero_mcp.schema import valid_fields` | **~1.73 s** | ~1480 |
| `zotero_mcp.schema` itself | 8 µs | — |
| `import pyzotero.zotero`, for scale | ~0.29 s | — |

All of the cost is the package `__init__`. `schema.py` is deliberately stdlib-only — its whole point is that base-field resolution keeps working offline, from the vendored table or the on-disk cache.

This matters for consumers that use the package **as a library** rather than as a server. `zotero_mcp.schema.valid_fields` is the natural way to filter fields before a batch write (the Zotero API fails an entire 50-item POST on one unknown field key), but reaching it today requires the full server stack to be installed and importable.

## Change

**1. `mcp` resolves lazily** via a PEP 562 module `__getattr__`.

`from zotero_mcp import mcp` is unchanged — it just imports the server on first access. It still degrades to `AttributeError` rather than propagating, matching the previous `try/except ImportError` behaviour when optional server deps are absent. Nothing inside the package uses `from zotero_mcp import mcp`; internal callers already go through `zotero_mcp.server`.

After: **~9 ms, 75 modules**, with none of `fastmcp` / `mcp` / `pydantic` / `pyzotero` / `bibtexparser` loaded.

**2. `_normalize_doi` gets a public home.**

It was the only canonical DOI handling the package exposes, but private, in a private module, and sitting behind `requests` + `pyzotero`. A downstream consumer wanting the same canonicalisation the server uses has to write `from zotero_mcp.tools._helpers import _normalize_doi` and pin itself to an implementation detail.

Moved verbatim to a new stdlib-only `zotero_mcp/identifiers.py` as `normalize_doi`. `tools/_helpers._normalize_doi` is kept as an alias, so every existing caller and the existing assertions in `tests/test_shared_helpers.py` are untouched — which is what demonstrates the move is transparent.

Happy to drop this half if you'd rather keep the surface small; part 1 stands alone.

## Tests

- `tests/test_lightweight_imports.py` — asserts the server packages stay out of `sys.modules` for stdlib-only submodules. Runs each import in a **subprocess**, since import cost is only observable on a cold interpreter (by the time the suite runs, `conftest` has already imported half the package). Also covers `from zotero_mcp import mcp` still resolving to the same object, `dir()`, and unknown-attribute behaviour.
- `tests/test_identifiers.py` — covers `normalize_doi` directly, including case preservation (Scite echoes back what it is given) and the trailing-punctuation handling.

Full suite: **1685 passed**. `ruff check` is clean on every file this touches (the repo has 120 pre-existing findings elsewhere, left alone).

## Context

Found while auditing a downstream plugin ([mronkko/claude-academic-research](https://github.com/mronkko/claude-academic-research)) that imports `zotero_mcp.schema.valid_fields` from a `uv run` script with PEP 723 inline dependencies. It was paying the full server import on every invocation of a batch Zotero importer, and declaring the entire server dependency tree to do it.