### PR TITLE
fix: resolve type-specific base fields when rendering an item's title

### DIFF
--- a/src/zotero_mcp/client.py
+++ b/src/zotero_mcp/client.py
@@ -15,6 +15,7 @@ import httpx
 from dotenv import load_dotenv
 from pyzotero import zotero
 
+from zotero_mcp import schema
 from zotero_mcp.extract import (
     categorize_attachment,
     extract_file,
@@ -299,9 +300,14 @@ def format_item_metadata(item: dict[str, Any], include_abstract: bool = True) ->
     data = item.get("data", {})
     item_type = data.get("itemType", "unknown")
 
+    # Some item types keep the title under a type-specific key (a statute's
+    # is "nameOfAct"); resolve_field maps "title" to whichever key this
+    # item type actually uses.
+    title_field = schema.resolve_field(item_type, "title")
+
     # Basic information
     lines = [
-        f"# {data.get('title', 'Untitled')}",
+        f"# {data.get(title_field, 'Untitled')}",
         f"**Type:** {item_type}",
         f"**Item Key:** {data.get('key')}",
     ]

--- a/tests/test_format_item_metadata_base_field.py
+++ b/tests/test_format_item_metadata_base_field.py
@@ -1,0 +1,88 @@
+"""Tests for base-field title resolution in format_item_metadata.
+
+Several Zotero item types store the title under a type-specific key instead
+of "title" itself: a statute's is "nameOfAct", a case's is "caseName", an
+email's is "subject" (see zotero_mcp.schema). The write path
+(zotero_update_item) already routes through schema.resolve_field for this
+(commit 94e3c1f, #402); format_item_metadata did a raw data.get("title", ...)
+lookup, so every one of these item types rendered as "# Untitled" even
+though the real title was present under its type-specific key.
+"""
+
+import importlib.util
+import pathlib
+import sys
+from unittest.mock import MagicMock
+
+_SRC = pathlib.Path(__file__).parent.parent / "src" / "zotero_mcp"
+
+# Stub out heavy optional dependencies so client.py can be imported in
+# isolation; schema is loaded for real below, not stubbed.
+for _mod_name in (
+    "pyzotero",
+    "pyzotero.zotero",
+    "dotenv",
+    "fastmcp",
+    "mcp",
+    "mcp.server",
+    "zotero_mcp",
+    "zotero_mcp.utils",
+    "zotero_mcp._app",
+):
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+if "zotero_mcp.schema" not in sys.modules:
+    _schema_spec = importlib.util.spec_from_file_location("zotero_mcp.schema", _SRC / "schema.py")
+    _schema_mod = importlib.util.module_from_spec(_schema_spec)
+    sys.modules["zotero_mcp.schema"] = _schema_mod
+    _schema_spec.loader.exec_module(_schema_mod)
+
+_client_spec = importlib.util.spec_from_file_location("zotero_mcp.client", _SRC / "client.py")
+_client_mod = importlib.util.module_from_spec(_client_spec)
+sys.modules["zotero_mcp.client"] = _client_mod
+_client_spec.loader.exec_module(_client_mod)
+format_item_metadata = _client_mod.format_item_metadata
+
+
+def _make_item(item_type, title_field, title):
+    data = {
+        "key": "TESTKEY1",
+        "itemType": item_type,
+        title_field: title,
+        "creators": [{"creatorType": "author", "lastName": "Smith", "firstName": "J."}],
+        "date": "2024",
+    }
+    return {"data": data}
+
+
+class TestBaseFieldTitle:
+    def test_statute_title_stored_under_name_of_act(self):
+        item = _make_item("statute", "nameOfAct", "The Clean Air Act")
+        output = format_item_metadata(item, include_abstract=False)
+        assert "# The Clean Air Act" in output
+        assert "# Untitled" not in output
+
+    def test_case_title_stored_under_case_name(self):
+        item = _make_item("case", "caseName", "Marbury v. Madison")
+        output = format_item_metadata(item, include_abstract=False)
+        assert "# Marbury v. Madison" in output
+        assert "# Untitled" not in output
+
+    def test_email_title_stored_under_subject(self):
+        item = _make_item("email", "subject", "Re: manuscript review")
+        output = format_item_metadata(item, include_abstract=False)
+        assert "# Re: manuscript review" in output
+        assert "# Untitled" not in output
+
+    def test_ordinary_type_still_reads_title_directly(self):
+        """journalArticle's title field is its own base field; unaffected types
+        must keep working exactly as before."""
+        item = _make_item("journalArticle", "title", "An Ordinary Article")
+        output = format_item_metadata(item, include_abstract=False)
+        assert "# An Ordinary Article" in output
+
+    def test_missing_title_field_falls_back_to_untitled(self):
+        item = {"data": {"key": "TESTKEY1", "itemType": "statute"}}
+        output = format_item_metadata(item, include_abstract=False)
+        assert "# Untitled" in output


### PR DESCRIPTION
## Root cause

`format_item_metadata` (`src/zotero_mcp/client.py`) reads the title with a
raw `data.get("title", "Untitled")`. Several Zotero item types store the
title under a different, type-specific key: a statute's is `nameOfAct`, a
case's is `caseName`, an email's is `subject` (`zotero_mcp/data/zotero_basefields.json`).
For those types `data` has no `title` key at all, so every statute, case
or email item renders as `# Untitled` regardless of its real title.

The write path already solves this for `zotero_update_item` by routing
generic field names through the type's base-field schema (94e3c1f, #402).
`format_item_metadata` predates that fix and was never updated.

## Fix

Resolve the type's actual title field with the same `schema.resolve_field`
used by the write path, then read the title from that key.

## Scope

Issue #452 also names about 15 other raw `data.get("title", ...)` sites
across `client.py`'s attachment helpers, `utils.py`, `retrieval.py`,
`annotations.py` and `discovery.py`. This PR covers only
`format_item_metadata`, the formatter behind `zotero_get_item_metadata`
and `zotero_get_item_fulltext`, since it is the highest-traffic path and
keeps this diff to one reviewable concern. The remaining sites are the
same one-line pattern and are a natural follow-up; happy to send that as
a second PR if useful. Using `Refs #452` rather than `Fixes #452` since
this does not close the whole issue.

## Verification

- New test (`tests/test_format_item_metadata_base_field.py`): statute,
  case and email items fail on `main` (title renders as `Untitled`) and
  pass on this branch; an ordinary type (title is its own base field) and
  a missing-title item are also covered and unaffected either way.
- Full suite, matching CI's own install and invocation
  (`pytest --ignore=tests/test_lifespan.py`): 1751 passed, 3 skipped, no
  new failures, run on Python 3.10 and 3.12 (the CI matrix's extremes).
- Not checked: the other read-path call sites named in #452, and a live
  round trip against the real Zotero API (the fix and its test only
  exercise the formatter against constructed item dicts).
