### PR TITLE
fix: terminate the subcollection walk on a collection cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **`zotero_set_item_parent` sets or clears an item's parent.** It can parent standalone notes and attachments, move them between parents, or make them top-level again.
 
+### Fixed
+- **A cycle among collections could hang `update-db` instead of indexing.** With `semantic_search.collection_keys` set, the local-database path expands each configured collection to include its subcollections by walking `parentCollectionID` downward. The walk kept no record of where it had been, so if a collection was ever its own ancestor it followed the loop forever, appending a collection id on every pass until the process ran out of memory — a hang partway through indexing, with nothing in the output pointing at collections. This should not be reachable through normal use: Zotero's own client will not let you nest a collection inside itself, so it takes a corrupted, partially synced or hand-edited `zotero.sqlite`. The guard is cheap enough to be worth having anyway. The walk now skips collections it has already visited, which also means that configuring both a collection and one of its ancestors no longer binds the same collection several times over into the query's parameter list — results are unchanged either way, since that query already selects distinct items. The expansion had no test coverage at all, so it arrives with tests for nesting depth, sibling exclusion, unknown keys and both cycle shapes.
+
 ## [0.9.1] - 2026-08-05
 
 ### Changed

--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -956,13 +956,28 @@ class LocalZoteroReader:
         if collection_keys:
             # Restrict the corpus to the configured collections, including
             # all of their subcollections (resolved recursively).
+            #
+            # `seen` spans every configured key, not just one walk, so it does
+            # two things. It terminates a parentCollection cycle, which the
+            # walk would otherwise follow forever, appending as it went;
+            # Zotero's own client cannot create one, but a corrupted,
+            # partially synced or hand-edited database can. And it collapses
+            # the overlap when the configured keys include both a collection
+            # and one of its ancestors, which would otherwise bind the same
+            # collectionID as several SQL parameters. Results are unchanged
+            # either way — the generated query already selects DISTINCT
+            # itemID — so this only bounds the walk and the parameter list.
             all_collection_ids = []
+            seen_collection_ids: set[int] = set()
             for ckey in collection_keys:
                 root = conn.execute("SELECT collectionID FROM collections WHERE key = ?", (ckey,)).fetchone()
                 if root:
                     to_process = [root[0]]
                     while to_process:
                         cid = to_process.pop()
+                        if cid in seen_collection_ids:
+                            continue
+                        seen_collection_ids.add(cid)
                         all_collection_ids.append(cid)
                         for sub in conn.execute("SELECT collectionID FROM collections WHERE parentCollectionID = ?", (cid,)).fetchall():
                             to_process.append(sub[0])

--- a/tests/test_collection_scope_expansion.py
+++ b/tests/test_collection_scope_expansion.py
@@ -1,0 +1,170 @@
+"""Collection scoping in `get_items_with_text`.
+
+`semantic_search.collection_keys` restricts indexing to the configured
+collections plus everything nested beneath them, resolved by walking
+`collections.parentCollectionID` in `local_db.py`. That walk had no test
+coverage at all, so most of what follows pins existing behaviour rather than
+new behaviour: nesting is followed to any depth, siblings are excluded,
+unknown keys are ignored.
+
+The one behaviour change is that the walk now remembers which collections it
+has already visited. A `parentCollection` cycle previously made it loop
+forever, and configuring both a collection and one of its ancestors bound the
+same collectionID as several SQL parameters.
+"""
+
+import sqlite3
+
+from zotero_mcp.local_db import LocalZoteroReader
+
+BASE_SCHEMA = [
+    "CREATE TABLE itemTypes (itemTypeID INTEGER PRIMARY KEY, typeName TEXT)",
+    """CREATE TABLE items (
+        itemID INTEGER PRIMARY KEY, itemTypeID INT, dateAdded TEXT,
+        dateModified TEXT, clientDateModified TEXT, libraryID INT,
+        key TEXT UNIQUE, version INT, synced INT
+    )""",
+    "CREATE TABLE libraries (libraryID INTEGER PRIMARY KEY, type TEXT, "
+    "editable INT, filesEditable INT)",
+    "CREATE TABLE groups (groupID INTEGER PRIMARY KEY, libraryID INT UNIQUE, "
+    "name TEXT, description TEXT, version INT)",
+    "CREATE TABLE deletedItems (itemID INTEGER PRIMARY KEY)",
+    "CREATE TABLE itemData (itemID INT, fieldID INT, valueID INT)",
+    "CREATE TABLE itemDataValues (valueID INTEGER PRIMARY KEY, value TEXT)",
+    "CREATE TABLE fields (fieldID INTEGER PRIMARY KEY, fieldName TEXT)",
+    "CREATE TABLE itemNotes (itemID INT, parentItemID INT, note TEXT)",
+    "CREATE TABLE itemCreators (itemID INT, creatorID INT)",
+    "CREATE TABLE creators (creatorID INTEGER PRIMARY KEY, firstName TEXT, "
+    "lastName TEXT)",
+    # The two tables the collection walk reads. No other test in the suite
+    # creates them, which is why this file exists.
+    "CREATE TABLE collections (collectionID INTEGER PRIMARY KEY, "
+    "collectionName TEXT, parentCollectionID INT, libraryID INT, key TEXT)",
+    "CREATE TABLE collectionItems (collectionID INT, itemID INT)",
+]
+
+
+def make_db(path, collections, memberships):
+    """Build a minimal zotero.sqlite.
+
+    ``collections`` maps a collection key to its parent's key (None for a
+    top-level collection). ``memberships`` maps a collection key to the item
+    keys filed directly in it. Every referenced item is created.
+    """
+    conn = sqlite3.connect(path)
+    for statement in BASE_SCHEMA:
+        conn.execute(statement)
+    conn.execute("INSERT INTO itemTypes VALUES (1, 'journalArticle')")
+    conn.execute("INSERT INTO libraries VALUES (1, 'user', 1, 1)")
+
+    ids = {key: index for index, key in enumerate(collections, start=1)}
+    for key, parent in collections.items():
+        conn.execute(
+            "INSERT INTO collections VALUES (?, ?, ?, 1, ?)",
+            (ids[key], f"Collection {key}", ids.get(parent), key),
+        )
+
+    item_ids = {}
+    for collection_key, item_keys in memberships.items():
+        for item_key in item_keys:
+            if item_key not in item_ids:
+                item_ids[item_key] = len(item_ids) + 1
+                conn.execute(
+                    "INSERT INTO items VALUES (?, 1, '2026-01-01 00:00:00', "
+                    "'2026-01-01 00:00:00', '2026-01-01 00:00:00', 1, ?, 1, 0)",
+                    (item_ids[item_key], item_key),
+                )
+            conn.execute(
+                "INSERT INTO collectionItems VALUES (?, ?)",
+                (ids[collection_key], item_ids[item_key]),
+            )
+    conn.commit()
+    conn.close()
+
+
+def scoped_item_keys(db_path, collection_keys):
+    with LocalZoteroReader(db_path=str(db_path)) as reader:
+        items = reader.get_items_with_text(collection_keys=collection_keys)
+    return sorted(item.key for item in items)
+
+
+def test_expands_nested_subcollections(tmp_path):
+    """A configured collection pulls in its descendants at any depth."""
+    db = tmp_path / "zotero.sqlite"
+    make_db(
+        db,
+        collections={"ROOT": None, "CHILD": "ROOT", "GRANDCHILD": "CHILD"},
+        memberships={"ROOT": ["ITEMROOT"], "CHILD": ["ITEMCHILD"],
+                     "GRANDCHILD": ["ITEMGRAND"]},
+    )
+    assert scoped_item_keys(db, ["ROOT"]) == ["ITEMCHILD", "ITEMGRAND", "ITEMROOT"]
+
+
+def test_sibling_collections_are_excluded(tmp_path):
+    """Scoping is real: a sibling branch is not swept in."""
+    db = tmp_path / "zotero.sqlite"
+    make_db(
+        db,
+        collections={"ROOT": None, "WANTED": "ROOT", "UNWANTED": "ROOT"},
+        memberships={"WANTED": ["ITEMKEEP"], "UNWANTED": ["ITEMDROP"]},
+    )
+    assert scoped_item_keys(db, ["WANTED"]) == ["ITEMKEEP"]
+
+
+def test_unknown_collection_key_is_ignored(tmp_path):
+    """An unknown key contributes nothing rather than raising."""
+    db = tmp_path / "zotero.sqlite"
+    make_db(
+        db,
+        collections={"ROOT": None},
+        memberships={"ROOT": ["ITEMROOT"]},
+    )
+    assert scoped_item_keys(db, ["ROOT", "NOSUCHKEY"]) == ["ITEMROOT"]
+
+
+def test_parent_cycle_terminates(tmp_path):
+    """A parentCollection cycle must not loop forever.
+
+    Zotero's own client cannot produce one, but a corrupted, partially synced
+    or hand-edited database can. Without a visited set the walk pops A, pushes
+    B, pops B, pushes A, appending to the collection-id list on every pass —
+    an unbounded loop rather than a wrong answer, which is why this test would
+    hang rather than fail before the fix.
+    """
+    db = tmp_path / "zotero.sqlite"
+    make_db(
+        db,
+        collections={"AAA": "BBB", "BBB": "AAA"},
+        memberships={"AAA": ["ITEMA"], "BBB": ["ITEMB"]},
+    )
+    # Both are reachable from either entry point once the cycle is followed.
+    assert scoped_item_keys(db, ["AAA"]) == ["ITEMA", "ITEMB"]
+
+
+def test_self_parenting_collection_terminates(tmp_path):
+    """The degenerate one-node cycle terminates too."""
+    db = tmp_path / "zotero.sqlite"
+    make_db(
+        db,
+        collections={"SELF": "SELF"},
+        memberships={"SELF": ["ITEMSELF"]},
+    )
+    assert scoped_item_keys(db, ["SELF"]) == ["ITEMSELF"]
+
+
+def test_overlapping_configured_keys_do_not_duplicate(tmp_path):
+    """Configuring a collection and its ancestor yields each item once.
+
+    Passes before and after the fix, deliberately: it is the no-regression
+    half of the dedupe. The generated SQL already selects DISTINCT itemID, so
+    the repeats never changed the result — what they changed is that the same
+    collectionID was bound as another parameter each time, against a cap
+    SQLite places on how many one statement may carry.
+    """
+    db = tmp_path / "zotero.sqlite"
+    make_db(
+        db,
+        collections={"ROOT": None, "CHILD": "ROOT"},
+        memberships={"ROOT": ["ITEMROOT"], "CHILD": ["ITEMCHILD"]},
+    )
+    assert scoped_item_keys(db, ["ROOT", "CHILD"]) == ["ITEMCHILD", "ITEMROOT"]


### PR DESCRIPTION
`get_items_with_text` expands each configured `semantic_search.collection_keys` entry to include its subcollections, by walking `parentCollectionID` downward:

```python
to_process = [root[0]]
while to_process:
    cid = to_process.pop()
    all_collection_ids.append(cid)
    for sub in conn.execute("...WHERE parentCollectionID = ?", (cid,)).fetchall():
        to_process.append(sub[0])
```

Nothing records where the walk has been. If a collection is ever its own ancestor, it pops A and pushes B, pops B and pushes A, appending a collection id on every pass until the process runs out of memory. The failure mode is a hang partway through `update-db` with nothing in the output pointing at collections — not a wrong answer.

**This is very unlikely to happen.** Zotero's own client will not let you nest a collection inside itself, so reaching it takes a corrupted, partially synced or hand-edited `zotero.sqlite`. I have not seen it occur. The guard is four lines and the failure it prevents is an unbounded loop, so it seemed worth having anyway rather than leaving as a known sharp edge.

### The change

A visited set, scoped across all configured keys rather than per walk. That second part is deliberate and does one extra thing: when the configured keys include both a collection and one of its ancestors, the shared subtree was previously bound into the query once per path, repeating the same `collectionID` as separate SQL parameters against the cap SQLite places on how many one statement may carry. Results are unchanged either way — the generated query already selects distinct items — so this only bounds the walk and the parameter list.

### Tests

The expansion had **no coverage at all**; no test in the suite so much as created a `collections` table. Most of the new file is therefore characterization, pinning what already worked:

| Test | Fails without the fix? |
|---|---|
| nesting followed to any depth | no — pins existing behaviour |
| sibling branches excluded | no — pins existing behaviour |
| unknown collection key ignored | no — pins existing behaviour |
| overlapping keys yield each item once | no — the no-regression half of the dedupe |
| two-collection cycle terminates | **yes** |
| self-parenting collection terminates | **yes** |

The two cycle tests fail by hitting the suite's 30s `pytest-timeout` rather than by asserting, which is the shape of the bug. Verified both ways by reverting the fix and re-running: 2 failed / 4 passed, then 6 passed with it restored.

Suite 1752 → 1758. Python 3.10 compile-checked and free of POSIX-only assumptions for the Windows job.

### Scope

Branched from `main` and independent of my other open PRs — it touches only the walk, its tests and the changelog. Flagged during coordination on #417, which extracts this same loop into a named `_resolve_collection_ids` helper and inherits the bug; fixing it here means that extraction picks up the guard rather than needing its own.
