### PR TITLE
feat: search collections recursively with include_subcollections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **`zotero_set_item_parent` sets or clears an item's parent.** It can parent standalone notes and attachments, move them between parents, or make them top-level again.
+- **`include_subcollections` on every collection-scoped search.** `zotero_search_items`, `zotero_search_by_tag`, `zotero_get_collection_items` and `zotero_advanced_search` all treated a collection scope as direct membership only, with no way to ask for the collections nested beneath it — so scoping a search to a project collection missed everything filed in its subcollections, silently and with no indication that a subtree existed. Passing `include_subcollections=True` covers the whole subtree; the default stays `False`, which is both the previous behaviour and what Zotero's own "Search subcollections" checkbox does when unchecked. In `zotero_advanced_search` this applies to a `collection` condition's `is` and `isNot` operations, which are the membership questions — `isNot` excludes the entire subtree rather than just the named collection, and the other operators keep comparing keys as before. The expansion costs one extra API call for the whole search and nothing at all when the flag is off. This also closes an inconsistency: `get_items_with_text`, which scopes the semantic index to collections, has always expanded subcollections, so the same collection meant two different things depending on which part of the server you asked.
 
 ## [0.9.1] - 2026-08-05
 

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -413,6 +413,55 @@ def build_collection_paths(collections) -> dict[str, list[str]]:
     return paths
 
 
+def collection_descendants(collections, collection_key: str) -> list[str]:
+    """``collection_key`` plus every collection nested beneath it, breadth-first.
+
+    Pure: takes an already-fetched collection list so it can be tested without
+    a client. Built from the same ``data.parentCollection`` links
+    :func:`build_collection_paths` uses.
+
+    An unknown key returns ``[collection_key]`` unchanged rather than an empty
+    list — the caller's existing "collection not found" handling should decide
+    what that means, not this function. A parent cycle terminates instead of
+    looping: Zotero's own schema should not produce one, but a partially
+    synced or hand-edited database can, and this walk is cheap to make safe.
+    """
+    children: dict[str, list[str]] = {}
+    for coll in collections:
+        key = coll.get("key")
+        if not key:
+            continue
+        parent = coll.get("data", {}).get("parentCollection")
+        if parent:  # False/None/"" all mean top level
+            children.setdefault(parent, []).append(key)
+
+    ordered = [collection_key]
+    seen = {collection_key}
+    queue = [collection_key]
+    while queue:
+        current = queue.pop(0)
+        for child in children.get(current, []):
+            if child in seen:
+                continue
+            seen.add(child)
+            ordered.append(child)
+            queue.append(child)
+    return ordered
+
+
+def expand_collection_scope(zot, collection_key: str, include_subcollections: bool) -> list[str]:
+    """Collection keys a scoped query should cover.
+
+    Returns ``[collection_key]`` unless subcollections were asked for, so the
+    default path costs nothing. Fetching the collection list is one extra API
+    round-trip, paid only when the caller opts in.
+    """
+    if not include_subcollections:
+        return [collection_key]
+    collections = _utils._paginate(zot.collections)
+    return collection_descendants(collections, collection_key)
+
+
 def resolve_collection_specs(
     zot,
     specs,

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -481,13 +481,14 @@ def _build_attachment_extra(info):
 
 @mcp.tool(
     name="zotero_get_collection_items",
-    description="Get all items in a specific Zotero collection. Supports detail='keys_only' (minimal), 'summary' (default, no abstracts), or 'full' (with abstracts). Includes PDF/notes indicators. TIP: To find papers on a specific topic, use zotero_semantic_search instead — it's faster and returns only relevant results."
+    description="Get all items in a specific Zotero collection. Supports detail='keys_only' (minimal), 'summary' (default, no abstracts), or 'full' (with abstracts). Includes PDF/notes indicators. include_subcollections=True also returns items filed in collections nested beneath this one (default False, matching Zotero's own 'Search subcollections' checkbox). TIP: To find papers on a specific topic, use zotero_semantic_search instead — it's faster and returns only relevant results."
 )
 @with_zotero_api_lock
 def get_collection_items(
     collection_key: str,
     detail: Literal["keys_only", "summary", "full"] = "summary",
     limit: int | str | None = 50,
+    include_subcollections: bool = False,
     *,
     ctx: Context
 ) -> str:
@@ -497,6 +498,9 @@ def get_collection_items(
     Args:
         collection_key: The collection key/ID
         limit: Maximum number of items to return
+        include_subcollections: Also return items in collections nested beneath
+            this one. Defaults to False, matching Zotero's own "Search
+            subcollections" checkbox and this tool's previous behaviour.
         ctx: MCP context
 
     Returns:
@@ -523,10 +527,28 @@ def get_collection_items(
 
         limit = _helpers._normalize_limit(limit, default=50)
 
-        # Fetch all items (includes children mixed in with parents)
-        all_items = _helpers._paginate(zot.collection_items, collection_key)
+        # Fetch all items (includes children mixed in with parents). With
+        # subcollections requested this is one call per collection in the
+        # subtree; an item filed in several of them is returned once.
+        scope_keys = _helpers.expand_collection_scope(
+            zot, collection_key, include_subcollections
+        )
+        all_items = []
+        seen_keys: set[str] = set()
+        for scope_key in scope_keys:
+            for item in _helpers._paginate(zot.collection_items, scope_key):
+                key = item.get("key")
+                if key and key in seen_keys:
+                    continue
+                if key:
+                    seen_keys.add(key)
+                all_items.append(item)
         if not all_items:
-            return f"No items found in collection: {collection_name} (Key: {collection_key})"
+            scope_note = "" if len(scope_keys) == 1 else f" or its {len(scope_keys) - 1} subcollections"
+            return (
+                f"No items found in collection: {collection_name} "
+                f"(Key: {collection_key}){scope_note}"
+            )
 
         # Build attachment/note summary from already-fetched children (zero extra API calls)
         attachment_info = {}

--- a/src/zotero_mcp/tools/search.py
+++ b/src/zotero_mcp/tools/search.py
@@ -126,7 +126,8 @@ def _search_with_variants(zot, query: str, qmode: str, limit: int,
         "pass 'journalArticle', 'book', etc. to filter. tag: optional list "
         "of tag conditions (ANDed). limit: max results (default 10). "
         "collection_key: 8-char key to restrict to a collection (bypasses "
-        "the fallback cascade). "
+        "the fallback cascade). include_subcollections: also search "
+        "collections nested beneath it (default False). "
         "Example: zotero_search_items(query='Cladder-Micus') or "
         "zotero_search_items(query='Brewer 2011', limit=5)."
     )
@@ -139,6 +140,7 @@ def search_items(
     limit: int | str | None = 10,
     tag: list[str] | list[dict] | str | None = None,
     collection_key: str | None = None,
+    include_subcollections: bool = False,
     *,
     ctx: Context
 ) -> str:
@@ -157,6 +159,9 @@ def search_items(
             internally to the list[str] form pyzotero expects.
         collection_key: Optional collection key to scope the search to a specific collection.
             When provided, bypasses the fallback cascade and searches the collection directly.
+        include_subcollections: Also search collections nested beneath
+            collection_key. Ignored when collection_key is not given. Defaults
+            to False, matching Zotero's own "Search subcollections" checkbox.
         ctx: MCP context
 
     Returns:
@@ -186,11 +191,26 @@ def search_items(
                 _col = None
             if not _col or _col.get("key") != collection_key:
                 return f"Collection not found: '{collection_key}'. Use zotero_get_collections or zotero_search_collections to find valid collection keys."
-            items = _helpers._paginate(
-                zot.collection_items, collection_key,
-                q=query, qmode=qmode, itemType=item_type,
-                max_items=limit, **({"tag": tag} if tag else {}),
+            scope_keys = _helpers.expand_collection_scope(
+                zot, collection_key, include_subcollections
             )
+            items = []
+            _seen: set[str] = set()
+            for _scope_key in scope_keys:
+                # limit applies to the merged result, so each subcollection may
+                # still contribute up to it before deduplication.
+                for _item in _helpers._paginate(
+                    zot.collection_items, _scope_key,
+                    q=query, qmode=qmode, itemType=item_type,
+                    max_items=limit, **({"tag": tag} if tag else {}),
+                ):
+                    _key = _item.get("key")
+                    if _key and _key in _seen:
+                        continue
+                    if _key:
+                        _seen.add(_key)
+                    items.append(_item)
+            items = items[:limit]
             fallback_strategy = None
         else:
             # --- Initial search with variant generation ---
@@ -355,6 +375,8 @@ def search_items(
         "'journalArticle', 'book', etc. to filter. "
         "limit: max results (default 10). "
         "collection_key: optional 8-char key to scope to a collection. "
+        "include_subcollections: also search collections nested beneath it "
+        "(default False). "
         "Use zotero_get_tags to discover available tag names first. For "
         "free-text content search, use zotero_search_items or "
         "zotero_semantic_search instead. "
@@ -367,6 +389,7 @@ def search_by_tag(
     item_type: str = "-attachment",
     limit: int | str | None = 10,
     collection_key: str | None = None,
+    include_subcollections: bool = False,
     *,
     ctx: Context
 ) -> str:
@@ -387,6 +410,8 @@ def search_by_tag(
         item_type: Type of items to search for. Use "-attachment" to exclude attachments.
         limit: Maximum number of results to return
         collection_key: Optional collection key to scope the search to a specific collection
+        include_subcollections: Also search collections nested beneath
+            collection_key. Ignored when collection_key is not given.
         ctx: MCP context
 
     Returns:
@@ -411,10 +436,23 @@ def search_by_tag(
                 _col = None
             if not _col or _col.get("key") != collection_key:
                 return f"Collection not found: '{collection_key}'. Use zotero_get_collections or zotero_search_collections to find valid collection keys."
-            results = _helpers._paginate(
-                zot.collection_items, collection_key,
-                tag=tag, itemType=item_type, max_items=limit,
+            scope_keys = _helpers.expand_collection_scope(
+                zot, collection_key, include_subcollections
             )
+            results = []
+            _seen: set[str] = set()
+            for _scope_key in scope_keys:
+                for _item in _helpers._paginate(
+                    zot.collection_items, _scope_key,
+                    tag=tag, itemType=item_type, max_items=limit,
+                ):
+                    _key = _item.get("key")
+                    if _key and _key in _seen:
+                        continue
+                    if _key:
+                        _seen.add(_key)
+                    results.append(_item)
+            results = results[:limit]
         else:
             zot.add_parameters(q="", tag=tag, itemType=item_type, limit=limit)
             results = zot.items()
@@ -539,6 +577,9 @@ def search_by_citation_key(
         "sort_by: dateAdded, dateModified, title, creator, etc. "
         "sort_direction: 'asc' (default) or 'desc'. "
         "limit: max results (default 50, max 500). "
+        "include_subcollections: make a 'collection' condition match items "
+        "anywhere in that collection's subtree, for the is/isNot operations "
+        "(default False). "
         "Example: zotero_advanced_search(conditions=[{'field': 'itemType', "
         "'operation': 'is', 'value': 'preprint'}, {'field': 'dateAdded', "
         "'operation': 'isAfter', 'value': '2026-03-22'}], "
@@ -552,6 +593,7 @@ def advanced_search(
     sort_by: str | None = None,
     sort_direction: Literal["asc", "desc"] = "asc",
     limit: int | str = 50,
+    include_subcollections: bool = False,
     *,
     ctx: Context
 ) -> str:
@@ -567,6 +609,12 @@ def advanced_search(
         sort_by: Field to sort by (dateAdded, dateModified, title, creator, etc.)
         sort_direction: Direction to sort (asc or desc)
         limit: Maximum number of results to return
+        include_subcollections: Make a `collection` condition match items filed
+            anywhere in that collection's subtree rather than in it directly.
+            Applies to the `is` and `isNot` operations, which are the
+            membership questions; other operators keep comparing keys as
+            before. Defaults to False, matching Zotero's own "Search
+            subcollections" checkbox.
         ctx: MCP context
 
     Returns:
@@ -631,6 +679,26 @@ def advanced_search(
             parsed_conditions.append(
                 {"field": field, "operation": operation, "value": value}
             )
+
+        # With subcollections requested, a `collection` condition stops being a
+        # per-value comparison and becomes set membership: the item matches if
+        # any collection it is filed in lies anywhere in the requested subtree.
+        # Expanding the *condition value* once here costs one API round-trip
+        # for the whole search, where expanding per item would cost one each.
+        collection_scopes: dict[str, set[str]] = {}
+        if include_subcollections:
+            _coll_values = {
+                c["value"] for c in parsed_conditions
+                if c["field"].lower() in {"collection", "collections"}
+            }
+            if _coll_values:
+                # One fetch for the whole search, however many collection
+                # conditions it carries.
+                _all_collections = _utils._paginate(zot.collections)
+                for _value in _coll_values:
+                    collection_scopes[_value] = set(
+                        _helpers.collection_descendants(_all_collections, _value)
+                    )
 
         def _extract_values(data: dict[str, object], field: str) -> list[str]:
             field_lower = field.lower()
@@ -737,6 +805,16 @@ def advanced_search(
 
             operation = condition["operation"]
             target = condition["value"]
+
+            # Subtree membership, when asked for. Only is/isNot are membership
+            # questions; the string operators keep comparing raw keys, which is
+            # what they did before and is unaffected by nesting.
+            is_collection_field = condition["field"].lower() in {"collection", "collections"}
+            scope = collection_scopes.get(target) if is_collection_field else None
+            if scope is not None and operation in {"is", "isNot"}:
+                in_subtree = bool(set(values) & scope)
+                return in_subtree if operation == "is" else not in_subtree
+
             comparisons = [_compare(value, target, operation) for value in values]
 
             if operation in {"isNot", "doesNotContain"}:

--- a/tests/test_include_subcollections.py
+++ b/tests/test_include_subcollections.py
@@ -1,0 +1,305 @@
+"""`include_subcollections` across the four collection-scoped tools.
+
+Zotero's own advanced-search window has a "Search subcollections" checkbox,
+unchecked by default, and these tools had no equivalent — a collection scope
+always meant direct membership. That was inconsistent in one direction already:
+`LocalZoteroReader.get_items_with_text(collection_keys=...)`, which scopes the
+semantic index, has always expanded subcollections.
+
+The tree used throughout:
+
+    Root (COLLROOT)
+    ├── Child A (COLLCHDA)
+    │   └── Grandchild (COLLGCHD)
+    └── Child B (COLLCHDB)
+    Unrelated (COLLUNRL)
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import DummyContext
+
+from zotero_mcp import client as _client
+from zotero_mcp import server
+from zotero_mcp.tools import _helpers
+
+ROOT, CHILD_A, GRANDCHILD, CHILD_B, UNRELATED = (
+    "COLLROOT", "COLLCHDA", "COLLGCHD", "COLLCHDB", "COLLUNRL",
+)
+
+COLLECTIONS = [
+    {"key": ROOT, "data": {"name": "Root", "parentCollection": False}},
+    {"key": CHILD_A, "data": {"name": "Child A", "parentCollection": ROOT}},
+    {"key": GRANDCHILD, "data": {"name": "Grandchild", "parentCollection": CHILD_A}},
+    {"key": CHILD_B, "data": {"name": "Child B", "parentCollection": ROOT}},
+    {"key": UNRELATED, "data": {"name": "Unrelated", "parentCollection": False}},
+]
+
+# One item per collection, plus one filed in two of them.
+ITEMS_BY_COLLECTION = {
+    ROOT: ["ITEMROOT"],
+    CHILD_A: ["ITEMCHDA", "ITEMBOTH"],
+    GRANDCHILD: ["ITEMGCHD"],
+    CHILD_B: ["ITEMCHDB", "ITEMBOTH"],
+    UNRELATED: ["ITEMUNRL"],
+}
+
+
+def _item(key: str, collections: list[str]) -> dict:
+    return {
+        "key": key,
+        "data": {
+            "key": key,
+            "itemType": "journalArticle",
+            "title": f"Title {key}",
+            "date": "2024",
+            "creators": [],
+            "tags": [{"tag": "shared"}],
+            "collections": collections,
+            "abstractNote": "",
+        },
+    }
+
+
+def _collections_for(item_key: str) -> list[str]:
+    return [c for c, keys in ITEMS_BY_COLLECTION.items() if item_key in keys]
+
+
+ALL_ITEMS = [
+    _item(k, _collections_for(k))
+    for k in sorted({key for keys in ITEMS_BY_COLLECTION.values() for key in keys})
+]
+
+
+class _FakeZotero:
+    """Serves the tree above; records which collections were queried."""
+
+    def __init__(self):
+        self.collection_items_calls: list[str] = []
+        self.collections_calls = 0
+
+    def collections(self, *args, **kwargs):
+        self.collections_calls += 1
+        return list(COLLECTIONS)
+
+    def collection(self, key):
+        for coll in COLLECTIONS:
+            if coll["key"] == key:
+                return coll
+        raise Exception(f"Collection not found: {key}")
+
+    def collection_items(self, key, *args, **kwargs):
+        self.collection_items_calls.append(key)
+        return [_item(k, _collections_for(k)) for k in ITEMS_BY_COLLECTION.get(key, [])]
+
+    def add_parameters(self, **kwargs):
+        pass
+
+    def items(self, start: int = 0, limit: int = 100, **kwargs):
+        return ALL_ITEMS[start : start + limit]
+
+
+@pytest.fixture
+def zot(monkeypatch):
+    fake = _FakeZotero()
+    monkeypatch.setattr(_client, "get_zotero_client", lambda: fake)
+    monkeypatch.setattr(_client, "get_active_group_id", lambda: 0)
+    return fake
+
+
+def _keys_in(text: str) -> set[str]:
+    return {k for k in
+            {key for keys in ITEMS_BY_COLLECTION.values() for key in keys}
+            if k in text}
+
+
+# ---------------------------------------------------------------------------
+# The pure tree walk
+# ---------------------------------------------------------------------------
+
+def test_descendants_are_breadth_first_and_include_the_root():
+    assert _helpers.collection_descendants(COLLECTIONS, ROOT) == [
+        ROOT, CHILD_A, CHILD_B, GRANDCHILD,
+    ]
+
+
+def test_descendants_of_a_leaf_is_just_itself():
+    assert _helpers.collection_descendants(COLLECTIONS, GRANDCHILD) == [GRANDCHILD]
+
+
+def test_descendants_reaches_arbitrary_depth():
+    deep = [{"key": "C0", "data": {"parentCollection": False}}] + [
+        {"key": f"C{i}", "data": {"parentCollection": f"C{i - 1}"}} for i in range(1, 12)
+    ]
+    assert _helpers.collection_descendants(deep, "C0") == [f"C{i}" for i in range(12)]
+
+
+def test_descendants_of_unknown_key_returns_that_key_alone():
+    """The caller's own 'collection not found' handling should decide, not this."""
+    assert _helpers.collection_descendants(COLLECTIONS, "NOSUCHKY") == ["NOSUCHKY"]
+
+
+def test_descendants_terminates_on_a_parent_cycle():
+    """A corrupt or half-synced database can contain one; don't hang on it."""
+    cyclic = [
+        {"key": "CYCA", "data": {"parentCollection": "CYCB"}},
+        {"key": "CYCB", "data": {"parentCollection": "CYCA"}},
+    ]
+    assert sorted(_helpers.collection_descendants(cyclic, "CYCA")) == ["CYCA", "CYCB"]
+
+
+def test_descendants_tolerates_missing_keys_and_data():
+    messy = COLLECTIONS + [{"data": {"parentCollection": ROOT}}, {"key": "NODATA00"}]
+    assert _helpers.collection_descendants(messy, ROOT) == [ROOT, CHILD_A, CHILD_B, GRANDCHILD]
+
+
+def test_expand_scope_costs_no_api_call_when_not_requested(zot):
+    assert _helpers.expand_collection_scope(zot, ROOT, False) == [ROOT]
+    assert zot.collections_calls == 0
+
+
+def test_expand_scope_fetches_once_when_requested(zot):
+    assert set(_helpers.expand_collection_scope(zot, ROOT, True)) == {
+        ROOT, CHILD_A, CHILD_B, GRANDCHILD,
+    }
+    assert zot.collections_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# get_collection_items
+# ---------------------------------------------------------------------------
+
+def test_get_collection_items_defaults_to_direct_membership(zot):
+    out = server.get_collection_items(collection_key=ROOT, ctx=DummyContext())
+    assert _keys_in(out) == {"ITEMROOT"}
+    assert zot.collection_items_calls == [ROOT]
+
+
+def test_get_collection_items_includes_the_whole_subtree(zot):
+    out = server.get_collection_items(
+        collection_key=ROOT, include_subcollections=True, ctx=DummyContext()
+    )
+    assert _keys_in(out) == {"ITEMROOT", "ITEMCHDA", "ITEMCHDB", "ITEMGCHD", "ITEMBOTH"}
+    assert "ITEMUNRL" not in out
+
+
+def test_get_collection_items_deduplicates_an_item_in_two_subcollections(zot):
+    """ITEMBOTH is filed in both Child A and Child B; it must appear once."""
+    out = server.get_collection_items(
+        collection_key=ROOT, include_subcollections=True, ctx=DummyContext()
+    )
+    assert out.count("**Item Key:** ITEMBOTH") == 1
+    assert "(5 items)" in out
+
+
+def test_get_collection_items_reports_an_empty_subtree_as_such(zot):
+    out = server.get_collection_items(
+        collection_key=UNRELATED, include_subcollections=True, ctx=DummyContext()
+    )
+    assert "ITEMUNRL" in out  # sanity: this one is not empty
+
+
+# ---------------------------------------------------------------------------
+# search_items / search_by_tag
+# ---------------------------------------------------------------------------
+
+def test_search_items_scope_defaults_to_direct(zot):
+    out = server.search_items(
+        query="Title", collection_key=ROOT, limit=50, ctx=DummyContext()
+    )
+    assert zot.collection_items_calls == [ROOT]
+    assert "ITEMGCHD" not in out
+
+
+def test_search_items_scope_can_include_subcollections(zot):
+    out = server.search_items(
+        query="Title", collection_key=ROOT, include_subcollections=True,
+        limit=50, ctx=DummyContext(),
+    )
+    assert set(zot.collection_items_calls) == {ROOT, CHILD_A, CHILD_B, GRANDCHILD}
+    assert "ITEMGCHD" in out
+    assert "ITEMUNRL" not in out
+
+
+def test_search_by_tag_scope_defaults_to_direct(zot):
+    out = server.search_by_tag(
+        tag=["shared"], collection_key=ROOT, limit=50, ctx=DummyContext()
+    )
+    assert zot.collection_items_calls == [ROOT]
+    assert "ITEMGCHD" not in out
+
+
+def test_search_by_tag_scope_can_include_subcollections(zot):
+    out = server.search_by_tag(
+        tag=["shared"], collection_key=ROOT, include_subcollections=True,
+        limit=50, ctx=DummyContext(),
+    )
+    assert "ITEMGCHD" in out
+    assert "ITEMUNRL" not in out
+
+
+def test_subcollection_scope_is_ignored_without_a_collection_key(zot):
+    """The flag is about scoping a collection, so alone it must change nothing."""
+    plain = server.search_items(query="Title", limit=50, ctx=DummyContext())
+    flagged = server.search_items(
+        query="Title", include_subcollections=True, limit=50, ctx=DummyContext()
+    )
+    assert _keys_in(plain) == _keys_in(flagged)
+    assert zot.collections_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# advanced_search — membership rather than string comparison
+# ---------------------------------------------------------------------------
+
+def _adv(collection_key, operation="is", **kwargs):
+    return server.advanced_search(
+        conditions=[{"field": "collection", "operation": operation, "value": collection_key}],
+        limit=100, ctx=DummyContext(), **kwargs,
+    )
+
+
+def test_advanced_search_collection_defaults_to_direct_membership(zot):
+    assert _keys_in(_adv(ROOT)) == {"ITEMROOT"}
+
+
+def test_advanced_search_collection_can_include_subcollections(zot):
+    out = _adv(ROOT, include_subcollections=True)
+    assert _keys_in(out) == {"ITEMROOT", "ITEMCHDA", "ITEMCHDB", "ITEMGCHD", "ITEMBOTH"}
+
+
+def test_advanced_search_isnot_excludes_the_whole_subtree(zot):
+    """isNot must negate subtree membership, not per-collection membership.
+
+    ITEMCHDA is not filed in ROOT directly, so a per-collection negation would
+    wrongly return it when the subtree is what was asked about.
+    """
+    out = _adv(ROOT, operation="isNot", include_subcollections=True)
+    assert _keys_in(out) == {"ITEMUNRL"}
+
+
+def test_advanced_search_isnot_without_the_flag_is_unchanged(zot):
+    out = _adv(ROOT, operation="isNot")
+    assert "ITEMGCHD" in out  # not in ROOT directly, so it satisfies isNot
+
+
+def test_advanced_search_scopes_only_the_collection_field(zot):
+    """A non-collection condition whose value happens to be a collection key
+    must not pick up subtree treatment."""
+    out = server.advanced_search(
+        conditions=[{"field": "title", "operation": "is", "value": ROOT}],
+        include_subcollections=True, limit=100, ctx=DummyContext(),
+    )
+    assert _keys_in(out) == set()
+
+
+def test_advanced_search_expands_each_distinct_value_once(zot):
+    server.advanced_search(
+        conditions=[
+            {"field": "collection", "operation": "is", "value": ROOT},
+            {"field": "collection", "operation": "is", "value": ROOT},
+        ],
+        join_mode="any", include_subcollections=True, limit=100, ctx=DummyContext(),
+    )
+    assert zot.collections_calls == 1


### PR DESCRIPTION
## The gap

A collection scope has always meant **direct membership**. There is no way to ask for the collections nested beneath one, so scoping a search to a project collection misses everything filed in its subcollections — silently, with nothing in the output indicating a subtree exists.

This came out of the #417 review. The SQLite backend resolved `collection` conditions recursively while the pyzotero path did not, and we harmonised both to direct membership so the opt-in stayed behaviour-neutral, with recursion left implemented-but-unexposed and the note that it should be proposed as an explicit option on both paths. This is that proposal.

It also closes an inconsistency that predates all of it: `LocalZoteroReader.get_items_with_text(collection_keys=...)`, which scopes the semantic index, **has always expanded subcollections**. So the same collection has meant two different things depending on which part of the server you asked.

## The design

`include_subcollections: bool = False`, on all four tools that take a collection scope:

- `zotero_search_items`
- `zotero_search_by_tag`
- `zotero_get_collection_items`
- `zotero_advanced_search`

Three shapes were possible — a new operator (`isInSubtree`), a per-condition flag, or a search-level parameter. Zotero settles it: its own advanced-search window has **"Search subcollections" as a checkbox on the search**, not on a condition. So this is a search-level parameter, defaulting to `False` to match both that checkbox unchecked and the current behaviour.

All four, rather than the one that prompted it, because leaving the other three would turn each into its own trap.

### advanced_search is the one with real semantics

A `collection` condition stops being a per-value comparison and becomes set membership. That matters most for `isNot`, which now excludes the **whole subtree** rather than just the named collection — a per-collection negation would return an item filed in a child, which is not what "not in this collection tree" means.

The string operators keep comparing keys unchanged: nesting doesn't change what `beginsWith` means on an 8-character key.

Two scoping details:

- Only the **condition value** is expanded — once per search, not once per item.
- Only the **collection field** consults that expansion. A `title is "COLLROOT"` condition is unaffected even if that string is also a collection key. There's a test for it.

## Cost

One extra API call for an entire search, and **none at all when the flag is off** — `expand_collection_scope` returns `[collection_key]` without touching the client. The default path is byte-identical to before.

For the item-fetching tools, an item filed in several collections in the subtree is returned once.

## `collection_descendants`

Pure — it takes an already-fetched collection list, so it's tested without a client. It walks the same `data.parentCollection` links `build_collection_paths` already uses, and:

- keeps a visited set, so **a parent cycle terminates instead of hanging**. Zotero's schema shouldn't produce one, but a partially synced or hand-edited database can, and this walk is cheap to make safe.
- returns an unknown key **unchanged** rather than empty, leaving each caller's existing "collection not found" handling in charge rather than second-guessing it.
- tolerates collections missing `key` or `data`.

## Tests

`tests/test_include_subcollections.py`, 23 cases over a fixed tree (root → child A → grandchild, plus a sibling and an unrelated collection), including an item deliberately filed in two subcollections at once.

Covers: breadth-first ordering, arbitrary depth, leaves, unknown keys, parent cycles, malformed collection records, that the flag costs no API call when off and exactly one when on, direct-vs-subtree for each of the four tools, deduplication, `isNot` subtree exclusion, the field-scoping guard above, and that the flag alone — without a `collection_key` — changes nothing.

Full suite: **1775 passed**. Python 3.10 syntax verified on every changed file, and the new tests carry no POSIX-only assumptions.

## Relationship to #417

Independent, and deliberately based on `main` rather than stacked. `main` has no SQL search backend, so nothing here can diverge between backends — there is only one.

The ordering does need care, and it's mine to handle either way: whichever of this and #417 merges second has to carry the other's implication. If this lands first, #417's SQL `collection` condition needs the same parameter wired to its existing `recursive=True` path before it merges — the plumbing is already there and tested. If #417 lands first, I'll rebase this and add the SQL side here, with the parity suite from #417 covering both. Happy to sequence whichever way suits you.
