### PR TITLE
fix(scite): render editorial notices using the real /papers field names

### DIFF
--- a/src/zotero_mcp/tools/scite.py
+++ b/src/zotero_mcp/tools/scite.py
@@ -62,10 +62,25 @@ def _format_editorial_notices(notices: list[dict]) -> list[str]:
     """Format editorial notices as warning lines."""
     lines = []
     for notice in notices:
-        ntype = notice.get("type", notice.get("editorialNoticeType", "notice"))
+        # Scite's /papers endpoint returns notices shaped
+        # {status, date, noticeDoi, doi}; older {type, sourceDoi} shapes are
+        # kept as fallbacks.
+        ntype = (
+            notice.get("status")
+            or notice.get("type")
+            or notice.get("editorialNoticeType")
+            or "notice"
+        )
         ntype = ntype.replace("_", " ").title()
-        source_doi = notice.get("sourceDoi", notice.get("source", ""))
-        lines.append(f"**{ntype}**: https://doi.org/{source_doi}")
+        ndate = notice.get("date", "")
+        source_doi = (
+            notice.get("noticeDoi")
+            or notice.get("sourceDoi")
+            or notice.get("source")
+            or ""
+        )
+        link = f"https://doi.org/{source_doi}" if source_doi else "(no notice DOI)"
+        lines.append(f"**{ntype}**{f' ({ndate})' if ndate else ''}: {link}")
     return lines
 
 
@@ -196,10 +211,24 @@ def enrich_item(
         if notices:
             output.append("## Editorial Notices")
             for notice in notices:
-                ntype = notice.get("type", notice.get("editorialNoticeType", "notice"))
+                # Scite's /papers notices are {status, date, noticeDoi, doi};
+                # older {type, sourceDoi} shapes kept as fallbacks.
+                ntype = (
+                    notice.get("status")
+                    or notice.get("type")
+                    or notice.get("editorialNoticeType")
+                    or "notice"
+                )
                 ntype = ntype.replace("_", " ").title()
-                source = notice.get("sourceDoi", notice.get("source", ""))
-                output.append(f"- **{ntype}**: https://doi.org/{source}")
+                ndate = notice.get("date", "")
+                source = (
+                    notice.get("noticeDoi")
+                    or notice.get("sourceDoi")
+                    or notice.get("source")
+                    or ""
+                )
+                link = f"https://doi.org/{source}" if source else "(no notice DOI)"
+                output.append(f"- **{ntype}**{f' ({ndate})' if ndate else ''}: {link}")
             output.append("")
 
         output.append(
@@ -408,10 +437,24 @@ def check_retractions(
             output.append(f"## {i}. {title}")
             output.append(f"**DOI:** {item_doi}")
             for notice in notices:
-                ntype = notice.get("type", notice.get("editorialNoticeType", "notice"))
+                # Scite's /papers notices are {status, date, noticeDoi, doi};
+                # older {type, sourceDoi} shapes kept as fallbacks.
+                ntype = (
+                    notice.get("status")
+                    or notice.get("type")
+                    or notice.get("editorialNoticeType")
+                    or "notice"
+                )
                 ntype = ntype.replace("_", " ").title()
-                source = notice.get("sourceDoi", notice.get("source", ""))
-                output.append(f"- **{ntype}**: https://doi.org/{source}")
+                ndate = notice.get("date", "")
+                source = (
+                    notice.get("noticeDoi")
+                    or notice.get("sourceDoi")
+                    or notice.get("source")
+                    or ""
+                )
+                link = f"https://doi.org/{source}" if source else "(no notice DOI)"
+                output.append(f"- **{ntype}**{f' ({ndate})' if ndate else ''}: {link}")
             output.append("")
 
         output.append(

--- a/tests/test_scite.py
+++ b/tests/test_scite.py
@@ -118,3 +118,70 @@ def test_check_retractions_flags_uppercase_doi(monkeypatch, dummy_ctx, fake_zot)
     assert "Editorial Notice Alerts" in result
     assert "Retraction" in result
     assert "All clear" not in result
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 — /papers editorialNotices carry {status, date, noticeDoi, doi},
+# not {type, sourceDoi}
+# ---------------------------------------------------------------------------
+
+
+def test_editorial_notices_render_real_api_field_names():
+    """Live /papers notices are shaped {status, date, noticeDoi, doi}.
+
+    The formatter used to read ``type``/``sourceDoi`` only, so every real
+    notice rendered as an empty ``**Notice**: https://doi.org/``.
+    """
+    lines = scite_tools._format_editorial_notices(
+        [
+            {
+                "status": "Has correction",
+                "date": "2021-2-3",
+                "noticeDoi": "10.1038/s43586-021-00017-2",
+                "doi": "10.1038/s43586-020-00001-2",
+            }
+        ]
+    )
+    assert lines == [
+        "**Has Correction** (2021-2-3): https://doi.org/10.1038/s43586-021-00017-2"
+    ]
+
+
+def test_editorial_notices_legacy_shape_still_renders():
+    """The pre-existing {type, sourceDoi} shape keeps working as a fallback."""
+    lines = scite_tools._format_editorial_notices(
+        [{"type": "retraction", "sourceDoi": "10.1016/x"}]
+    )
+    assert lines == ["**Retraction**: https://doi.org/10.1016/x"]
+
+
+def test_check_retractions_renders_real_api_notice_fields(
+    monkeypatch, dummy_ctx, fake_zot
+):
+    """check_retractions output must include the notice type and notice DOI."""
+    fake_zot._items = [
+        {"key": "ITEM0001", "data": {"DOI": UPPER_DOI, "title": "Wakefield 1998"}}
+    ]
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake_zot)
+    monkeypatch.setattr(
+        scite_tools._scite,
+        "get_papers_batch",
+        lambda dois: {
+            LOWER_DOI: {
+                "editorialNotices": [
+                    {
+                        "status": "Retracted",
+                        "date": "2010-2-2",
+                        "noticeDoi": "10.1016/S0140-6736(10)60175-4",
+                        "doi": LOWER_DOI,
+                    }
+                ]
+            }
+        },
+    )
+
+    result = scite_tools.check_retractions(ctx=dummy_ctx)
+
+    assert "Editorial Notice Alerts" in result
+    assert "**Retracted** (2010-2-2)" in result
+    assert "https://doi.org/10.1016/S0140-6736(10)60175-4" in result


### PR DESCRIPTION
## Bug

Scite's `/papers` endpoint returns `editorialNotices` entries shaped `{status, date, noticeDoi, doi}`. Live example for `10.1038/s43586-020-00001-2`:

```json
[{"status": "Has correction", "date": "2021-2-3",
  "noticeDoi": "10.1038/s43586-021-00017-2",
  "doi": "10.1038/s43586-020-00001-2"}]
```

All three render sites — `_format_editorial_notices` (used by `scite_enrich_search`), `scite_enrich_item`, and `scite_check_retractions` — read only `type`/`editorialNoticeType` and `sourceDoi`/`source`, none of which exist in the response. So every real notice renders as an empty:

```
**Notice**: https://doi.org/
```

with no notice type and no notice DOI — a user running a retraction screen can't tell whether a flag is a retraction or a routine correction without querying the Scite API by hand (which is how I caught this: a 110-item library screen returned two flagged items with blank notices; both turned out to be benign corrections only after checking `api.scite.ai/papers/<doi>` directly).

This is the same API-contract bug class as the `POST /papers` body shape and lowercased DOI keys fixed in #331/#353 — the existing tests fabricate the `{type, sourceDoi}` shape, so they pass while the live API renders empty.

## Fix

At all three sites: read `status` and `noticeDoi` first (old keys kept as fallbacks so any older/other response shapes still render), include the notice `date`, and print `(no notice DOI)` instead of a dangling `https://doi.org/` when no DOI is present. Output now:

```
**Has Correction** (2021-2-3): https://doi.org/10.1038/s43586-021-00017-2
```

## Tests

- `test_editorial_notices_render_real_api_field_names` — real API shape through the formatter (fails on main).
- `test_check_retractions_renders_real_api_notice_fields` — end-to-end `check_retractions` output contains notice type + notice DOI (fails on main).
- `test_editorial_notices_legacy_shape_still_renders` — `{type, sourceDoi}` fallback guard.

`pytest tests/test_scite.py`: 6 passed (3 pre-existing + 3 new).
