### PR TITLE
fix: keep brackets that belong to the DOI when stripping prose punctuation (#469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **`zotero_set_item_parent` sets or clears an item's parent.** It can parent standalone notes and attachments, move them between parents, or make them top-level again.
 
+### Fixed
+- **`normalize_doi` no longer truncates DOIs that legitimately end in a bracket (#469).** The trailing-punctuation strip was `rstrip(".,);]")`, which cannot tell prose punctuation from a bracket the DOI itself opened. TAO (Terrestrial, Atmospheric and Oceanic Sciences) puts a parenthesised topical suffix on its DOIs, so `10.3319/TAO.2009.05.25.02(IWNOP)` was normalised to `…02(IWNOP` and every path that resolves a DOI — `zotero_add_item(source_type="doi")` among them — reported "DOI not found on CrossRef" for a record CrossRef holds and resolves. The strip now walks the end of the string and stops at a closer whose opener is present in the DOI, so `10.1038/nphys1170)` copied out of "(see 10.1038/nphys1170)" still loses its stray bracket while a balanced pair survives. Bracketed suffixes are rare enough that the failure reads as a missing record rather than a client bug, which is how it went unnoticed.
+
 ## [0.9.1] - 2026-08-05
 
 ### Changed

--- a/src/zotero_mcp/identifiers.py
+++ b/src/zotero_mcp/identifiers.py
@@ -33,14 +33,34 @@ _DOI_IN_URL_RE = re.compile(
 #: Punctuation that trails a DOI copied out of prose or a reference list.
 _TRAILING_PUNCT = ".,);]"
 
+#: Closing brackets and the opener each one belongs to. A closer is prose
+#: punctuation only when the DOI holds no matching opener.
+_CLOSERS = {")": "(", "]": "["}
+
+
+def _strip_trailing_punct(s):
+    """Strip prose punctuation from the end of a DOI, keeping brackets that
+    the DOI itself opened.
+
+    ``rstrip(_TRAILING_PUNCT)`` cannot tell "(see 10.1234/foo)" from TAO's
+    ``10.3319/TAO.2009.05.25.02(IWNOP)``, where the parentheses are part of
+    the suffix and CrossRef 404s without the closer.
+    """
+    while s and s[-1] in _TRAILING_PUNCT:
+        opener = _CLOSERS.get(s[-1])
+        if opener is not None and s.count(opener) >= s.count(s[-1]):
+            break
+        s = s[:-1]
+    return s
+
 
 def normalize_doi(raw):
     """Normalize a DOI string from various input formats.
 
     Accepts a bare DOI, a ``doi:`` prefixed form, or a ``doi.org`` /
     ``dx.doi.org`` URL, and strips trailing punctuation picked up from
-    surrounding prose. Returns the canonical bare DOI, or ``None`` when the
-    input is not a DOI.
+    surrounding prose (brackets the DOI itself opened are kept). Returns
+    the canonical bare DOI, or ``None`` when the input is not a DOI.
 
     Case is preserved: DOIs are case-insensitive for resolution, but some
     consumers (Scite among them) echo back what they were given.
@@ -55,7 +75,7 @@ def normalize_doi(raw):
         if not m:
             return None
         s = m.group(1)
-    s = s.rstrip(_TRAILING_PUNCT)
+    s = _strip_trailing_punct(s)
     if DOI_RE.match(s):
         return s
     return None

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -40,6 +40,38 @@ class TestNormalizeDoi:
         assert normalize_doi(raw) == expected
 
     @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            # TAO (Terrestrial, Atmospheric and Oceanic Sciences) puts a
+            # parenthesised topical suffix on its DOIs, and it is part of the
+            # DOI: CrossRef resolves the closing bracket and 404s without it.
+            (
+                "10.3319/TAO.2009.05.25.02(IWNOP)",
+                "10.3319/TAO.2009.05.25.02(IWNOP)",
+            ),
+            (
+                "doi:10.3319/TAO.2009.05.25.02(IWNOP)",
+                "10.3319/TAO.2009.05.25.02(IWNOP)",
+            ),
+            (
+                "https://doi.org/10.3319/TAO.2009.05.25.02(IWNOP)",
+                "10.3319/TAO.2009.05.25.02(IWNOP)",
+            ),
+            # Prose punctuation still goes, and only the punctuation.
+            (
+                "10.3319/TAO.2009.05.25.02(IWNOP).",
+                "10.3319/TAO.2009.05.25.02(IWNOP)",
+            ),
+            ("10.1234/a[b]", "10.1234/a[b]"),
+        ],
+    )
+    def test_balanced_brackets_are_part_of_the_doi(self, raw, expected):
+        """A closing bracket that has an opener inside the DOI is not prose
+        punctuation. Stripping it unconditionally turns a resolvable DOI into
+        a 404 (upstream #469)."""
+        assert normalize_doi(raw) == expected
+
+    @pytest.mark.parametrize(
         "raw",
         [
             None,


### PR DESCRIPTION
Closes #469.

`normalize_doi` finishes with `rstrip(".,);]")`. That is the right move for a DOI copied out of a sentence — `"(see 10.1038/nphys1170)"` — and the wrong one for a DOI that opens a bracket itself.

TAO (*Terrestrial, Atmospheric and Oceanic Sciences*) puts a parenthesised topical suffix on its DOIs:

```python
>>> normalize_doi("10.3319/TAO.2009.05.25.02(IWNOP)")
'10.3319/TAO.2009.05.25.02(IWNOP'      # before
'10.3319/TAO.2009.05.25.02(IWNOP)'     # after
```

The closer is part of the DOI — CrossRef resolves the full string and 404s without it — so every DOI-driven path, `zotero_add_item(source_type="doi")` included, answered *"DOI not found on CrossRef"* for a record CrossRef holds:

```bash
curl -sS -H 'Accept: application/vnd.citationstyles.csl+json' \
  "https://api.crossref.org/works/10.3319%2FTAO.2009.05.25.02%28IWNOP%29/transform/application/vnd.citationstyles.csl+json"
```

## The change

`_strip_trailing_punct()` walks the tail instead of calling `rstrip`, and stops at a closer whose opener is present in the string. A stray bracket still goes; a balanced pair stays.

```python
while s and s[-1] in _TRAILING_PUNCT:
    opener = _CLOSERS.get(s[-1])
    if opener is not None and s.count(opener) >= s.count(s[-1]):
        break
    s = s[:-1]
```

## Tests

Five new cases in `TestNormalizeDoi.test_balanced_brackets_are_part_of_the_doi` — the bare DOI, the `doi:` form, the `doi.org` URL, the DOI followed by a sentence period, and `10.1234/a[b]` for square brackets. They fail on `main` and pass here. The existing `test_trailing_punctuation_from_prose` cases (`10.1038/nphys1170)` and `10.1038/nphys1170];`) are unchanged and still pass, which is what pins the stray-bracket behaviour.

`pytest tests/` — 1,396 passed on this branch. The 5 failures and 15 collection errors in my environment are `pymupdf` / `chromadb` not installed and reproduce identically on `main`.

## Why it lasted

The failure reads as a missing record rather than a client bug, so the natural response is to go look for the paper somewhere else. Bracketed suffixes are rare — TAO is the one I hit — but they resolve fine everywhere except here.