### PR TITLE
feat(local-api): support Zotero 10 local write endpoints (#471, #277)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,12 @@
 # Zotero MCP 环境变量配置
 # 复制此文件为 .env 并填写你的配置
 
-# 必需配置
+# 连接方式: 本地 Zotero API (需要 Zotero 正在运行)
+# 设为 true 后, 读取无需任何凭据
+# ZOTERO_LOCAL=true
+
+# Web API 凭据
+# 本地模式下也可以设置, 用于混合模式 (本地读取 + Web API 写入)
 ZOTERO_API_KEY=your_api_key_here
 ZOTERO_LIBRARY_ID=your_library_id_here
 
@@ -9,6 +14,14 @@ ZOTERO_LIBRARY_ID=your_library_id_here
 # 个人库: user
 # 群组库: group
 ZOTERO_LIBRARY_TYPE=user
+
+# 本地写入 (需要 Zotero 10 或更新版本)
+# 通常由 `zotero-mcp authorize-local` 自动写入配置文件,
+# 这些变量适用于容器和 CI 等不便使用配置文件的场景
+# ZOTERO_LOCAL_API_KEY=local_api_key_here
+# ZOTERO_LOCAL_SERVER_ID=server_id_here
+# 设为 false 可强制通过 Web API 写入 (默认 auto)
+# ZOTERO_LOCAL_WRITE=auto
 
 # OpenAI API Key (用于语义搜索功能，可选)
 # OPENAI_API_KEY=your_openai_key_here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Gemini gets a Batch API path, and `--batch` replaces the per-provider flags.** Asynchronous batch embedding runs at roughly half the realtime price, which on a library large enough to need it is the difference between a run you schedule and one you think twice about. It existed for OpenAI only, behind `--openai-batch`. Gemini now has the same path, and both are reached through one provider-neutral `--batch` (`--batch-provider openai|gemini` when the configured embedding model does not already settle it). `--openai-batch`, `--no-openai-batch`, `zotero-mcp openai-batch-status` and `openai-batch-import` all keep working as deprecated aliases, so anything scripted against 0.10.0 is unaffected. Underneath, the two providers now share one implementation: `batch_common` owns JSONL chunking, the run manifest, submission and status refresh, and each provider supplies only what genuinely differs through a `BatchAdapter` — request shaping, its SDK calls, and its status vocabulary. That vocabulary is the reason the manifest gained a normalized `state` beside the provider's raw `status`: OpenAI says `completed` where Gemini says `JOB_STATE_SUCCEEDED`, and import-eligibility should not be spelled twice. Manifests written before this release are backfilled on read, so a batch submitted by an older build still imports. Batch submissions are also now paced against an enqueued-token budget rather than fired all at once — the Tier 1 ceilings (3M tokens for OpenAI, 500k for Gemini) are what a large library actually hits first, so chunks beyond the budget are written to disk and submitted as earlier ones finish, and `--auto-loop` will poll, import and feed the queue until the run is done. Gemini's batch vectors are shaped identically to its realtime ones, prefix and task type included, so the two are interchangeable in one collection. Google marks the Gemini embeddings Batch API experimental; the setup wizard says so where it offers it.
 - **`update-db` can run several embedding requests at once, paced against the provider's token budget.** Set `semantic_search.embedding_config.max_parallel_requests` and indexing overlaps its three phases instead of running them in lockstep: one thread builds documents and works out which are new, that many workers embed, and the main thread commits vectors to ChromaDB. Previously each batch of 25 items blocked on a single embedding round-trip before the next batch was even prepared. Concurrency against a metered API needs pacing, and for embeddings it is tokens that bind rather than requests — at a 64 × ~500-token payload each request costs about 32K tokens, so a 1,000,000 TPM ceiling caps throughput near 31 requests a minute against a 3,000 RPM allowance. Requests are therefore metered against a token budget, `embedding_config.tokens_per_minute`, which halves on a 429 and creeps back up on success but never past what you configured. It is configured rather than inferred because a rate derived from the request cadence that was just throttled lets a single early 429 hold a multi-hour run far below the real ceiling, and because the provider's own `x-ratelimit-*-tokens` headers — which OpenAI does send, and which the limiter reads as a refill hint — only arrive with a response, leaving the start of a run unpaced and telling a provider that omits them nothing at all. `scripts/check_openai_ratelimits.py` reports what your key is actually allowed. Retries of throttled and 5xx requests are now shared by all three remote providers instead of being absent, `max_retries` bounds them, and `update-db -v` logs each request's worker thread, wire time and time spent waiting on the budget. Separately, truncation no longer runs the tiktoken encoder on text whose byte length already proves it fits, which is output-identical and removes what had been the CPU bottleneck of a large indexing run. None of this changes a default run: without `max_parallel_requests` the sequential path is unchanged, and no registered embedding-function name, stored config key or text-shaping rule moves, so existing collections keep working untouched.
 
+- **Local API write support (Zotero 10+)** (#471, #277). Zotero 10 added write endpoints
+  to the local API, so writes no longer have to go through the cloud. Items,
+  collections, tags, notes, annotations, trashing and file attachments all work against
+  a local-only library with no zotero.org account — which also sidesteps the Zotero
+  Storage quota that made attachment uploads fail with HTTP 413 (#399) and the
+  cloud-only attachments of #463. Nothing changes for anyone on an older Zotero: the
+  existing hybrid path stays as the fallback and is chosen automatically.
+- **`zotero-mcp authorize-local`** — request a local API key from Zotero, which prompts
+  the user with Allow / Always Allow / Deny. A remembered key is stored under its own
+  `local_api` section of `~/.config/zotero-mcp/config.json` with owner-only permissions.
+  A single-use key (plain "Allow") is deliberately never written to disk: it is consumed
+  by the first write, and a dead key on disk would outrank working web credentials on
+  every subsequent run. `--status`, `--revoke`, `--print` and `--no-save` cover the rest
+  of the lifecycle.
+- A local key that Zotero rejects is dropped automatically, so the next write falls back
+  to web credentials if the user has them rather than failing against a key that can
+  never work again.
+- **`zotero_authorize_local_writes`** and **`zotero_write_capabilities`** MCP tools, so a
+  client can obtain the key and diagnose a refused write without dropping to a shell.
+- New environment variables: `ZOTERO_LOCAL_API_KEY`, `ZOTERO_LOCAL_SERVER_ID`, and
+  `ZOTERO_LOCAL_WRITE` (set to `false` to keep writes on the web API regardless).
+- `zotero-mcp setup-info` now reports which write path is in effect.
+
 ### Changed
 
 - `tests/test_issue_455_toc_stdout_pollution.py` injects its stdout pollution through `sitecustomize` instead of `usercustomize`. `site.main()` runs `execsitecustomize()` unconditionally but gates `execusercustomize()` on `ENABLE_USER_SITE`, which every venv sets to False, so the test failed its own precondition — and therefore the whole test — for anyone running the suite from a venv rather than a system or conda interpreter. Several contributors reported it as a pre-existing failure on `main`. It now works there, and skips with a stated reason on any interpreter where the hook does not fire, rather than failing.
 
 - **`zotero_semantic_search` scopes to the active library by default (#163).** It previously searched every indexed library whenever `library_id` was omitted, which made it the one search tool whose unqualified behaviour differed from the rest — the same query meant "this library" through two tools and "all libraries" through the third. The default is now the active library, matching `zotero_search_items` and `zotero_advanced_search`, and global is reached the same way as on those two, with `search_all_libraries=True`. `library_id` still scopes to a specific library and is mutually exclusive with the new flag.
+
+- Bumped the `pyzotero` floor to `>=1.14.0` — the first release with `authorize_local()`,
+  the `server_id`/`local_api_key` constructor arguments, and the internal write
+  dispatcher that attaches the headers a local write requires.
+- Every write tool now resolves its backend through one path with one error message,
+  replacing the three divergent gateways that had drifted apart in `write.py`,
+  `annotations.py` and the inline checks in the two annotation-creation tools. When no
+  backend can write, the message names both remedies and leads with whichever one
+  actually applies to the running Zotero.
+- Attachment uploads made through the local API skip the WebDAV upload workaround. That
+  step exists because web-API uploads land in Zotero Storage, which a WebDAV-configured
+  desktop never reads; a local upload is already in local storage and Zotero syncs it.
+- Tool descriptions that claimed writes need "a web API key or hybrid mode" now name
+  both routes.
 
 ### Fixed
 
@@ -46,6 +83,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The check is also now the complete one rather than just `auto_update`: a config with `auto_update: true` and `update_frequency: "manual"`, or an interval that is not yet due, no longer pays for the import either.
 
 - **A semantic-search hit from another library could be found but not read (#163).** Results are hydrated through the pyzotero client, which is bound to exactly one library, so a hit from any other library 404'd and was reported as `Could not fetch full item data` instead of as a result — the index knew about the paper, and the tool could not show it. Foreign hits are now hydrated from `zotero.sqlite` directly, in one batched query, arriving with their library attribution attached; hits from the client's own library still go through the client, which is authoritative for them. This does not require a re-index: an index built before the `group_id` tagging landed carries no library attribution at all, so a foreign hit there cannot be recognised as foreign up front — those are tried against the client first and fall back to the local database when it cannot serve them.
+
+- The injected local HTTP client had no timeout and so inherited httpx's 5-second
+  default. Reads were unaffected (pyzotero passes its own per-request timeout on read
+  paths) but every write shared that budget, and it would have made the authorization
+  dialog impossible to answer in time. Reads, writes and authorization now get explicit,
+  separately-sized timeouts.
+- Trashing an item, note or annotation went out through a raw `client.patch` that
+  bypassed pyzotero's write dispatcher. Harmless against the web API, but it would have
+  sent a local write without the required headers.
+- The zotero.org API key is no longer sent to `localhost:23119`. In hybrid mode the
+  local read client is built with that key, and restoring pyzotero's default headers
+  would have turned it into an `Authorization: Bearer` aimed at the local server, which
+  has no use for it.
+- `zotero-mcp authorize-local --revoke` now reports honestly when it clears a key
+  granted during the running session, and warns when `ZOTERO_LOCAL_API_KEY` is still set
+  in the environment — which revoke cannot reach, and which would otherwise keep local
+  writes silently enabled.
+- The config file is written atomically, and a config that exists but cannot be parsed
+  is no longer silently replaced — doing so would have discarded the user's
+  `semantic_search` and `client_env` settings along with it.
+- POSIX absolute paths are recognised on Windows again. Python 3.13 changed
+  `ntpath.isabs()` so that `/Users/me/paper.pdf` counts as relative, which meant
+  `zotero_add_item` could not tell such a path was a file at all, and a library synced
+  from macOS or Linux resolved every linked-file attachment to nothing when opened on
+  Windows.
+- `scripts/gen_skill_reference.py` writes LF. `Path.write_text` translates newlines on
+  Windows, so running the generator there rewrote the whole checked-in reference in
+  CRLF; the staleness check compared decoded text, which normalizes CRLF away, so
+  nothing reported the drift.
+
 
 ## [0.10.0] - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@
 - **Add papers by URL** (arXiv, DOI links, generic webpages) or from local files
 - Create and manage collections, update item metadata, batch-update tags
 - Find and merge duplicate items with dry-run preview
-- **Hybrid mode**: local reads + web API writes for local-mode users
+- **Local writes** (Zotero 10+): writes land in the running Zotero directly — no cloud
+  account, no sync round-trip, no Zotero Storage quota. See
+  [Local write support](#local-write-support)
+- **Hybrid mode**: local reads + web API writes, for anyone on an older Zotero
 
 ### 📊 Scite Citation Intelligence (optional `[scite]` extra)
 - **Citation tallies**: See how many papers support, contrast, or mention each item — the MCP version of the [Scite Zotero Plugin](https://github.com/scitedotai/scite-zotero-plugin)
@@ -65,9 +68,10 @@
 - No Scite account required — uses public API endpoints
 
 ### 🌐 Flexible Access Methods
-- Local mode for offline access (no API key needed)
-- Web API for cloud library access
-- Hybrid mode: read from local Zotero, write via web API
+- Local read-only: offline access to a running Zotero, no credentials at all
+- Local read-write (Zotero 10+): add one authorization and writes stay local too
+- Web API: cloud library access from anywhere
+- Hybrid: read from local Zotero, write via the web API
 
 ### ⌨️ Standalone CLI (`zotero-cli`)
 - Search, browse, and edit your library directly from the terminal — no AI assistant required
@@ -340,11 +344,16 @@ After installation, either:
    }
    ```
 
-   For **local read-only use**, `ZOTERO_LOCAL: "true"` is all you need — drop the `ZOTERO_API_KEY` and `ZOTERO_LIBRARY_ID` lines entirely.
+   For **local reads**, `ZOTERO_LOCAL: "true"` is all you need — drop the
+   `ZOTERO_API_KEY` and `ZOTERO_LIBRARY_ID` lines entirely.
 
-   The local API is fast but read-only, so the MCP server uses the Zotero web API for write operations.
+   For **writes** you have two routes. On Zotero 10 or newer, run
+   `zotero-mcp authorize-local` once and writes go straight to the running Zotero —
+   see [Local write support](#local-write-support). On any older Zotero the
+   local API is read-only, so keep the two variables below and the server writes
+   through the Zotero web API instead.
 
-   To enable **write mode**:
+   To enable **write mode through the web API**:
    - Keep `ZOTERO_LOCAL: "true"` — with API credentials set, the server runs in hybrid mode (fast local reads, web API writes)
    - Click [here](https://www.zotero.org/settings/security#applications) to generate a Zotero API key and replace `YOUR_API_KEY` with it
    - `ZOTERO_LIBRARY_ID` is your numeric **userID**, shown on that same page (for a group library, use the group's ID and also set `ZOTERO_LIBRARY_TYPE: "group"`).
@@ -410,6 +419,57 @@ Then click "Save".
 
 Cherry Studio also provides a visual configuration method for general settings and tools selection.
 
+<a id="local-write-support"></a>
+
+## ✏️ Local write support (Zotero 10+)
+
+Zotero's local API was read-only for most of its life, which is why writes have always
+gone through the Zotero web API. Zotero 10 added local write endpoints, so on that
+version writes can stay entirely on your machine: no cloud account, no waiting for a
+sync round-trip, and no Zotero Storage quota to run into when attaching PDFs.
+
+Writes need a **local API key**. It has nothing to do with a zotero.org API key and
+can't be created in advance — Zotero grants it through a dialog:
+
+```bash
+zotero-mcp authorize-local
+```
+
+Zotero shows a prompt with three buttons. **Always Allow** grants a reusable key that
+is saved to `~/.config/zotero-mcp/config.json` (owner-only permissions) and picked up
+automatically from then on — that's the one you want. **Allow** grants a key valid for
+exactly one write; it is never saved to disk, since a consumed key sitting there would
+take priority over working web credentials on every later run. **Deny** grants nothing.
+
+If a key is ever rejected — consumed, revoked from Zotero's side, or belonging to a
+Zotero database you no longer have — the server drops it and falls back to web
+credentials if you have them, rather than failing against a key that cannot work again.
+
+An MCP client can do the same thing without dropping to a shell: the
+`zotero_authorize_local_writes` tool opens the same dialog, and
+`zotero_write_capabilities` reports which write path is currently available. If a write
+is refused, that second tool tells you whether the fix is authorizing or supplying web
+credentials.
+
+```bash
+zotero-mcp authorize-local --status    # what can write right now
+zotero-mcp authorize-local --revoke    # forget the stored key
+zotero-mcp authorize-local --print     # print it for ZOTERO_LOCAL_API_KEY instead
+```
+
+Nothing here is required. Without a local key the server behaves exactly as before:
+hybrid mode if web credentials are set, and a message explaining both options if not.
+Set `ZOTERO_LOCAL_WRITE=false` to keep writes on the web API even when a key exists.
+
+**Revoking.** `--revoke` removes the copy this server stores. Zotero keeps its own
+record of what it has authorized, cleared from **Settings → Advanced → Clear Write
+Authorizations**.
+
+**Requirements.** Zotero 10 or newer, with "Allow other applications on this computer
+to communicate with Zotero" enabled in Settings → Advanced. Older versions have no
+local write endpoints at all; `zotero-mcp authorize-local` detects this and says so
+rather than opening a dialog that can't help.
+
 ## 🔧 Advanced Configuration
 
 ### Using Web API Instead of Local API
@@ -427,6 +487,13 @@ zotero-mcp setup --no-local --api-key YOUR_API_KEY --library-id YOUR_LIBRARY_ID
 - `ZOTERO_API_KEY`: Your Zotero API key (for web API)
 - `ZOTERO_LIBRARY_ID`: Your Zotero library ID (for web API)
 - `ZOTERO_LIBRARY_TYPE`: The type of library (user or group, default: user)
+- `ZOTERO_LOCAL_API_KEY`: Local API key for writes (Zotero 10+). Normally set for you by
+  `zotero-mcp authorize-local`; use the variable for containers and CI, where the config
+  file isn't convenient
+- `ZOTERO_LOCAL_SERVER_ID`: Pin the local Zotero database the key belongs to (optional —
+  discovered automatically)
+- `ZOTERO_LOCAL_WRITE`: `auto` (default) or `false` to force writes onto the web API even
+  when a local key exists
 - `ZOTERO_WEBDAV_URL`: Optional WebDAV folder URL for direct attachment downloads in remote mode
 - `ZOTERO_WEBDAV_USERNAME`: Optional WebDAV username
 - `ZOTERO_WEBDAV_PASSWORD`: Optional WebDAV password
@@ -893,6 +960,10 @@ Example (Claude Desktop / Claude Code):
 - `scite_enrich_item`: Get Scite citation tallies and retraction alerts for a paper
 - `scite_enrich_search`: Search your Zotero library with Scite-enriched results (tallies + alerts inline)
 - `scite_check_retractions`: Scan items for retractions and editorial notices
+
+### ✏️ Write Access Tools
+- `zotero_authorize_local_writes`: Request local write permission from Zotero (Zotero 10+) — opens a dialog in the Zotero app
+- `zotero_write_capabilities`: Report which write path is available (local / hybrid / web / none) and what to do about it
 
 ### 📦 Item & Collection Management Tools
 - `zotero_add_by_doi`: Add a paper by DOI with automatic metadata and open-access PDF attachment

--- a/docs/ANNOTATION_FEATURE.md
+++ b/docs/ANNOTATION_FEATURE.md
@@ -187,7 +187,10 @@ Works with both:
 - **Zotero Cloud Storage**: Downloads via Web API
 - **WebDAV Storage**: Downloads via local Zotero (port 23119)
 
-Annotations are always created via Web API (local API is read-only).
+Annotations are created through whichever backend can write: the local API on Zotero 10
+or newer once `zotero-mcp authorize-local` has been run, otherwise the Web API. The
+attachment is still downloaded from whichever source has the bytes, which is not
+necessarily the same backend.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -221,9 +221,15 @@ If you encounter issues:
 
 ### Local Library Limitations
 
-Some functionality will not work for local libraries due to the distinct differences with [Zotero's local JS API](https://www.zotero.org/support/dev/client_coding/javascript_api). For instance, tagging and other library modifications might not work as expected with the local API connection.
+**On Zotero 10 or newer** the local API accepts writes. Run `zotero-mcp authorize-local`
+once, choose "Always Allow" in the dialog Zotero shows, and tagging, item edits, notes,
+collections and file attachments all work against the local library with no cloud
+account. See [Local write support](../README.md#local-write-support).
 
-**Workaround**: Even without web storage, a workaround for some of these functionalities might be to set up a web library, point the MCP at that, and then things like setting tags should work properly. We're thinking about better ways to work with local instances in future updates.
+**On Zotero 9 and older** the local API is read-only, so library modifications will not
+work over the local connection alone. Set `ZOTERO_API_KEY` and `ZOTERO_LIBRARY_ID`
+alongside `ZOTERO_LOCAL=true` — the server then reads locally and writes through the web
+API ("hybrid mode"), which is what makes tagging and the rest behave as expected.
 
 ### Database Issues
 

--- a/docs/integration-test-plan.md
+++ b/docs/integration-test-plan.md
@@ -3,11 +3,14 @@
 Use this document as instructions for Claude Co-Work. Copy/paste each section as a prompt, or give the whole document at once and ask Claude to work through it step by step.
 
 **Prerequisites:**
-- Zotero 8 is running on this computer
+- Zotero is running on this computer (Zotero 8 or newer; Zotero 10 or newer to exercise the local write path)
 - The local API is enabled in Zotero preferences ("Allow other applications on this computer to communicate with Zotero")
 - The modified zotero-mcp is installed (run `zotero-mcp version` in terminal to verify)
+- Run `zotero-mcp authorize-local --status` and note which write mode is reported — `local`, `hybrid` or `web`. Several checks below depend on it.
 
-**Important:** After each write operation, open Zotero and verify the change appeared. This confirms hybrid mode is working (local reads + web writes syncing back to local).
+**Important:** After each write operation, open Zotero and verify the change appeared.
+
+In **hybrid** mode this confirms the round-trip works (local reads, web writes syncing back to local). In **local** mode the change should appear in Zotero immediately, with no sync — if it only shows up after a sync, the write went to the cloud and the local path is not actually in use.
 
 **Test item tagging and cleanup rules:**
 
@@ -235,6 +238,63 @@ For example: /Users/eugenehawkin/Documents/some-paper.pdf
 **Verify:** Item created in Zotero. If the PDF contained a DOI, metadata should be auto-populated. The PDF should be attached to the item.
 
 *Skip this test if you don't have a convenient PDF file to test with.*
+
+---
+
+## Phase 7b: Local Write Path (Zotero 10+ only)
+
+Skip this phase on Zotero 9 or older — `zotero-mcp authorize-local --status` will report
+that the running Zotero has no local write API, and everything falls back to hybrid mode.
+
+To exercise the local path honestly, unset `ZOTERO_API_KEY` and `ZOTERO_LIBRARY_ID` for
+the run. With them set, a failure of the local path would silently fall back to the web
+API and the phase would pass without proving anything.
+
+### Test 7b.1: Authorization
+Run `zotero-mcp authorize-local` in a terminal.
+
+**Verify:** the dialog appears in Zotero and **stays up for more than five seconds
+without the command giving up** — a too-short client timeout would make the feature
+unusable. Choose "Always Allow". The command reports a reusable key and the path it was
+saved to. `zotero-mcp authorize-local --status` then reports write mode `local`.
+
+### Test 7b.2: Round trip with no cloud involved
+```
+Add the DOI 10.1038/nature12373 to my library, then update its title, then trash it.
+```
+**Verify:** each change appears in Zotero **immediately**, with no sync. Check Zotero's
+sync status — nothing should have been uploaded.
+
+### Test 7b.3: File attachment lands locally
+```
+Use zotero_add_from_file to import a local PDF.
+```
+**Verify:** the file exists under Zotero's own `storage/` directory. If WebDAV is
+configured, confirm no WebDAV upload was attempted — the desktop handles that itself for
+locally-stored files.
+
+### Test 7b.4: Single-use keys fail loudly
+Run `zotero-mcp authorize-local` again and choose plain **Allow** this time. Perform two
+writes.
+
+**Verify:** the first succeeds; the second fails with a message explaining that keys
+granted with "Allow" are single-use and telling you to re-authorize with "Always Allow".
+Not a bare 401.
+
+### Test 7b.5: Config survives setup
+Run `zotero-mcp setup` (accept the defaults), then `zotero-mcp authorize-local --status`.
+
+**Verify:** the stored key is still there. Setup rebuilds part of the config file, and
+the key lives in its own section so that rewrite cannot drop it.
+
+### Test 7b.6: Group libraries still address the right library
+Switch to a group library with `zotero_switch_library`, create an item and trash it.
+
+**Verify:** both land in the group, not in My Library.
+
+### Phase 7b Cleanup
+Restore `ZOTERO_API_KEY` and `ZOTERO_LIBRARY_ID` if you unset them. Trash any items
+created here (they should carry `_MCP-test-to-delete`).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    # 1.14.0 for local API write support: authorize_local(), the
+    # server_id/local_api_key constructor args, and the Zotero._write()
+    # dispatcher that attaches the headers a local write requires.
+    #
     # 1.13.5 retries a rate-limited read internally and raises
     # TooManyRetriesError once the backoff is exhausted (upstream
     # urschrei/pyzotero#352). Below it, every read method hands the HTTP 429
@@ -28,7 +32,7 @@ dependencies = [
     # load-bearing, not just preferred. (1.13.3 is also required, for sending
     # Path(filename).name as the stored-file filename — upstream #341, without
     # which every attach pays for the two-step fallback in _attach_and_verify.)
-    "pyzotero>=1.13.5",
+    "pyzotero>=1.15.1",
     "python-dotenv>=1.0.0",
     # PDF text extraction. Rust with prebuilt abi3 wheels for every platform
     # we support and no Python dependencies of its own. Pinned exactly while

--- a/scripts/gen_skill_reference.py
+++ b/scripts/gen_skill_reference.py
@@ -116,7 +116,16 @@ def build() -> str:
 
 
 if __name__ == "__main__":
+    # An explicit destination lets a caller (the test suite, most of all)
+    # generate without writing over the checked-in copy.
+    out = Path(sys.argv[1]) if len(sys.argv) > 1 else OUT
     text = build()
-    OUT.parent.mkdir(parents=True, exist_ok=True)
-    OUT.write_text(text, encoding="utf-8")
-    print(f"wrote {OUT.relative_to(REPO)} ({len(text)} chars)")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    # newline="\n" is load-bearing on Windows: write_text's default
+    # translates every "\n" to "\r\n", so a run of this script rewrote the
+    # tracked file in CRLF. The repo is LF throughout, and read_text()
+    # normalizes on the way back in, so nothing downstream reported the drift.
+    with open(out, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write(text)
+    shown = out.relative_to(REPO) if out.is_relative_to(REPO) else out
+    print(f"wrote {shown} ({len(text)} chars)")

--- a/src/zotero_mcp/cli.py
+++ b/src/zotero_mcp/cli.py
@@ -33,6 +33,7 @@ def obfuscate_config_for_display(config):
     obfuscated = config.copy()
     sensitive_keys = [
         "ZOTERO_API_KEY",
+        "ZOTERO_LOCAL_API_KEY",
         "ZOTERO_LIBRARY_ID",
         "ZOTERO_WEBDAV_URL",
         "ZOTERO_WEBDAV_USERNAME",
@@ -431,6 +432,158 @@ def _normalize_help_args(argv: list[str]) -> list[str]:
     return [*argv[1:], "--help"]
 
 
+def _print_write_capabilities(caps):
+    """Print the write configuration, key masked."""
+    labels = {
+        "local": "local API (writes go straight to the running Zotero)",
+        "hybrid": "hybrid (local reads, writes through the Zotero web API)",
+        "web": "web API",
+        "none": "none — writes are not possible",
+    }
+    print(f"Write mode:            {caps['mode']} — {labels[caps['mode']]}")
+    print(f"Local mode:            {'yes' if caps['local_mode'] else 'no'}")
+    if caps["local_mode"]:
+        supported = caps["server_supports_local_writes"]
+        print(f"Zotero supports local writes: "
+              f"{'yes' if supported else 'no (needs Zotero 10 or newer)'}")
+        if caps["server_id"]:
+            print(f"Server ID:             {caps['server_id']}")
+        if caps["has_local_key"]:
+            validity = {True: "reusable", False: "single-use", None: "unknown"}[
+                caps["local_key_remember"]
+            ]
+            print(f"Local API key:         held ({caps['local_key_source']}, {validity})")
+        else:
+            print("Local API key:         none")
+        if not caps["local_write_enabled"]:
+            print("Local writes:          disabled via ZOTERO_LOCAL_WRITE")
+    print(f"Web API credentials:   {'set' if caps['has_web_credentials'] else 'not set'}")
+
+
+def cmd_authorize_local(args):
+    """Grant this app write access to the local Zotero API. Returns an exit code."""
+    from pyzotero.errors import (
+        LocalAPIDeniedError,
+        TooManyRequestsError,
+        UnsupportedParamsError,
+    )
+
+    from zotero_mcp import client as _client
+
+    if args.status:
+        _print_write_capabilities(_client.get_write_capabilities())
+        return 0
+
+    if args.revoke:
+        if _client.clear_local_write_credentials():
+            print("Stored local API key removed.")
+        else:
+            print("No stored local API key to remove.")
+        # Revoke cannot reach into the environment of a process it doesn't
+        # own, so a key set there survives and writes keep going local.
+        # Saying nothing would make revoke look like it had failed.
+        if os.environ.get(_client.LOCAL_API_KEY_ENV):
+            print(
+                f"\nWarning: {_client.LOCAL_API_KEY_ENV} is still set in the "
+                "environment, so local writes remain enabled. Unset it to "
+                "finish revoking."
+            )
+        print(
+            "\nZotero keeps its own record of granted authorizations. To clear "
+            "those too, use Settings > Advanced > Clear Write Authorizations."
+        )
+        return 0
+
+    if not _client.is_local_mode():
+        print(
+            "ZOTERO_LOCAL is not enabled, so there is no local API to authorize. "
+            "Writes already go through the Zotero web API."
+        )
+        return 7
+
+    if not _client.probe_local_server_id():
+        print(
+            "The local Zotero API did not return a Zotero-Server-ID header.\n\n"
+            "Either Zotero is not running with 'Allow other applications on this "
+            "computer to communicate with Zotero' enabled (Settings > Advanced), "
+            "or this build predates local write support, which needs Zotero 10 "
+            "or newer. Until then, set ZOTERO_API_KEY and ZOTERO_LIBRARY_ID to "
+            "write through the web API."
+        )
+        return 5
+
+    app_name = args.app_name or _client.DEFAULT_APP_NAME
+    print(f"Requesting local API write access as \"{app_name}\".")
+    print()
+    print("Zotero will now show an authorization dialog — switch to it and answer:")
+    print("  Always Allow  a reusable key, saved for future sessions")
+    print("  Allow         a key valid for exactly ONE write")
+    print("  Deny          no access")
+    print()
+    print(f"Waiting up to {args.timeout:.0f}s...")
+    # Flush before blocking. Python buffers stdout whenever it isn't a TTY, so
+    # when this command is piped or captured the instructions above would
+    # otherwise not appear until the call returns — i.e. after the user has
+    # already answered the dialog they were being told to look for.
+    sys.stdout.flush()
+
+    try:
+        result = _client.authorize_local_api(
+            app_name=app_name, timeout=args.timeout, persist=not args.no_save
+        )
+    except LocalAPIDeniedError:
+        print("\nDenied. Nothing was changed. Re-run this command to try again.")
+        return 3
+    except TooManyRequestsError:
+        print(
+            "\nZotero is rate-limiting authorization prompts (about 5 per "
+            "minute). Wait a minute and re-run this command."
+        )
+        return 4
+    except UnsupportedParamsError as e:
+        print(f"\n{e}")
+        return 5
+    except Exception as e:
+        print(f"\nAuthorization failed: {e}")
+        return 1
+
+    print()
+    if not result.get("remember"):
+        # Not saved, deliberately: it dies with the first write, and a dead
+        # key on disk would outrank working web credentials on every run.
+        print(
+            "Granted: SINGLE-USE key, not saved. \"Allow\" was chosen rather "
+            "than \"Always Allow\", so it is consumed by one write — and this "
+            "command's own process is about to exit, so nothing will use it."
+        )
+        print(
+            "\nRe-run this command and choose \"Always Allow\" to get a key "
+            "that persists."
+        )
+        if args.print_key:
+            print(f"\nZOTERO_LOCAL_API_KEY={result['key']}")
+            print(f"ZOTERO_LOCAL_SERVER_ID={result.get('server_id')}")
+        return 0
+
+    print("Granted: reusable key.")
+    if args.no_save:
+        print("Not saved (--no-save): export it below to use it.")
+    elif result.get("stored_at"):
+        print(f"Saved to {result['stored_at']} (owner-only permissions).")
+    else:
+        print(
+            "Warning: the key could not be written to the config file. Export "
+            "it as ZOTERO_LOCAL_API_KEY to keep it across runs."
+        )
+
+    if args.print_key:
+        print(f"\nZOTERO_LOCAL_API_KEY={result['key']}")
+        print(f"ZOTERO_LOCAL_SERVER_ID={result.get('server_id')}")
+
+    print("\nWrites will now go directly to the running Zotero, not the cloud.")
+    return 0
+
+
 def main():
     """Main entry point for the CLI."""
     parser = argparse.ArgumentParser(
@@ -620,6 +773,24 @@ def main():
         help="Overwrite existing files. In a shared instructions file only the "
              "managed block changes. No backup is kept.")
 
+    # Local write authorization command
+    authorize_parser = subparsers.add_parser(
+        "authorize-local",
+        help="Grant this app write access to the local Zotero API (Zotero 10+)",
+    )
+    authorize_parser.add_argument("--app-name", default=None,
+                                  help="Name shown in the Zotero dialog")
+    authorize_parser.add_argument("--timeout", type=float, default=120.0,
+                                  help="Seconds to wait for the dialog (default: 120)")
+    authorize_parser.add_argument("--status", action="store_true",
+                                  help="Report the current write configuration and exit")
+    authorize_parser.add_argument("--revoke", action="store_true",
+                                  help="Forget the stored local API key and exit")
+    authorize_parser.add_argument("--print", dest="print_key", action="store_true",
+                                  help="Print the granted key (for ZOTERO_LOCAL_API_KEY)")
+    authorize_parser.add_argument("--no-save", action="store_true",
+                                  help="Do not persist the key to the config file")
+
     args = parser.parse_args(_normalize_help_args(sys.argv[1:]))
 
     # If no command is provided, default to 'serve'
@@ -680,6 +851,10 @@ def main():
         else:
             print(f"Zotero schema already current (version {after}).")
         sys.exit(0)
+
+    elif args.command == "authorize-local":
+        setup_zotero_environment()
+        sys.exit(cmd_authorize_local(args))
 
     elif args.command == "setup-info":
         # Setup Zotero environment variables
@@ -747,6 +922,22 @@ def main():
                 }
             }
             print(json.dumps(config_snippet, indent=2))
+
+        # Show how writes reach Zotero
+        print()
+        print("✏️  Write Access:")
+        try:
+            from zotero_mcp import client as _client_mod
+            caps = _client_mod.get_write_capabilities()
+            _print_write_capabilities(caps)
+            if caps["mode"] == "hybrid" and caps["server_supports_local_writes"]:
+                print("  💡 This Zotero supports local writes — run "
+                      "'zotero-mcp authorize-local' to skip the cloud round-trip.")
+            elif caps["mode"] == "none":
+                print("  💡 Run 'zotero-mcp authorize-local' (Zotero 10+), or set "
+                      "ZOTERO_API_KEY and ZOTERO_LIBRARY_ID.")
+        except Exception as e:
+            print(f"  Could not determine write access: {e}")
 
         # Show semantic search database info with detailed statistics
         print()

--- a/src/zotero_mcp/client.py
+++ b/src/zotero_mcp/client.py
@@ -3,13 +3,16 @@ Zotero client wrapper for MCP server.
 """
 
 import functools
+import json
 import logging
 import os
 import re
 import shutil
 import threading
+import time
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +31,7 @@ from zotero_mcp.utils import (
     _paginate,
     format_creators,
     html_to_text,
+    is_local_mode,
     item_display_date,
     item_display_title,
 )
@@ -162,7 +166,21 @@ def get_active_group_id() -> int:
     return 0
 
 
-def _make_local_http_client() -> httpx.Client:
+# Timeouts for the injected local httpx client. pyzotero only passes an
+# explicit per-request timeout on its READ paths; Zotero._write() and
+# authorize_local() hand the request straight to self.client with no timeout
+# kwarg. pyzotero's own default client sets one at construction, but we supply
+# our own client (for the HTTP/1.1 pin below), so without these constants every
+# local write would inherit httpx's 5s default — and authorize_local() would
+# time out about five seconds into a modal dialog nobody could answer that fast.
+_LOCAL_READ_TIMEOUT = 30.0
+_LOCAL_WRITE_TIMEOUT = 120.0
+# Kept under FastMCP's ~60s client timeout so the MCP tool reports a real
+# outcome instead of the transport dying first.
+_LOCAL_AUTHORIZE_TIMEOUT = 55.0
+
+
+def _make_local_http_client(timeout: float = _LOCAL_READ_TIMEOUT) -> httpx.Client:
     """Return an httpx.Client pinned to HTTP/1.1 for the local Zotero server.
 
     Zotero 8's local server (port 23119) only speaks HTTP/1.0. httpx defaults
@@ -170,11 +188,42 @@ def _make_local_http_client() -> httpx.Client:
     Bad Gateway — every tool call fails even though the MCP starts cleanly
     (#160). Forcing http1=True / http2=False on the transport keeps requests
     on HTTP/1.1 and the local API answers normally.
+
+    The explicit timeout is load-bearing, not tidying: see the comment on the
+    constants above. Connect stays short because the server is on loopback —
+    if it isn't listening we want to know immediately, not in two minutes.
     """
     return httpx.Client(
         transport=httpx.HTTPTransport(http1=True, http2=False),
         follow_redirects=True,
+        timeout=httpx.Timeout(timeout, connect=5.0),
     )
+
+
+def _apply_default_headers(zot: zotero.Zotero) -> zotero.Zotero:
+    """Restore the pyzotero headers that supplying our own client drops.
+
+    pyzotero only calls default_headers() when it builds the httpx client
+    itself, so an injected client sends neither User-Agent nor
+    Zotero-API-Version: 3. Harmless while we only read; worth having once we
+    start writing.
+
+    Authorization is stripped deliberately. In hybrid mode this client is
+    built with the zotero.org API key, and default_headers() turns that into
+    `Authorization: Bearer <key>` — which would send a cloud credential to a
+    local HTTP server that has no use for it. Local writes authenticate with
+    Zotero-API-Key instead, attached per-request by pyzotero.
+    """
+    try:
+        headers = {
+            name: value
+            for name, value in zot.default_headers().items()
+            if name.lower() != "authorization"
+        }
+        zot.client.headers.update(headers)
+    except Exception:
+        pass
+    return zot
 
 
 @dataclass
@@ -227,13 +276,14 @@ def get_zotero_client() -> zotero.Zotero:
             "or use ZOTERO_LOCAL=true for local Zotero instance."
         )
 
-    return zotero.Zotero(
+    zot = zotero.Zotero(
         library_id=library_id,
         library_type=library_type,
         api_key=api_key,
         local=local,
         client=_make_local_http_client() if local else None,
     )
+    return _apply_default_headers(zot) if local else zot
 
 
 def get_local_zotero_client() -> zotero.Zotero | None:
@@ -251,12 +301,14 @@ def get_local_zotero_client() -> zotero.Zotero | None:
         # Create a local client - library_id 0 is the default for local.
         # HTTP/1.1-only transport for compatibility with Zotero 8's local
         # server (#160) — httpx default HTTP/2 negotiation returns 502.
-        client = zotero.Zotero(
-            library_id="0",
-            library_type="user",
-            api_key=None,
-            local=True,
-            client=_make_local_http_client(),
+        client = _apply_default_headers(
+            zotero.Zotero(
+                library_id="0",
+                library_type="user",
+                api_key=None,
+                local=True,
+                client=_make_local_http_client(),
+            )
         )
         # Test connection by making a simple request
         client.items(limit=1)
@@ -294,6 +346,340 @@ def is_local_zotero_available() -> bool:
     """Check if local Zotero instance is running and accessible."""
     client = get_local_zotero_client()
     return client is not None
+
+
+# ---------------------------------------------------------------------------
+# Local API write access (Zotero 10+)
+#
+# Writing through the local API needs two things the read path never sends: a
+# Zotero-Server-ID header identifying the Zotero database, and a local API key
+# the user grants through a dialog in the Zotero app. The key is unrelated to
+# a zotero.org API key and cannot be created ahead of time.
+# ---------------------------------------------------------------------------
+
+ZOTERO_MCP_CONFIG_PATH = Path.home() / ".config" / "zotero-mcp" / "config.json"
+
+LOCAL_API_KEY_ENV = "ZOTERO_LOCAL_API_KEY"
+LOCAL_SERVER_ID_ENV = "ZOTERO_LOCAL_SERVER_ID"
+LOCAL_WRITE_ENV = "ZOTERO_LOCAL_WRITE"
+DEFAULT_APP_NAME = "Zotero MCP"
+
+# Credentials granted during this process, before/instead of anything on disk.
+_local_write_state: dict[str, Any] = {}
+# Cached capability probe: {"server_id": str | None, "checked_at": float}
+_local_probe_cache: dict[str, Any] = {}
+# A negative probe is re-checked after this long, so upgrading or restarting
+# Zotero mid-session recovers without restarting the MCP server.
+_LOCAL_PROBE_NEGATIVE_TTL = 60.0
+
+# Deliberately NOT _zotero_api_lock. Authorization blocks until a human clicks
+# a button; holding the shared API lock that long would push every other tool
+# past its bounded 45s acquire. This lock exists only to stop two dialogs from
+# being opened at once, so it is always acquired non-blocking.
+_local_auth_lock = threading.Lock()
+
+
+class ZoteroAuthInProgressError(RuntimeError):
+    """Raised when an authorization dialog is already open."""
+
+
+def load_zotero_mcp_config() -> dict:
+    """Return the parsed ``~/.config/zotero-mcp/config.json``, or ``{}``.
+
+    Missing file or parse errors yield an empty dict so callers can use
+    ``.get(...)`` chains without guarding. Callers that intend to write the
+    file back must use ``_readable_config_for_update`` instead — an empty dict
+    here does not distinguish "no config" from "could not read it", and
+    rewriting on the latter would discard the user's other settings.
+    """
+    try:
+        return _readable_config_for_update()
+    except OSError:
+        return {}
+
+
+def _readable_config_for_update() -> dict:
+    """Parse the config file for a read-modify-write. Raises if unreadable.
+
+    A config that exists but cannot be parsed must not be silently replaced:
+    it also holds ``semantic_search`` and ``client_env``, and treating a
+    transient read failure or a hand-editing typo as "empty" would drop both.
+    """
+    if not ZOTERO_MCP_CONFIG_PATH.exists():
+        return {}
+    try:
+        with open(ZOTERO_MCP_CONFIG_PATH, encoding="utf-8") as f:
+            return json.load(f) or {}
+    except json.JSONDecodeError as e:
+        raise OSError(
+            f"{ZOTERO_MCP_CONFIG_PATH} is not valid JSON ({e}). Fix or remove "
+            "the file; refusing to overwrite it and lose the other settings."
+        ) from e
+
+
+def _local_write_enabled() -> bool:
+    """Honour the ZOTERO_LOCAL_WRITE kill switch. Unset or "auto" means on."""
+    raw = os.getenv(LOCAL_WRITE_ENV, "").strip().lower()
+    if not raw or raw == "auto":
+        return True
+    return raw in {"true", "yes", "1"}
+
+
+def probe_local_server_id(timeout: float = 3.0, force: bool = False) -> str | None:
+    """Return the local Zotero server ID, or None if this build has no writes.
+
+    Every local API response carries a Zotero-Server-ID header; a build that
+    predates local write support carries none. GET /api/ (the trailing slash
+    matters — bare /api is a 404) is the cheapest way to ask.
+
+    Never called at import or from the write path itself: only the capability
+    tool, the CLI, and the message shown when writes are unavailable.
+    """
+    cached_at = _local_probe_cache.get("checked_at")
+    if not force and cached_at is not None:
+        server_id = _local_probe_cache.get("server_id")
+        if server_id or (time.monotonic() - cached_at) < _LOCAL_PROBE_NEGATIVE_TTL:
+            return server_id
+
+    # Deliberately not ZOTERO_LOCAL_PORT: pyzotero hardcodes localhost:23119
+    # for local mode, so probing anywhere else could report "writes supported"
+    # for a server the writes will never reach.
+    server_id = None
+    try:
+        with _make_local_http_client(timeout) as http:
+            resp = http.get("http://localhost:23119/api/")
+            server_id = resp.headers.get("zotero-server-id")
+    except Exception:
+        server_id = None
+
+    _local_probe_cache["server_id"] = server_id
+    _local_probe_cache["checked_at"] = time.monotonic()
+    return server_id
+
+
+def get_local_write_credentials() -> tuple[str | None, str | None, str | None]:
+    """Return (api_key, server_id, source) for local writes.
+
+    Precedence: credentials granted in this process, then the environment,
+    then the config file. Source is "session", "env", "config" or None.
+    """
+    if key := _local_write_state.get("key"):
+        return key, _local_write_state.get("server_id"), "session"
+
+    if key := os.getenv(LOCAL_API_KEY_ENV, "").strip():
+        return key, os.getenv(LOCAL_SERVER_ID_ENV, "").strip() or None, "env"
+
+    stored = load_zotero_mcp_config().get("local_api") or {}
+    if key := stored.get("key"):
+        return key, stored.get("server_id"), "config"
+
+    return None, None, None
+
+
+def _local_key_remembered() -> bool | None:
+    """Whether the active key was granted with "Always Allow", if we know."""
+    _key, _server_id, source = get_local_write_credentials()
+    if source == "session":
+        return _local_write_state.get("remember")
+    if source == "config":
+        return (load_zotero_mcp_config().get("local_api") or {}).get("remember")
+    return None
+
+
+def _write_config(config: dict) -> None:
+    """Persist the config file, owner-only, replacing it atomically."""
+    ZOTERO_MCP_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = ZOTERO_MCP_CONFIG_PATH.with_suffix(".json.tmp")
+    with open(temp_path, "w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2)
+    # The file holds a credential — keep it owner-only. Best-effort; a no-op
+    # on platforms without POSIX permissions. Set before the rename so the
+    # key is never briefly world-readable at its final name.
+    try:
+        os.chmod(temp_path, 0o600)
+    except OSError:
+        pass
+    os.replace(temp_path, ZOTERO_MCP_CONFIG_PATH)
+
+
+def store_local_write_credentials(
+    key: str, server_id: str | None, remember: bool, app_name: str = DEFAULT_APP_NAME
+) -> Path | None:
+    """Cache credentials for this process and persist them. Returns the path.
+
+    Persisted under its own ``local_api`` section rather than ``client_env``,
+    which ``setup_helper._write_standalone_config`` rebuilds from scratch on
+    every ``zotero-mcp setup`` run and would silently drop the key.
+
+    Returns None if the file could not be written, including when it exists
+    but cannot be parsed — the session copy is still set, so the caller can
+    keep working and warn.
+    """
+    _local_write_state.update({"key": key, "server_id": server_id, "remember": remember})
+
+    try:
+        config = _readable_config_for_update()
+        config["local_api"] = {
+            "key": key,
+            "server_id": server_id,
+            "remember": remember,
+            "app_name": app_name,
+            "granted": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+        _write_config(config)
+        return ZOTERO_MCP_CONFIG_PATH
+    except OSError:
+        return None
+
+
+def clear_local_write_credentials() -> bool:
+    """Forget the local API key. True if anything was actually cleared.
+
+    Covers the session copy as well as the stored one, so a key granted during
+    this run reports honestly instead of "nothing to remove". A key supplied
+    through the environment cannot be cleared from here — the caller is
+    expected to say so.
+    """
+    cleared = bool(_local_write_state)
+    _local_write_state.clear()
+
+    try:
+        config = _readable_config_for_update()
+    except OSError:
+        return cleared
+    if "local_api" not in config:
+        return cleared
+    del config["local_api"]
+    try:
+        _write_config(config)
+        return True
+    except OSError:
+        return cleared
+
+
+def get_local_write_client() -> zotero.Zotero | None:
+    """Return a local Zotero client authorized to write, or None.
+
+    None — never an exception — when local writes are switched off, when we
+    aren't in local mode, or when no key has been granted yet. Callers treat
+    that as "fall back to the web API".
+    """
+    if not _local_write_enabled() or not is_local_mode():
+        return None
+
+    key, server_id, _source = get_local_write_credentials()
+    if not key:
+        return None
+
+    override = _active_library_override
+    library_type = override.get("library_type") or os.getenv("ZOTERO_LIBRARY_TYPE", "user")
+    library_id = override.get("library_id") or os.getenv("ZOTERO_LIBRARY_ID")
+    # The local API addresses the user library as users/0 whatever the web
+    # user id is; a group keeps its real numeric id.
+    if not library_type.startswith("group"):
+        library_id = "0"
+    elif not library_id:
+        # A group with no id is a broken configuration, but this factory
+        # promises None rather than an exception — pyzotero would raise
+        # MissingCredentialsError, which no caller is catching.
+        return None
+
+    zot = zotero.Zotero(
+        library_id=library_id,
+        library_type=library_type,
+        api_key=None,
+        local=True,
+        client=_make_local_http_client(_LOCAL_WRITE_TIMEOUT),
+        # Supplying the cached id spares pyzotero a GET /api/ before the first
+        # write of every tool call, since each call builds a fresh client.
+        server_id=server_id or None,
+        local_api_key=key,
+    )
+    return _apply_default_headers(zot)
+
+
+def authorize_local_api(
+    app_name: str = DEFAULT_APP_NAME,
+    timeout: float = _LOCAL_AUTHORIZE_TIMEOUT,
+    persist: bool = True,
+) -> dict:
+    """Ask Zotero for a local API key. Blocks on a dialog in the Zotero app.
+
+    Returns pyzotero's response — a ``key`` and a ``remember`` flag — with the
+    server id added. ``remember`` is False when the user chose "Allow" rather
+    than "Always Allow", which makes the key valid for exactly one write.
+
+    Raises ZoteroAuthInProgressError if a dialog is already open, and lets
+    pyzotero's LocalAPIDeniedError / TooManyRequestsError / UnsupportedParams-
+    Error through for the caller to phrase.
+    """
+    if not _local_auth_lock.acquire(blocking=False):
+        raise ZoteroAuthInProgressError(
+            "A Zotero authorization dialog is already open. Answer it in "
+            "Zotero, then retry."
+        )
+    try:
+        zot = zotero.Zotero(
+            library_id="0",
+            library_type="user",
+            api_key=None,
+            local=True,
+            client=_make_local_http_client(timeout),
+        )
+        result = dict(zot.authorize_local(app_name))
+        result["server_id"] = zot.server_id
+        remember = bool(result.get("remember"))
+
+        # A single-use key is never written to disk. It is consumed by the
+        # first write, and a dead key on disk outranks working web credentials
+        # on every later run — which would turn one stray click on "Allow"
+        # into a permanently broken hybrid setup. Keeping it in the session
+        # still lets this process use it once, and still lets the 401 handler
+        # explain what happened.
+        if persist and remember:
+            result["stored_at"] = store_local_write_credentials(
+                result["key"], zot.server_id, remember, app_name
+            )
+        else:
+            _local_write_state.update(
+                {
+                    "key": result["key"],
+                    "server_id": zot.server_id,
+                    "remember": remember,
+                }
+            )
+        return result
+    finally:
+        _local_auth_lock.release()
+
+
+def get_write_capabilities(probe: bool = True) -> dict[str, Any]:
+    """Describe how (and whether) writes can reach Zotero right now."""
+    local_mode = is_local_mode()
+    key, server_id, source = get_local_write_credentials()
+    has_web = bool(os.getenv("ZOTERO_LIBRARY_ID") and os.getenv("ZOTERO_API_KEY"))
+    probed_id = probe_local_server_id() if (probe and local_mode) else None
+
+    if not local_mode:
+        mode = "web" if has_web else "none"
+    elif key and _local_write_enabled():
+        mode = "local"
+    elif has_web:
+        mode = "hybrid"
+    else:
+        mode = "none"
+
+    return {
+        "mode": mode,
+        "local_mode": local_mode,
+        "local_write_enabled": _local_write_enabled(),
+        "server_supports_local_writes": bool(probed_id),
+        "server_id": probed_id or server_id,
+        "has_local_key": bool(key),
+        "local_key_source": source,
+        "local_key_remember": _local_key_remembered(),
+        "has_web_credentials": has_web,
+    }
 
 
 def format_item_metadata(item: dict[str, Any], include_abstract: bool = True) -> str:

--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -774,7 +774,12 @@ class LocalZoteroReader:
             return Path(decoded_path)
 
         # Linked file as absolute path: '/Users/me/papers/file.pdf'
-        if os.path.isabs(zotero_path):
+        #
+        # The leading-slash test is separate from isabs() on purpose: since
+        # Python 3.13 ntpath.isabs() calls "/Users/me/paper.pdf" relative, so a
+        # library synced from macOS or Linux and opened on Windows would
+        # resolve every linked file to None instead of to a path.
+        if zotero_path.startswith("/") or os.path.isabs(zotero_path):
             return Path(zotero_path)
 
         # Zotero 'attachments:' relative path — resolve against the linked

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -7,6 +7,7 @@ over research libraries.
 """
 
 import contextlib
+import functools
 import json
 import logging
 import os
@@ -101,8 +102,65 @@ def _realtime_slice_size(max_parallel: int) -> int:
     return min(25 * max(1, max_parallel), 200)
 
 
+_WIN_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+_WIN_STILL_ACTIVE = 259
+_WIN_ERROR_ACCESS_DENIED = 5
+
+
+@functools.lru_cache(maxsize=1)
+def _kernel32():
+    """kernel32 with the three entry points below given explicit signatures.
+
+    HANDLE must be declared: ctypes defaults a return type to C ``int``, which
+    truncates a 64-bit handle and leaks it.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    lib = ctypes.WinDLL("kernel32", use_last_error=True)
+    lib.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    lib.OpenProcess.restype = wintypes.HANDLE
+    lib.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+    lib.GetExitCodeProcess.restype = wintypes.BOOL
+    lib.CloseHandle.argtypes = (wintypes.HANDLE,)
+    lib.CloseHandle.restype = wintypes.BOOL
+    return lib
+
+
+def _pid_is_alive_windows(pid: int) -> bool:
+    """Liveness check for Windows, where ``os.kill(pid, 0)`` is not a probe.
+
+    ``signal.CTRL_C_EVENT`` is 0, so ``os.kill(pid, 0)`` never asks whether
+    *pid* exists: it calls ``GenerateConsoleCtrlEvent`` and delivers a real
+    Ctrl+C to every process sharing this console — the test run itself, and
+    whatever shell launched it. ``OpenProcess`` answers the actual question
+    and sends nothing.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    lib = _kernel32()
+    handle = lib.OpenProcess(_WIN_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        # Access denied means it exists but is owned by another user; that is
+        # the PermissionError branch below, so report it alive.
+        return ctypes.get_last_error() == _WIN_ERROR_ACCESS_DENIED
+    try:
+        code = wintypes.DWORD()
+        if not lib.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return True  # the handle opened, so the process object exists
+        return code.value == _WIN_STILL_ACTIVE
+    finally:
+        lib.CloseHandle(handle)
+
+
 def _pid_is_alive(pid: int) -> bool:
-    """Best-effort liveness check for a process id (POSIX ``kill(pid, 0)``)."""
+    """Best-effort liveness check for a process id."""
+    if sys.platform == "win32":
+        try:
+            return _pid_is_alive_windows(pid)
+        except Exception:
+            return False
     try:
         os.kill(pid, 0)
     except ProcessLookupError:

--- a/src/zotero_mcp/server.py
+++ b/src/zotero_mcp/server.py
@@ -16,13 +16,16 @@ from zotero_mcp._app import mcp  # noqa: F401 — re-export
 
 # -- Re-export client helpers (used by tests as server.X) -------------------
 from zotero_mcp.client import (  # noqa: F401
+    authorize_local_api,
     clear_active_library,
     convert_to_markdown,
     format_item_metadata,
     generate_bibtex,
     get_active_library,
     get_attachment_details,
+    get_local_write_client,
     get_web_zotero_client,
+    get_write_capabilities,
     get_zotero_client,
     set_active_library,
 )
@@ -36,6 +39,13 @@ from zotero_mcp.tools._helpers import (  # noqa: F401
     _format_bbt_result,
     _format_citekey_result,
     _get_write_client,
+    resolve_write_client,
+    write_unavailable_message,
+    item_template_for,
+    attach_files,
+    trash_item,
+    format_zotero_error,
+    describe_write_failure,
     _handle_write_response,
     _normalize_arxiv_id,
     _normalize_doi,
@@ -69,6 +79,10 @@ from zotero_mcp.tools.annotations import (  # noqa: F401
 from zotero_mcp.tools.connectors import (  # noqa: F401
     chatgpt_connector_search,
     connector_fetch,
+)
+from zotero_mcp.tools.local_auth import (  # noqa: F401
+    authorize_local_writes,
+    write_capabilities,
 )
 from zotero_mcp.tools.read_pdf import (  # noqa: F401
     read_pdf_pages,

--- a/src/zotero_mcp/tools/__init__.py
+++ b/src/zotero_mcp/tools/__init__.py
@@ -5,6 +5,7 @@ from zotero_mcp.tools import (  # noqa: F401
     connectors,
     discovery,
     item_parent,
+    local_auth,
     read_pdf,
     retrieval,
     search,

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -1,8 +1,10 @@
 """Shared private helpers used across tool modules."""
 
 import contextlib
+import copy
 import hashlib
 import json
+import mimetypes
 import os
 import re
 import socket
@@ -12,10 +14,20 @@ from ipaddress import ip_address
 from urllib.parse import urljoin, urlparse
 
 import requests
-from pyzotero.zotero_errors import (
+
+# pyzotero.errors, not the pyzotero.zotero_errors back-compat shim: the shim
+# re-exports only the pre-1.14 names and its own maintainer note says not to
+# add new ones there, so the local-API classes are absent from it.
+from pyzotero.errors import (
+    CallDoesNotExistError,
+    LocalAPIDeniedError,
+    LocalAPIKeyRequiredError,
     PreConditionFailedError,
+    ServerIDMismatchError,
+    ServerIDRequiredError,
     TooManyRequestsError,
     TooManyRetriesError,
+    UnsupportedParamsError,
 )
 
 from zotero_mcp import client as _client
@@ -23,6 +35,21 @@ from zotero_mcp import utils as _utils
 from zotero_mcp.identifiers import normalize_doi
 from zotero_mcp.local_db import get_local_zotero_reader
 from zotero_mcp.utils import _paginate
+
+
+# ---------------------------------------------------------------------------
+# Config file
+# ---------------------------------------------------------------------------
+
+def _load_zotero_mcp_config() -> dict:
+    """Return the parsed ``~/.config/zotero-mcp/config.json``, or ``{}``.
+
+    Delegates to ``client`` so the file has a single owner — it now also holds
+    the local API key, which ``client`` reads without going through this
+    module (``_helpers`` imports ``client``, so it can't go the other way).
+    """
+    return _client.load_zotero_mcp_config()
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -124,24 +151,393 @@ def apply_library_override(zot, override: dict | None) -> None:
         zot.library_type = raw_type if raw_type.endswith("s") else raw_type + "s"
 
 
-def _get_write_client(ctx):
-    """Return (read_client, write_client) for hybrid-mode operations.
+def write_unavailable_message(op_description: str = "write operations") -> str:
+    """Explain that nothing can be written, and how to fix it.
 
-    In web-only mode: both are the web client.
-    In local mode with web credentials: read from local, write to web.
-    In local-only mode: raises ValueError with clear message.
+    Ordered by what is actually wrong: if the running Zotero exposes the write
+    API, authorizing is one command away and comes first; if it doesn't, web
+    credentials are the only route and saying so up front saves the user from
+    chasing a feature their Zotero build doesn't have.
     """
-    read_zot = _client.get_zotero_client()
+    authorize = (
+        "  1. Local writes (Zotero 10 or newer): run `zotero-mcp authorize-local`, "
+        "or call the zotero_authorize_local_writes tool, then choose "
+        "\"Always Allow\" in the Zotero dialog."
+    )
+    web = (
+        "  2. Web API writes (any Zotero version): set ZOTERO_API_KEY and "
+        "ZOTERO_LIBRARY_ID to enable hybrid mode — local reads, cloud writes."
+    )
+    header = (
+        f"Cannot perform write operations in local-only mode: no writable "
+        f"Zotero backend is configured for {op_description}."
+    )
+    if _client.probe_local_server_id():
+        return f"{header}\n\nTwo options:\n{authorize}\n{web}"
+    return (
+        f"{header}\n\nThis Zotero build does not expose the local write API "
+        f"(that needs Zotero 10 or newer), so:\n"
+        f"{web.replace('  2.', '  -')}\n"
+        f"{authorize.replace('  1.', '  -')}"
+    )
+
+
+def resolve_write_client(ctx=None, *, op_description: str = "write operations"):
+    """Return (read_client, write_client, mode) for a mutating operation.
+
+    Resolution order: web mode uses the web client for both; local mode
+    prefers the local API once a key has been granted; otherwise it falls back
+    to web credentials (hybrid mode); otherwise it raises.
+
+    In local mode the same client is returned for reads and writes on purpose.
+    Local object versions are scoped to the Zotero database that issued them
+    and have no relation to web API versions, so reading from one backend and
+    writing to the other is precisely the mismatch that forces hybrid mode to
+    re-fetch every item before touching it.
+    """
     if not _utils.is_local_mode():
-        return read_zot, read_zot
+        zot = _client.get_zotero_client()
+        return zot, zot, "web"
+
+    local_write_zot = _client.get_local_write_client()
+    if local_write_zot is not None:
+        # No apply_library_override here, unlike the web client below: the
+        # factory already read the override, and it maps a user library to
+        # users/0 — the only id the local API serves. Re-applying the override
+        # would write that mapping back to whatever id the switch-library tool
+        # reported (the SQLite libraryID, typically 1) and every write would
+        # go to a library that does not exist locally.
+        return local_write_zot, local_write_zot, "local"
+
     web_zot = _client.get_web_zotero_client()
     if web_zot is not None:
         apply_library_override(web_zot, _client.get_active_library())
-        return read_zot, web_zot
-    raise ValueError(
-        "Cannot perform write operations in local-only mode. "
-        "Add ZOTERO_API_KEY and ZOTERO_LIBRARY_ID to enable hybrid mode."
+        return _client.get_zotero_client(), web_zot, "hybrid"
+
+    raise ValueError(write_unavailable_message(op_description))
+
+
+def _get_write_client(ctx):
+    """Return (read_client, write_client) for a mutating operation.
+
+    Thin wrapper kept for the write tools, which don't care which backend they
+    were handed. See resolve_write_client for the resolution order.
+    """
+    read_zot, write_zot, _mode = resolve_write_client(ctx)
+    return read_zot, write_zot
+
+
+# ---------------------------------------------------------------------------
+# Local/web write compatibility shims
+#
+# The local Zotero API does not implement /items/new, so item_template() (and
+# attachment_simple() / attachment_both(), which build on it) raise
+# CallDoesNotExistError against a local client. The helpers below take the web
+# path when it works and fall back to an equivalent local construction, so
+# call sites don't branch on which backend they got.
+# ---------------------------------------------------------------------------
+
+def _is_template_unavailable(exc: Exception) -> bool:
+    """True when *exc* is the local API's missing-/items/new failure."""
+    return isinstance(exc, CallDoesNotExistError) or "items/new" in str(exc)
+
+
+# Verbatim api.zotero.org/items/new responses. item_type_fields("attachment")
+# does not describe linkMode / contentType / charset, and note has no field
+# endpoint at all, so these two types are reproduced literally rather than
+# synthesized. Keeping them identical to the web response means the local and
+# web paths send the same payload.
+_ATTACHMENT_TEMPLATES: dict[str, dict] = {
+    "imported_file": {
+        "itemType": "attachment", "linkMode": "imported_file", "title": "",
+        "accessDate": "", "note": "", "tags": [], "collections": [],
+        "relations": {}, "contentType": "", "charset": "", "filename": "",
+        "md5": None, "mtime": None,
+    },
+    "imported_url": {
+        "itemType": "attachment", "linkMode": "imported_url", "title": "",
+        "accessDate": "", "url": "", "note": "", "tags": [], "collections": [],
+        "relations": {}, "contentType": "", "charset": "", "filename": "",
+        "md5": None, "mtime": None,
+    },
+    "linked_file": {
+        "itemType": "attachment", "linkMode": "linked_file", "title": "",
+        "accessDate": "", "note": "", "tags": [], "relations": {},
+        "contentType": "", "charset": "", "path": "",
+    },
+    "linked_url": {
+        "itemType": "attachment", "linkMode": "linked_url", "title": "",
+        "accessDate": "", "url": "", "note": "", "tags": [], "collections": [],
+        "relations": {}, "contentType": "", "charset": "",
+    },
+}
+
+_NOTE_TEMPLATE = {
+    "itemType": "note", "note": "", "tags": [], "collections": [], "relations": {},
+}
+
+# Synthesized templates are cached because item_type_fields() is a network
+# call taking an argument, so pyzotero's own template cache never covers it,
+# and the batch importers ask for one template per entry.
+_local_template_cache: dict[tuple, dict] = {}
+
+
+def _local_item_template(zot, item_type: str, link_mode: str | None = None) -> dict:
+    """Build an item template from endpoints the local API does implement."""
+    if item_type == "attachment":
+        template = _ATTACHMENT_TEMPLATES.get(link_mode or "imported_file")
+        if template is None:
+            raise ValueError(f"Unknown attachment link mode: {link_mode}")
+        return copy.deepcopy(template)
+    if item_type == "note":
+        return copy.deepcopy(_NOTE_TEMPLATE)
+
+    cache_key = (getattr(zot, "server_id", None) or zot.endpoint, item_type, link_mode)
+    if cache_key not in _local_template_cache:
+        fields = zot.item_type_fields(item_type)
+        template = {"itemType": item_type}
+        for entry in fields:
+            name = entry.get("field") if isinstance(entry, dict) else entry
+            if name:
+                template[name] = ""
+        # The web template lists creators/tags/collections/relations for every
+        # regular type; item_type_fields() covers none of them.
+        template["creators"] = []
+        template["tags"] = []
+        template["collections"] = []
+        template["relations"] = {}
+        _local_template_cache[cache_key] = template
+    return copy.deepcopy(_local_template_cache[cache_key])
+
+
+def item_template_for(zot, item_type: str, link_mode: str | None = None) -> dict:
+    """Return a new-item template, whichever backend *zot* talks to."""
+    try:
+        template = (
+            zot.item_template(item_type, linkmode=link_mode)
+            if link_mode
+            else zot.item_template(item_type)
+        )
+        return dict(template)
+    except Exception as exc:
+        if not _is_template_unavailable(exc):
+            raise
+        return _local_item_template(zot, item_type, link_mode)
+
+
+def attach_files(zot, pairs, parentid=None) -> dict:
+    """Attach files as child items. *pairs* is [(display_title, file_path)].
+
+    Mirrors ``attachment_both``'s signature and return value. Against a local
+    client that method is unavailable, so the attachment items are built here
+    and handed to ``upload_attachments``, which the local API does support.
+    Both routes end in the same ``Zupload.upload()``, so the returned
+    ``{"success": [...], "unchanged": [...], "failure": [...]}`` shape is the
+    same either way.
+    """
+    try:
+        return zot.attachment_both(pairs, parentid=parentid)
+    except Exception as exc:
+        if not _is_template_unavailable(exc):
+            raise
+        # Retrying is safe: attachment_both fetches the template before it
+        # creates anything, so this failure means nothing reached Zotero.
+        payload = []
+        for title, path in pairs:
+            attachment = copy.deepcopy(_ATTACHMENT_TEMPLATES["imported_file"])
+            attachment["title"] = title
+            # Zupload resolves filename against basedir to read the bytes, and
+            # strips it to a basename for the outgoing item, so a full path is
+            # what it wants here — the same thing attachment_both passes.
+            attachment["filename"] = os.path.abspath(path)
+            attachment["contentType"] = (
+                mimetypes.guess_type(path)[0] or "application/octet-stream"
+            )
+            payload.append(attachment)
+        return zot.upload_attachments(payload, parentid=parentid)
+
+
+def trash_item(zot, item) -> tuple[bool, str]:
+    """Move an item to the trash. Returns (succeeded, error detail).
+
+    pyzotero's delete_item() deletes permanently and update_item() strips the
+    ``deleted`` field, so the trash flag has to be PATCHed directly. Routing
+    through ``Zotero._write`` rather than ``zot.client.patch`` is what attaches
+    the Zotero-Server-ID and Zotero-API-Key headers a local write requires; the
+    fallback keeps older clients (and the test doubles that only provide
+    ``client.patch``) working. ``_write`` does no status checking of its own,
+    so failures are mapped here.
+    """
+    from pyzotero.zotero import build_url
+
+    key = item.get("key") or item.get("data", {}).get("key")
+    url = build_url(zot.endpoint, f"/{zot.library_type}/{zot.library_id}/items/{key}")
+    headers = {
+        "If-Unmodified-Since-Version": str(item["version"]),
+        # Required, not decorative: httpx does not infer a content type for a
+        # raw body, and the local API answers a PATCH that lacks one with
+        # "400 Empty request body". The web API tolerates its absence, which
+        # is why this went unnoticed for as long as writes were cloud-only.
+        "Content-Type": "application/json",
+    }
+    body = json.dumps({"deleted": 1})
+
+    writer = getattr(zot, "_write", None)
+    if callable(writer):
+        resp = writer("PATCH", url=url, headers=headers, content=body)
+    else:
+        resp = zot.client.patch(url=url, headers=headers, content=body)
+
+    if resp.status_code in (200, 204):
+        return True, ""
+    return False, describe_write_failure(resp, zot)
+
+
+# ---------------------------------------------------------------------------
+# Error messages
+#
+# The local API overloads 401/412/428, and pyzotero picks the specific
+# exception class by matching the response *body*, not the status. A local 401
+# whose body doesn't carry the expected phrase therefore arrives as a plain
+# UserNotAuthorisedError. Both helpers below key on the exception class OR the
+# status code together with the client being local, so an unmatched body still
+# produces the right advice.
+# ---------------------------------------------------------------------------
+
+_REAUTHORIZE = (
+    "Run `zotero-mcp authorize-local` (or call zotero_authorize_local_writes) "
+    "and choose \"Always Allow\"."
+)
+
+
+def _local_key_rejected_message() -> str:
+    """Explain a rejected local key, and stop it from blocking the fallback.
+
+    A 401 from the local API means the key is invalid, revoked, or consumed —
+    it will never work again. Dropping it here is what lets the next write
+    resolve somewhere useful: back to web credentials if the user has them,
+    instead of failing forever against a key we know is dead.
+    """
+    was_single_use = False
+    try:
+        # probe=False: this runs while formatting an error, and the answer
+        # doesn't depend on the capability probe. No network from here.
+        caps = _client.get_write_capabilities(probe=False)
+        was_single_use = caps.get("local_key_remember") is False
+        had_web_fallback = caps.get("has_web_credentials")
+        _client.clear_local_write_credentials()
+    except Exception:
+        had_web_fallback = False
+
+    detail = (
+        " That key was granted with \"Allow\", so it was only ever valid for one write."
+        if was_single_use
+        else ""
     )
+    recovery = (
+        " Web API credentials are configured, so the next write will use those; "
+        "re-authorize to go back to writing locally."
+        if had_web_fallback
+        else f" {_REAUTHORIZE}"
+    )
+    return (
+        "Zotero rejected the write: the local API key is missing, expired or "
+        "already used. A key granted with \"Allow\" rather than \"Always Allow\" "
+        "is single-use and is consumed by the first successful write."
+        + detail
+        + recovery
+    )
+
+
+def _server_id_mismatch_message() -> str:
+    # The key is bound to one Zotero database, so a mismatch means the stored
+    # one can never work again. Drop it rather than making the user guess.
+    try:
+        _client.clear_local_write_credentials()
+    except Exception:
+        pass
+    return (
+        "The stored local API key belongs to a different Zotero database "
+        "(a switched profile, or a restored backup). The stored credentials "
+        "have been cleared. " + _REAUTHORIZE
+    )
+
+
+def format_zotero_error(exc: Exception, zot=None) -> str:
+    """Turn a pyzotero exception into advice a user can act on."""
+    local = bool(getattr(zot, "local", False))
+    if isinstance(exc, LocalAPIKeyRequiredError):
+        return _local_key_rejected_message()
+    if isinstance(exc, LocalAPIDeniedError):
+        return (
+            "Zotero denied the local API authorization request. Re-run it and "
+            "choose \"Allow\" or \"Always Allow\" in the Zotero dialog."
+        )
+    if isinstance(exc, ServerIDMismatchError):
+        return _server_id_mismatch_message()
+    if isinstance(exc, ServerIDRequiredError):
+        return (
+            "Internal error: this write reached the local API without a "
+            "Zotero-Server-ID header. Please report it, naming the tool you "
+            f"called. ({exc})"
+        )
+    if isinstance(exc, TooManyRequestsError):
+        return (
+            "Zotero is rate-limiting requests (authorization prompts are "
+            f"capped at about 5 per minute). Wait a moment and retry. ({exc})"
+        )
+    if isinstance(exc, UnsupportedParamsError) and "Zotero-Server-ID" in str(exc):
+        return (
+            "This Zotero build does not expose the local write API — that "
+            "needs Zotero 10 or newer. Set ZOTERO_API_KEY and "
+            "ZOTERO_LIBRARY_ID to write through the web API instead."
+        )
+    if local and isinstance(exc, CallDoesNotExistError):
+        return (
+            "The local Zotero API does not implement this endpoint. Please "
+            f"report it, naming the tool you called. ({exc})"
+        )
+    return str(exc)
+
+
+def describe_write_failure(resp, zot=None) -> str:
+    """Describe a failed write response. Counterpart to format_zotero_error.
+
+    Needed because ``Zotero._write`` returns the raw response without raising:
+    pyzotero's status checking lives in the ``backoff_check`` decorator on the
+    public write methods, which this path deliberately bypasses.
+    """
+    status = getattr(resp, "status_code", None)
+    local = bool(getattr(zot, "local", False))
+    body = ""
+    try:
+        body = (resp.text or "")[:500]
+    except Exception:
+        pass
+
+    if local and status == 401:
+        return _local_key_rejected_message()
+    if local and status == 403:
+        return (
+            "Zotero refused the write (403). The local API may be disabled, or "
+            "authorization was denied. " + _REAUTHORIZE
+        )
+    if local and status == 412 and "Zotero-Server-ID" in body:
+        return _server_id_mismatch_message()
+    if status == 412:
+        return (
+            "The item changed in Zotero since it was read (412). Retry the "
+            "operation so it picks up the current version."
+        )
+    if local and status == 428:
+        return (
+            "Internal error: this write reached the local API without a "
+            "Zotero-Server-ID header (428). Please report it, naming the tool "
+            "you called."
+        )
+    if status == 429:
+        return "Zotero is rate-limiting requests (429). Wait a moment and retry."
+    return f"HTTP {status}: {body}"
 
 
 def _get_bibliography_client(ctx=None):
@@ -1223,6 +1619,11 @@ def _maybe_upload_to_webdav(attach_result, file_path, ctx, write_zot=None):
     Web API's file upload lands bytes in Zotero Storage, which a desktop
     client with File Syncing set to WebDAV never consults.
 
+    That reasoning is specific to the web API. An upload through the local API
+    hands the bytes to the running Zotero, which files them in its own storage
+    and syncs them to WebDAV itself, so pass ``write_zot`` and the workaround
+    steps aside.
+
     Returns ``""`` when WebDAV is not configured, when the attachment key
     cannot be extracted, or after a successful PUT with logging via ``ctx``
     (callers that don't surface the suffix can ignore the return value).
@@ -1232,6 +1633,9 @@ def _maybe_upload_to_webdav(attach_result, file_path, ctx, write_zot=None):
     branch.
     """
     from zotero_mcp import webdav as _webdav
+
+    if getattr(write_zot, "local", False):
+        return ""
 
     if not _webdav.is_webdav_configured():
         return ""
@@ -1312,10 +1716,17 @@ def _webdav_first_attach(write_zot, filename, file_path, parent_key, ctx, conten
     """
     from zotero_mcp import webdav as _webdav
 
+    # An upload through the local API hands the bytes to the running Zotero,
+    # which files them in its own storage and syncs them to WebDAV itself;
+    # the workaround below is a web-API-only concern. See
+    # ``_maybe_upload_to_webdav`` for the same reasoning on the other side.
+    if getattr(write_zot, "local", False):
+        return None
+
     if not _webdav.is_webdav_configured():
         return None
 
-    template = write_zot.item_template("attachment", linkmode="imported_file")
+    template = item_template_for(write_zot, "attachment", "imported_file")
     template["title"] = filename
     template["filename"] = filename
     template["parentItem"] = parent_key
@@ -1391,17 +1802,14 @@ def _describe_attach_failure(attach_result):
 def _assert_upload_capable(write_zot):
     """Raise ValueError if *write_zot* cannot upload file bytes.
 
-    Zotero's local HTTP API has no attachment/upload endpoints — the
-    template fetch that starts ``attachment_both()`` 404s against
-    ``localhost:23119`` (#403). Failing fast here beats a confusing
-    "No endpoint found" deep inside pyzotero.
+    An unauthorized local client cannot: writing to ``localhost:23119``
+    without a local API key fails deep inside pyzotero (#403), and failing
+    fast here beats a confusing "No endpoint found". A local client that
+    holds a key uploads fine on Zotero 10 — ``attach_files`` routes it past
+    the missing ``/items/new`` — so it is not rejected.
     """
-    if getattr(write_zot, "local", False):
-        raise ValueError(
-            "Cannot upload file bytes through Zotero's local API — it has no "
-            "attachment endpoints. Add ZOTERO_API_KEY and ZOTERO_LIBRARY_ID "
-            "to enable hybrid mode (local reads, web-API writes)."
-        )
+    if getattr(write_zot, "local", False) and not getattr(write_zot, "local_api_key", None):
+        raise ValueError(write_unavailable_message("file attachments"))
 
 
 def _two_step_attach(write_zot, filename, file_path, parent_key, ctx, content_type=None):
@@ -1415,7 +1823,7 @@ def _two_step_attach(write_zot, filename, file_path, parent_key, ctx, content_ty
     ``(None, reason)`` on failure, cleaning up the orphaned shell so a
     failed upload doesn't leave a fileless attachment behind.
     """
-    template = write_zot.item_template("attachment", linkmode="imported_file")
+    template = item_template_for(write_zot, "attachment", "imported_file")
     template["title"] = filename
     template["filename"] = filename
     template["parentItem"] = parent_key
@@ -1470,7 +1878,8 @@ def _attach_and_verify(
     """
     _assert_upload_capable(write_zot)
 
-    attach_result = write_zot.attachment_both(
+    attach_result = attach_files(
+        write_zot,
         [(filename, file_path)],
         parentid=parent_key,
     )
@@ -1481,7 +1890,7 @@ def _attach_and_verify(
         )
         return True, suffix, _extract_attachment_key(attach_result)
 
-    ctx.info(f"attachment_both failed ({reason}); retrying as create + upload")
+    ctx.info(f"attachment upload failed ({reason}); retrying as create + upload")
     attachment_key, fallback_reason = _two_step_attach(
         write_zot, filename, file_path, parent_key, ctx, content_type=content_type
     )
@@ -1544,7 +1953,7 @@ def _attachment_filename_exists(write_zot, parent_key, filename):
 def _attach_pdf_linked_url(write_zot, pdf_url, parent_key, ctx):
     """Create a linked-URL attachment (bookmarks the PDF URL without downloading)."""
     try:
-        template = write_zot.item_template("attachment", "linked_url")
+        template = item_template_for(write_zot, "attachment", "linked_url")
         template["url"] = pdf_url
         template["title"] = "PDF (linked URL)"
         template["contentType"] = "application/pdf"

--- a/src/zotero_mcp/tools/annotations.py
+++ b/src/zotero_mcp/tools/annotations.py
@@ -140,24 +140,66 @@ def _download_attachment_for_processing(
     )
 
 
+def _create_note_via_connector(item_key, parent_title, html_content, tags):
+    """Last-resort note creation through Zotero's connector endpoint.
+
+    Only reachable in local mode with no writable API backend: a Zotero older
+    than 10 (no local write endpoints) and no web credentials. The connector
+    ignores parentItem, so the note lands standalone — worth having, since the
+    alternative for those users is no note at all, but the caller must not
+    present it as a child note.
+
+    Returns a message on success, or None so the caller can fall back to its
+    own error.
+    """
+    if not _utils.is_local_mode():
+        return None
+    port = os.getenv("ZOTERO_LOCAL_PORT", "23119")
+    payload = {
+        "items": [
+            {
+                "itemType": "note",
+                "note": html_content,
+                "tags": list(tags or []),
+                "parentItem": item_key,
+            }
+        ],
+        "uri": "about:blank",
+    }
+    try:
+        resp = requests.post(
+            f"http://127.0.0.1:{port}/connector/saveItems",
+            headers={"Content-Type": "application/json"},
+            json=payload,
+            timeout=30,
+        )
+    except Exception:
+        return None
+    if resp.status_code != 201:
+        return None
+    return (
+        f"Note created for \"{parent_title}\" but it is a standalone note, not "
+        f"attached to the paper.\n\n"
+        "To create properly attached child notes, either run "
+        "`zotero-mcp authorize-local` (Zotero 10 or newer), or add these "
+        "environment variables alongside ZOTERO_LOCAL=true:\n"
+        + _WEB_API_ENV_VARS
+    )
+
+
 def _get_note_write_client(op_description: str):
     """Return (client, None) or (None, error_msg) for note-write operations.
 
-    Zotero's local API is read-only, so in local mode this falls back to the
-    web client and propagates any active library override.
+    Keeps the two-value contract its callers expect while delegating the
+    actual choice of backend to the one resolver every write goes through.
     """
-    if _utils.is_local_mode():
-        zot = _client.get_web_zotero_client()
-        if zot is None:
-            return None, (
-                f"Error: Web API credentials required for {op_description}.\n\n"
-                "Please configure the following environment variables:\n"
-                + _WEB_API_ENV_VARS
-            )
-        _helpers.apply_library_override(zot, _client.get_active_library())
-    else:
-        zot = _client.get_zotero_client()
-    return zot, None
+    try:
+        _read_zot, write_zot, _mode = _helpers.resolve_write_client(
+            op_description=op_description
+        )
+        return write_zot, None
+    except ValueError as e:
+        return None, f"Error: {e}"
 
 
 @mcp.tool(
@@ -602,7 +644,7 @@ def get_annotations(
 
     except Exception as e:
         ctx.error(f"Error fetching annotations: {str(e)}")
-        return f"Error fetching annotations: {str(e)}"
+        return f"Error fetching annotations: {_helpers.format_zotero_error(e)}"
 
 
 # Alias kept for backward compatibility (imported by server.py).
@@ -713,7 +755,7 @@ def get_notes(
 
     except Exception as e:
         ctx.error(f"Error fetching notes: {str(e)}")
-        return f"Error fetching notes: {str(e)}"
+        return f"Error fetching notes: {_helpers.format_zotero_error(e)}"
 
 
 # ---------------------------------------------------------------------------
@@ -1120,7 +1162,8 @@ def get_notes_tool(
         "delete: moves the note to the Trash — recoverable; emptying the "
         "Trash is manual in Zotero. Notes only, not items/collections/"
         "attachments. "
-        "Requires a writable library (web API key or hybrid mode). "
+        "Requires a writable library: local writes (Zotero 10+, via "
+        "zotero_authorize_local_writes) or a web API key. "
         "Example: (action='create', item_key='ABC12345', "
         "note_title='Reading notes', note_text='<p>Key claim ...</p>')."
     )
@@ -1242,74 +1285,28 @@ def create_note(
             "tags": [{"tag": tag} for tag in (tags or [])]
         }
 
-        # In local mode, the local API does not support POST to create items,
-        # and the connector/saveItems endpoint ignores parentItem (creating
-        # standalone notes instead of child notes). If an API key is available,
-        # use the web API which properly supports parentItem.
-        if _utils.is_local_mode():
-            web_zot = _client.get_web_zotero_client()
-            if web_zot is not None:
-                # Propagate library override if user switched libraries
-                _helpers.apply_library_override(web_zot, _client.get_active_library())
-                result = web_zot.create_items([note_data])
-                if "success" in result and result["success"]:
-                    successful = result["success"]
-                    if len(successful) > 0:
-                        note_key = next(iter(successful.values()))
-                        return f"Successfully created note for \"{parent_title}\"\n\nNote key: {note_key}"
-                    else:
-                        return f"Note creation response was successful but no key was returned: {result}"
-                else:
-                    return f"Failed to create note: {result.get('failed', 'Unknown error')}"
-            else:
-                # Fallback: connector endpoint (note will NOT be attached as child)
-                port = os.getenv("ZOTERO_LOCAL_PORT", "23119")
-                connector_url = f"http://127.0.0.1:{port}/connector/saveItems"
-                payload = {
-                    "items": [
-                        {
-                            "itemType": "note",
-                            "note": html_content,
-                            "tags": [tag for tag in (tags or [])],
-                            "parentItem": item_key,
-                        }
-                    ],
-                    "uri": "about:blank",
-                }
-                resp = requests.post(
-                    connector_url,
-                    headers={"Content-Type": "application/json"},
-                    json=payload,
-                    timeout=30,
-                )
-                if resp.status_code == 201:
-                    return (
-                        f"Note created for \"{parent_title}\" but it is a standalone note, not attached "
-                        f"to the paper.\n\n"
-                        "To create properly attached child notes, add these environment variables "
-                        "to your Claude Desktop config alongside ZOTERO_LOCAL=true:\n"
-                        + _WEB_API_ENV_VARS
-                    )
-                else:
-                    return f"Failed to create note via local connector (HTTP {resp.status_code}): {resp.text}"
-        else:
-            # Remote API: use pyzotero's create_items
-            result = zot.create_items([note_data])
+        write_zot, err = _get_note_write_client("creating notes")
+        if err:
+            # Nothing can write through the API. On a Zotero build without the
+            # local write endpoints and without web credentials, the connector
+            # is the only thing left — but it ignores parentItem, so the note
+            # arrives standalone. Say so rather than pretending it worked.
+            return _create_note_via_connector(
+                item_key, parent_title, html_content, tags
+            ) or err
 
-            # Check if creation was successful
-            if "success" in result and result["success"]:
-                successful = result["success"]
-                if len(successful) > 0:
-                    note_key = next(iter(successful.values()))
-                    return f"Successfully created note for \"{parent_title}\"\n\nNote key: {note_key}"
-                else:
-                    return f"Note creation response was successful but no key was returned: {result}"
-            else:
-                return f"Failed to create note: {result.get('failed', 'Unknown error')}"
+        result = write_zot.create_items([note_data])
+        if "success" in result and result["success"]:
+            successful = result["success"]
+            if len(successful) > 0:
+                note_key = next(iter(successful.values()))
+                return f"Successfully created note for \"{parent_title}\"\n\nNote key: {note_key}"
+            return f"Note creation response was successful but no key was returned: {result}"
+        return f"Failed to create note: {result.get('failed', 'Unknown error')}"
 
     except Exception as e:
         ctx.error(f"Error creating note: {str(e)}")
-        return f"Error creating note: {str(e)}"
+        return f"Error creating note: {_helpers.format_zotero_error(e)}"
 
 
 def update_note(
@@ -1360,7 +1357,7 @@ def update_note(
 
     except Exception as e:
         ctx.error(f"Error updating note: {str(e)}")
-        return f"Error updating note: {str(e)}"
+        return f"Error updating note: {_helpers.format_zotero_error(e)}"
 
 
 def delete_note(
@@ -1395,25 +1392,16 @@ def delete_note(
             return f"Error: Item {item_key} is not a note (itemType={data.get('itemType')})"
 
         # pyzotero's delete_item() permanently destroys items, and update_item()
-        # strips the "deleted" field. We send a direct PATCH with {"deleted": 1}
-        # to move the note to Zotero's Trash (recoverable by the user).
-        from pyzotero.zotero import build_url
-        url = build_url(
-            zot.endpoint,
-            f"/{zot.library_type}/{zot.library_id}/items/{item_key}",
-        )
-        resp = zot.client.patch(
-            url=url,
-            headers={"If-Unmodified-Since-Version": str(item["version"])},
-            content=json.dumps({"deleted": 1}),
-        )
-        if resp.status_code in (200, 204):
+        # strips the "deleted" field, so trashing is a direct PATCH with
+        # {"deleted": 1} — recoverable by the user.
+        ok, detail = _helpers.trash_item(zot, item)
+        if ok:
             return f"Successfully trashed note {item_key} (recoverable from Zotero's Trash)"
-        return f"Failed to trash note {item_key} (HTTP {resp.status_code}): {resp.text[:200]}"
+        return f"Failed to trash note {item_key}: {detail}"
 
     except Exception as e:
         ctx.error(f"Error trashing note: {str(e)}")
-        return f"Error trashing note: {str(e)}"
+        return f"Error trashing note: {_helpers.format_zotero_error(e)}"
 
 
 @mcp.tool(
@@ -1433,8 +1421,8 @@ def delete_note(
         "must fit the page. Call zotero_get_page_layout first and reuse a "
         "detected region's bbox instead of guessing coordinates. "
         "comment, color (hex, default '#ffd400'), tags: optional. "
-        "Requires PyMuPDF (the [pdf] extra) and a writable library (web "
-        "API key or hybrid mode). "
+        "Requires PyMuPDF (the [pdf] extra) and a writable library: "
+        "local writes (Zotero 10+) or a web API key. "
         "Examples: (attachment_key='NHZFE5A7', page=4, text='working "
         "memory'); (attachment_key='NHZFE5A7', page=7, rect=[0.15, 0.22, "
         "0.6, 0.35], comment='Figure 3')."
@@ -1552,26 +1540,17 @@ def _create_highlight_annotation(
     try:
         ctx.info(f"Creating annotation on attachment {attachment_key}, page {page}")
 
-        # Get clients for different operations
+        # Two different jobs here: somewhere to write the annotation, and
+        # somewhere to fetch the attachment's bytes from. They are not always
+        # the same backend, so resolve them separately.
+        metadata_client, err = _get_note_write_client("creating annotations")
+        if err:
+            return err
+
         local_client = _client.get_local_zotero_client()
         web_client = _client.get_web_zotero_client()
-
-        # Propagate library override if user switched libraries
         if web_client:
             _helpers.apply_library_override(web_client, _client.get_active_library())
-
-        # REQUIREMENT: Web API is required for creating annotations
-        # Zotero's local API (port 23119) is read-only
-        if not web_client:
-            return (
-                "Error: Web API credentials required for creating annotations.\n\n"
-                "Please configure the following environment variables:\n"
-                + _WEB_API_ENV_VARS
-                + "\n\nNote: Zotero's local API is read-only and cannot create annotations."
-            )
-
-        # Use web client for metadata (it has the credentials)
-        metadata_client = web_client
 
         # Verify the attachment exists and is a PDF
         try:
@@ -1727,10 +1706,9 @@ def _create_highlight_annotation(
             if page_label:
                 annotation_data["annotationPageLabel"] = page_label
 
-            ctx.info(f"Creating annotation via Web API...")
+            ctx.info("Creating annotation...")
 
-            # Create the annotation using web client
-            result = web_client.create_items([annotation_data])
+            result = metadata_client.create_items([annotation_data])
 
             # Check if creation was successful
             if "success" in result and result["success"]:
@@ -1765,7 +1743,7 @@ def _create_highlight_annotation(
 
     except Exception as e:
         ctx.error(f"Error creating annotation: {str(e)}")
-        return f"Error creating annotation: {str(e)}"
+        return f"Error creating annotation: {_helpers.format_zotero_error(e)}"
 
 
 def create_area_annotation(
@@ -1828,24 +1806,17 @@ def create_area_annotation(
         if y + height > 1:
             return "Error: Rectangle must fit within the page height (y + height must be <= 1)"
 
+        write_client, err = _get_note_write_client("creating annotations")
+        if err:
+            return err
+
         local_client = _client.get_local_zotero_client()
         web_client = _client.get_web_zotero_client()
-
         if web_client:
             _helpers.apply_library_override(web_client, _client.get_active_library())
 
-        if not web_client:
-            return (
-                "Error: Web API credentials required for creating annotations.\n\n"
-                "Please configure the following environment variables:\n"
-                "- ZOTERO_API_KEY: Your Zotero API key (from zotero.org/settings/keys)\n"
-                "- ZOTERO_LIBRARY_ID: Your library ID\n"
-                "- ZOTERO_LIBRARY_TYPE: 'user' or 'group'\n\n"
-                "Note: Zotero's local API is read-only and cannot create annotations."
-            )
-
         try:
-            attachment = web_client.item(attachment_key)
+            attachment = write_client.item(attachment_key)
             attachment_data = attachment.get("data", {})
 
             if attachment_data.get("itemType") != "attachment":
@@ -1902,7 +1873,7 @@ def create_area_annotation(
             }
 
             ctx.info("Creating area annotation via Web API...")
-            result = web_client.create_items([annotation_data])
+            result = write_client.create_items([annotation_data])
 
             if "success" in result and result["success"]:
                 successful = result["success"]
@@ -1926,7 +1897,7 @@ def create_area_annotation(
 
     except Exception as e:
         ctx.error(f"Error creating area annotation: {str(e)}")
-        return f"Error creating area annotation: {str(e)}"
+        return f"Error creating area annotation: {_helpers.format_zotero_error(e)}"
 
 
 def _format_page_layout(
@@ -2093,7 +2064,7 @@ def get_page_layout(
 
     except Exception as e:
         ctx.error(f"Error detecting page layout: {str(e)}")
-        return f"Error detecting page layout: {str(e)}"
+        return f"Error detecting page layout: {_helpers.format_zotero_error(e)}"
 
 
 @mcp.tool(
@@ -2186,7 +2157,7 @@ def update_annotation(
         return f"Input error: {e}"
     except Exception as e:
         ctx.error(f"Error updating annotation: {e}")
-        return f"Error updating annotation: {e}"
+        return f"Error updating annotation: {_helpers.format_zotero_error(e)}"
 
 
 @mcp.tool(
@@ -2220,26 +2191,14 @@ def delete_annotation(
                 f"(itemType={data.get('itemType')})"
             )
 
-        from pyzotero.zotero import build_url
-        url = build_url(
-            zot.endpoint,
-            f"/{zot.library_type}/{zot.library_id}/items/{annotation_key}",
-        )
-        resp = zot.client.patch(
-            url=url,
-            headers={"If-Unmodified-Since-Version": str(item["version"])},
-            content=json.dumps({"deleted": 1}),
-        )
-        if resp.status_code in (200, 204):
+        ok, detail = _helpers.trash_item(zot, item)
+        if ok:
             return (
                 f"Successfully trashed annotation {annotation_key} "
                 "(recoverable from Zotero's Trash)"
             )
-        return (
-            f"Failed to trash annotation {annotation_key} "
-            f"(HTTP {resp.status_code}): {resp.text[:200]}"
-        )
+        return f"Failed to trash annotation {annotation_key}: {detail}"
 
     except Exception as e:
         ctx.error(f"Error trashing annotation: {str(e)}")
-        return f"Error trashing annotation: {str(e)}"
+        return f"Error trashing annotation: {_helpers.format_zotero_error(e)}"

--- a/src/zotero_mcp/tools/local_auth.py
+++ b/src/zotero_mcp/tools/local_auth.py
@@ -1,0 +1,197 @@
+"""Local API write authorization tools.
+
+Writing through Zotero's local API needs a key the user grants in a dialog in
+the Zotero app. These two tools let an agent obtain that key and check whether
+it already has one, instead of guessing why a write was refused.
+"""
+
+import httpx
+from pyzotero.errors import (
+    LocalAPIDeniedError,
+    ParamNotPassedError,
+    TooManyRequestsError,
+    UnsupportedParamsError,
+)
+
+from zotero_mcp import client as _client
+from zotero_mcp import utils as _utils
+from zotero_mcp._app import mcp
+from zotero_mcp._context import Context
+
+# Under FastMCP's ~60s client timeout: past that the transport gives up and
+# the user gets an opaque failure instead of "you didn't answer the dialog".
+_MIN_TIMEOUT = 5
+_MAX_TIMEOUT = 55
+
+
+@mcp.tool(
+    name="zotero_authorize_local_writes",
+    description=(
+        "Request permission to write to the local Zotero library (Zotero 10+). "
+        "BLOCKS until the user answers a dialog that appears in the Zotero "
+        "app, so tell them to switch to Zotero before calling this. "
+        "\"Always Allow\" grants a reusable key that is saved for future "
+        "sessions; \"Allow\" grants a key good for exactly ONE write. "
+        "Call this when a write tool reports that no writable backend is "
+        "configured and zotero_write_capabilities says the server supports "
+        "local writes but no key is held. Not needed in web API mode. "
+        "app_name: the name shown to the user in the dialog. "
+        "timeout: seconds to wait for the answer (5-55, default 45). "
+        "Zotero rate-limits this to about 5 prompts per minute — do not retry "
+        "in a loop. Example: zotero_authorize_local_writes()."
+    )
+)
+def authorize_local_writes(
+    app_name: str = _client.DEFAULT_APP_NAME,
+    timeout: int = 45,
+    *,
+    ctx: Context
+) -> str:
+    """Obtain a local API key, prompting the user in the Zotero app.
+
+    Deliberately NOT wrapped in @with_zotero_api_lock, unlike every other
+    write-adjacent tool here. This call blocks on a human decision; holding
+    the shared API lock for that long would push every concurrent tool past
+    its bounded acquire and turn one dialog into a wave of "Zotero is busy"
+    errors. The narrower hazard — two dialogs at once — is covered by the
+    dedicated lock inside client.authorize_local_api.
+    """
+    if not _utils.is_local_mode():
+        return (
+            "Local writes do not apply here: the server is not in local mode "
+            "(ZOTERO_LOCAL is not set). Writes already go through the web API."
+        )
+
+    timeout = max(_MIN_TIMEOUT, min(_MAX_TIMEOUT, int(timeout)))
+
+    try:
+        ctx.info(f"Requesting local API authorization as {app_name!r}")
+        result = _client.authorize_local_api(app_name=app_name, timeout=timeout)
+    except _client.ZoteroAuthInProgressError as e:
+        return f"Error: {e}"
+    except LocalAPIDeniedError:
+        return (
+            "Authorization denied — the request was declined in Zotero. "
+            "Call this tool again and choose \"Allow\" or \"Always Allow\"."
+        )
+    except TooManyRequestsError:
+        return (
+            "Zotero is rate-limiting authorization prompts (about 5 per "
+            "minute). Wait a minute before trying again."
+        )
+    except UnsupportedParamsError:
+        return (
+            "This Zotero build does not expose the local write API, which "
+            "needs Zotero 10 or newer. Set ZOTERO_API_KEY and "
+            "ZOTERO_LIBRARY_ID to write through the web API instead."
+        )
+    except ParamNotPassedError:
+        return "Error: app_name cannot be empty — it identifies this app in the dialog."
+    except httpx.TimeoutException:
+        return (
+            f"No answer within {timeout}s. The dialog is probably still open "
+            "in Zotero — answer it there, then call this tool again. It will "
+            "not open a second dialog while the first is pending."
+        )
+    except Exception as e:
+        ctx.error(f"Local authorization failed: {e}")
+        return f"Error requesting local API authorization: {e}"
+
+    if result.get("remember"):
+        return (
+            "Local write access granted and saved.\n\n"
+            "Writes now go straight to the running Zotero instead of the "
+            "cloud. The key was stored in ~/.config/zotero-mcp/config.json "
+            "and will be reused in future sessions. Revoke it with "
+            "`zotero-mcp authorize-local --revoke`, or from Zotero's "
+            "Settings > Advanced > Clear Write Authorizations."
+        )
+    return (
+        "Local write access granted for a SINGLE write.\n\n"
+        "\"Allow\" was chosen rather than \"Always Allow\", so this key is "
+        "consumed by the next successful write and the one after that will "
+        "fail. It has deliberately not been saved to disk, because a consumed "
+        "key there would take priority over working web credentials on every "
+        "later run. Ask the user to call this tool again and choose "
+        "\"Always Allow\" for a key that persists."
+    )
+
+
+@mcp.tool(
+    name="zotero_write_capabilities",
+    description=(
+        "Report whether and how this server can write to Zotero: local API, "
+        "web API, hybrid (local reads + cloud writes), or nothing. Read-only "
+        "and instant — it never opens a dialog. Call it when a write tool "
+        "reports that no writable backend is configured, to find out which "
+        "fix applies before asking the user for anything: if the local "
+        "server supports writes but no key is held, call "
+        "zotero_authorize_local_writes; otherwise web API credentials are "
+        "needed. Takes no arguments. Example: zotero_write_capabilities()."
+    )
+)
+def write_capabilities(*, ctx: Context) -> str:
+    """Describe the currently available write path."""
+    caps = _client.get_write_capabilities()
+
+    modes = {
+        "local": "Local API — writes go directly to the running Zotero.",
+        "hybrid": "Hybrid — local reads, writes through the Zotero web API.",
+        "web": "Web API — reads and writes both go through zotero.org.",
+        "none": "None — writes are not possible with the current configuration.",
+    }
+    lines = [
+        "# Zotero write capabilities",
+        "",
+        f"**Mode:** {caps['mode']} — {modes[caps['mode']]}",
+        "",
+        f"- Local mode (ZOTERO_LOCAL): {'yes' if caps['local_mode'] else 'no'}",
+    ]
+
+    if caps["local_mode"]:
+        supported = caps["server_supports_local_writes"]
+        lines.append(
+            f"- Running Zotero supports local writes: "
+            f"{'yes' if supported else 'no (needs Zotero 10 or newer)'}"
+        )
+        if caps["has_local_key"]:
+            remember = caps["local_key_remember"]
+            validity = {
+                True: "reusable",
+                False: "SINGLE USE — consumed by the next write",
+                None: "validity unknown",
+            }[remember]
+            lines.append(
+                f"- Local API key: held, from {caps['local_key_source']} ({validity})"
+            )
+        else:
+            lines.append("- Local API key: none")
+        if not caps["local_write_enabled"]:
+            lines.append("- Local writes are switched off by ZOTERO_LOCAL_WRITE")
+
+    lines.append(
+        f"- Web API credentials: {'set' if caps['has_web_credentials'] else 'not set'}"
+    )
+
+    if caps["mode"] == "none":
+        lines += ["", "**To enable writes:**"]
+        if caps["server_supports_local_writes"]:
+            lines += [
+                "1. Call zotero_authorize_local_writes and have the user "
+                "choose \"Always Allow\" in Zotero.",
+                "2. Or set ZOTERO_API_KEY and ZOTERO_LIBRARY_ID for web API writes.",
+            ]
+        else:
+            lines.append(
+                "- Set ZOTERO_API_KEY and ZOTERO_LIBRARY_ID for web API writes "
+                "(this Zotero has no local write API)."
+            )
+    elif caps["mode"] == "hybrid" and caps["server_supports_local_writes"]:
+        lines += [
+            "",
+            "This Zotero supports local writes. Calling "
+            "zotero_authorize_local_writes would keep writes off the cloud "
+            "round-trip.",
+        ]
+
+    return "\n".join(lines)

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import difflib
+import functools
 import hashlib
 import json
 import os
@@ -446,11 +447,14 @@ def batch_update_tags(
             return "Error: After parsing, no valid tags were provided to add or remove"
 
         ctx.info(f"Batch updating tags for items matching '{query}'")
-        zot = _client.get_zotero_client()
 
-        # Use shared hybrid-mode helper for correct library override propagation
+        # One resolution for both roles. Taking the read client from here
+        # rather than building a separate one is what makes the
+        # `write_zot is not zot` check below mean "the backends differ" —
+        # otherwise it is always true and every item pays for a re-fetch it
+        # doesn't need.
         try:
-            _, write_zot = _helpers._get_write_client(ctx)
+            zot, write_zot = _helpers._get_write_client(ctx)
         except ValueError as e:
             return str(e)
 
@@ -538,8 +542,9 @@ def batch_update_tags(
                 try:
                     item_key = item.get("key", "unknown")
 
-                    # If writing via web API, re-fetch the item from web to get
-                    # the correct version number for the update
+                    # When reads and writes go to different backends, the
+                    # version numbers are unrelated — re-fetch from the write
+                    # side so the update carries a version it recognizes.
                     if write_zot is not zot:
                         def _set_tags(it):
                             it["data"]["tags"] = current_tags
@@ -591,7 +596,7 @@ def batch_update_tags(
 
     except Exception as e:
         ctx.error(f"Error in batch tag update: {str(e)}")
-        return f"Error in batch tag update: {str(e)}"
+        return f"Error in batch tag update: {_helpers.format_zotero_error(e)}"
 
 
 def _apply_extra_edits(
@@ -906,7 +911,7 @@ def create_collection(
                 keys = _helpers._resolve_collection_names(read_zot, [parent_collection], ctx=ctx)
                 parent_key = keys[0] if keys else None
             except ValueError as e:
-                return f"Error resolving parent collection: {e}"
+                return f"Error resolving parent collection: {_helpers.format_zotero_error(e)}"
 
         coll_data = {"name": name}
         if parent_key:
@@ -927,7 +932,7 @@ def create_collection(
 
     except Exception as e:
         ctx.error(f"Error creating collection: {e}")
-        return f"Error creating collection: {e}"
+        return f"Error creating collection: {_helpers.format_zotero_error(e)}"
 
 
 @mcp.tool(
@@ -969,7 +974,7 @@ def delete_collection(
 
     except Exception as e:
         ctx.error(f"Error deleting collection: {e}")
-        return f"Error deleting collection: {e}"
+        return f"Error deleting collection: {_helpers.format_zotero_error(e)}"
 
 
 @mcp.tool(
@@ -1048,7 +1053,7 @@ def search_collections(
 
     except Exception as e:
         ctx.error(f"Error searching collections: {e}")
-        return f"Error searching collections: {e}"
+        return f"Error searching collections: {_helpers.format_zotero_error(e)}"
 
 
 @mcp.tool(
@@ -1141,7 +1146,7 @@ def manage_collections(
         return f"Input error: {e}"
     except Exception as e:
         ctx.error(f"Error managing collections: {e}")
-        return f"Error managing collections: {e}"
+        return f"Error managing collections: {_helpers.format_zotero_error(e)}"
 
 
 # Source-specific add implementations. These are no longer registered as
@@ -1278,7 +1283,7 @@ def _memoized_item_template_fn(write_zot):
     def template_fn(zot_type: str) -> dict:
         if zot_type not in cache:
             with zotero_api_lock():
-                cache[zot_type] = write_zot.item_template(zot_type)
+                cache[zot_type] = _helpers.item_template_for(write_zot, zot_type)
         return cache[zot_type]
 
     return template_fn
@@ -1395,7 +1400,7 @@ def _dedup_check_one_doi(read_zot, write_zot, doi, coll_keys, tags, if_exists, c
 
     except Exception as e:
         ctx.error(f"Error adding by DOI: {e}")
-        return ("final", f"Error adding by DOI: {e}")
+        return ("final", f"Error adding by DOI: {_helpers.format_zotero_error(e)}")
 
 
 def _fetch_one_doi_metadata(normalized: str, ctx) -> tuple[str, dict | str]:
@@ -1425,7 +1430,7 @@ def _fetch_one_doi_metadata(normalized: str, ctx) -> tuple[str, dict | str]:
     except requests.RequestException as e:
         return ("final", f"Error fetching from CrossRef: {e}")
     except Exception as e:
-        return ("final", f"Error adding by DOI: {e}")
+        return ("final", f"Error adding by DOI: {_helpers.format_zotero_error(e)}")
 
 
 def _fetch_doi_metadata_batch(normalized_dois: list[str], ctx) -> dict[str, tuple[str, dict | str]]:
@@ -1740,7 +1745,7 @@ def add_by_doi(
 
     except Exception as e:
         ctx.error(f"Error adding by DOI: {e}")
-        return f"Error adding by DOI: {e}"
+        return f"Error adding by DOI: {_helpers.format_zotero_error(e)}"
 
 
 # CrossRef types that describe a *container* rather than a work. A DOI
@@ -1859,7 +1864,7 @@ def _add_from_embedded_metadata(
     else:
         zot_type = "webpage"
 
-    template = dict(write_zot.item_template(zot_type))
+    template = dict(_helpers.item_template_for(write_zot, zot_type))
     _set = _citation_import._set_if_in_template
 
     _set(template, "title", meta.title or url)
@@ -2051,7 +2056,7 @@ def add_by_url(
                     )
 
             ctx.info(f"Creating webpage item for: {url}")
-            template = write_zot.item_template("webpage")
+            template = _helpers.item_template_for(write_zot, "webpage")
             template["url"] = url
             template["title"] = url
             template["accessDate"] = ""
@@ -2088,7 +2093,7 @@ def add_by_url(
 
     except Exception as e:
         ctx.error(f"Error adding by URL: {e}")
-        return f"Error adding by URL: {e}"
+        return f"Error adding by URL: {_helpers.format_zotero_error(e)}"
 
 
 def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto",
@@ -2251,7 +2256,7 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
                     matched_by=f"arXiv ID {arxiv_id}", ctx=ctx,
                 )
 
-        template = write_zot.item_template("preprint")
+        template = _helpers.item_template_for(write_zot, "preprint")
         template["title"] = title
         if authors:
             template["creators"] = authors
@@ -2567,7 +2572,7 @@ def add_by_isbn(
             )
 
         # Build Zotero book item
-        template = write_zot.item_template("book")
+        template = _helpers.item_template_for(write_zot, "book")
         item_data = dict(template)
         if meta.get("title"):
             item_data["title"] = meta["title"]
@@ -2630,7 +2635,7 @@ def add_by_isbn(
 
     except Exception as e:
         ctx.error(f"Error adding by ISBN: {e}")
-        return f"Error adding by ISBN: {e}"
+        return f"Error adding by ISBN: {_helpers.format_zotero_error(e)}"
 
 
 # Maps Zotero API field names to tool parameter names for user-facing messages
@@ -2875,7 +2880,7 @@ def update_item(
             old_item_type = data.get("itemType", "")
             if old_item_type != item_type:
                 try:
-                    new_template = write_zot.item_template(item_type)
+                    new_template = _helpers.item_template_for(write_zot, item_type)
                 except Exception as e:
                     return f"Error: invalid item_type '{item_type}': {e}"
 
@@ -3029,7 +3034,7 @@ def update_item(
         return f"Input error: {e}"
     except Exception as e:
         ctx.error(f"Error updating item: {e}")
-        return f"Error updating item: {e}"
+        return f"Error updating item: {_helpers.format_zotero_error(e)}"
 
 
 @mcp.tool(
@@ -3085,31 +3090,19 @@ def delete_item(
             )
 
         # pyzotero's delete_item() permanently destroys items, and update_item()
-        # strips the "deleted" field. Send a direct PATCH with {"deleted": 1}
-        # to move the item to Zotero's Trash (recoverable by the user).
-        from pyzotero.zotero import build_url
-        url = build_url(
-            write_zot.endpoint,
-            f"/{write_zot.library_type}/{write_zot.library_id}/items/{item_key}",
-        )
-        resp = write_zot.client.patch(
-            url=url,
-            headers={"If-Unmodified-Since-Version": str(item["version"])},
-            content=json.dumps({"deleted": 1}),
-        )
-        if resp.status_code in (200, 204):
+        # strips the "deleted" field, so trashing is a direct PATCH with
+        # {"deleted": 1} — recoverable by the user.
+        ok, detail = _helpers.trash_item(write_zot, item)
+        if ok:
             return (
                 f"Successfully trashed item {item_key} "
                 f"(type={item_type}, recoverable from Zotero's Trash)"
             )
-        return (
-            f"Failed to trash item {item_key} (HTTP {resp.status_code}): "
-            f"{resp.text[:200]}"
-        )
+        return f"Failed to trash item {item_key}: {detail}"
 
     except Exception as e:
         ctx.error(f"Error trashing item: {str(e)}")
-        return f"Error trashing item: {str(e)}"
+        return f"Error trashing item: {_helpers.format_zotero_error(e)}"
 
 
 # ---------------------------------------------------------------------------
@@ -3313,7 +3306,7 @@ def find_duplicates(
         return f"Input error: {e}"
     except Exception as e:
         ctx.error(f"Error finding duplicates: {e}")
-        return f"Error finding duplicates: {e}"
+        return f"Error finding duplicates: {_helpers.format_zotero_error(e)}"
 
 
 # ---------------------------------------------------------------------------
@@ -3447,24 +3440,12 @@ def _merge_plan(write_zot, keeper_key: str, dup_keys: list[str]) -> dict:
 def _trash_item(write_zot, item_key: str) -> tuple[bool, str]:
     """Move one item to Zotero's Trash (recoverable), not a permanent delete.
 
-    pyzotero's update_item() strips "deleted" and delete_item() destroys the
-    item, so this is a direct version-conditioned PATCH of {"deleted": 1}.
+    Thin key-taking wrapper over ``_helpers.trash_item``, which owns the
+    version-conditioned PATCH and routes it through pyzotero's write
+    dispatcher — the local API rejects a PATCH sent any other way.
     """
     try:
-        item = write_zot.item(item_key)
-        from pyzotero.zotero import build_url
-        url = build_url(
-            write_zot.endpoint,
-            f"/{write_zot.library_type}/{write_zot.library_id}/items/{item_key}",
-        )
-        resp = write_zot.client.patch(
-            url=url,
-            headers={"If-Unmodified-Since-Version": str(item["version"])},
-            content=json.dumps({"deleted": 1}),
-        )
-        if resp.status_code in (200, 204):
-            return True, ""
-        return False, f"HTTP {resp.status_code}"
+        return _helpers.trash_item(write_zot, write_zot.item(item_key))
     except Exception as e:
         return False, str(e)
 
@@ -3719,7 +3700,8 @@ def _render_auto_plan(qualifying, skipped, clipped, token, method, max_groups) -
         "AUTO NEEDS TWO CALLS: auto=True alone returns a plan plus a "
         "plan_token; executing needs confirm=True AND that token. "
         "confirm=True alone is refused, as is a stale token. "
-        "Needs a writable library (web API key/hybrid); fails local-only. "
+        "Needs a writable library: local writes (Zotero 10+) or a web "
+        "API key. "
         "Example: zotero_merge_duplicates(keeper_key='ABC12345', "
         "duplicate_keys=['XYZ98765']), then again with confirm=True. "
         "Auto: zotero_merge_duplicates(auto=True), then the same plus "
@@ -3818,7 +3800,7 @@ def merge_duplicates(
         return f"Input error: {e}"
     except Exception as e:
         ctx.error(f"Error merging duplicates: {e}")
-        return f"Error merging duplicates: {e}"
+        return f"Error merging duplicates: {_helpers.format_zotero_error(e)}"
 
 
 def _merge_duplicates_auto(
@@ -4267,7 +4249,7 @@ def get_pdf_outline(
         raise
     except Exception as e:
         ctx.error(f"Error extracting PDF outline: {e}")
-        return f"Error extracting PDF outline: {e}"
+        return f"Error extracting PDF outline: {_helpers.format_zotero_error(e)}"
 
 
 @with_zotero_api_lock
@@ -4360,7 +4342,7 @@ def add_from_file(
                 return f"DOI lookup succeeded but couldn't extract item key.\n\n{result_msg}"
         else:
             # Create a basic item
-            template = write_zot.item_template(item_type)
+            template = _helpers.item_template_for(write_zot, item_type)
             template["title"] = title or os.path.basename(file_path)
 
             tag_list = _helpers._normalize_str_list_input(tags, "tags")
@@ -4436,7 +4418,7 @@ def add_from_file(
 
     except Exception as e:
         ctx.error(f"Error adding from file: {e}")
-        return f"Error adding from file: {e}"
+        return f"Error adding from file: {_helpers.format_zotero_error(e)}"
 
 
 def _upload_attachment(write_zot, item_key, display_name, filepath, ctx):
@@ -4804,7 +4786,7 @@ def add_item_relation(
 
     except Exception as e:
         ctx.error(f"Error adding item relation: {e}")
-        return f"Error adding item relation: {e}"
+        return f"Error adding item relation: {_helpers.format_zotero_error(e)}"
 
 
 @mcp.tool(
@@ -4916,7 +4898,7 @@ def remove_item_relation(
 
     except Exception as e:
         ctx.error(f"Error removing item relation: {e}")
-        return f"Error removing item relation: {e}"
+        return f"Error removing item relation: {_helpers.format_zotero_error(e)}"
 
 
 # ---------------------------------------------------------------------------
@@ -5252,7 +5234,7 @@ def add_by_bibtex(
         try:
             entries = _citation_import.parse_bibtex(bibtex)
         except Exception as e:
-            return f"Error parsing BibTeX: {e}"
+            return f"Error parsing BibTeX: {_helpers.format_zotero_error(e)}"
 
         if not entries:
             return "Error: No valid @entries found in the BibTeX input."
@@ -5276,7 +5258,7 @@ def add_by_bibtex(
         for entry in entries:
             try:
                 item_data = _citation_import.bibtex_entry_to_zotero(
-                    entry, write_zot.item_template
+                    entry, functools.partial(_helpers.item_template_for, write_zot)
                 )
             except Exception as e:
                 results.append({
@@ -5308,7 +5290,7 @@ def add_by_bibtex(
 
     except Exception as e:
         ctx.error(f"Error adding by BibTeX: {e}")
-        return f"Error adding by BibTeX: {e}"
+        return f"Error adding by BibTeX: {_helpers.format_zotero_error(e)}"
 
 
 def add_by_csl_json(
@@ -5372,7 +5354,7 @@ def add_by_csl_json(
         for entry in entries:
             try:
                 item_data = _citation_import.csl_json_to_zotero(
-                    entry, write_zot.item_template
+                    entry, functools.partial(_helpers.item_template_for, write_zot)
                 )
             except Exception as e:
                 results.append({
@@ -5404,7 +5386,7 @@ def add_by_csl_json(
 
     except Exception as e:
         ctx.error(f"Error adding by CSL JSON: {e}")
-        return f"Error adding by CSL JSON: {e}"
+        return f"Error adding by CSL JSON: {_helpers.format_zotero_error(e)}"
 
 
 # ---------------------------------------------------------------------------
@@ -5469,9 +5451,16 @@ def _looks_like_url(s: str) -> bool:
 
 
 def _looks_like_path(s: str) -> bool:
-    """True when *s* has the shape of a filesystem path (POSIX or Windows)."""
+    """True when *s* has the shape of a filesystem path (POSIX or Windows).
+
+    The leading-slash test is explicit rather than left to ``os.path.isabs``:
+    since Python 3.13 ``ntpath.isabs`` calls "/Users/me/paper.pdf" relative,
+    so on Windows a POSIX path would fall through to the "could not tell what
+    kind of source this is" error instead of being recognised as a file.
+    """
     return (
-        os.path.isabs(s)
+        s.startswith("/")
+        or os.path.isabs(s)
         or bool(re.match(r"^[A-Za-z]:[\\/]", s))
         or s.startswith(("~", "./", "../", ".\\", "..\\"))
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from pyzotero.errors import CallDoesNotExistError
 
 # Always exercise the source tree that these tests live in, not whatever
 # `zotero_mcp` an editable install happens to resolve to. Without this, running
@@ -33,6 +34,36 @@ skip_on_windows = pytest.mark.skipif(
 )
 
 
+@pytest.fixture(autouse=True)
+def isolate_local_write_state(monkeypatch, tmp_path):
+    """Keep local-write config and capability probing out of the tests.
+
+    Two things would otherwise leak the developer's machine into the results:
+    the local API key is read from ~/.config/zotero-mcp/config.json, so anyone
+    who has authorized local writes would resolve a different write client
+    than CI does; and the capability probe makes a real request to
+    localhost:23119, so the outcome would depend on whether Zotero happens to
+    be running. Both are pinned here; tests that exercise them override.
+    """
+    import time
+
+    from zotero_mcp import client as _client
+
+    monkeypatch.setattr(_client, "ZOTERO_MCP_CONFIG_PATH", tmp_path / "config.json")
+    monkeypatch.setattr(_client, "_local_write_state", {})
+    # Seed the probe cache with a negative answer rather than stubbing the
+    # function, so tests can opt into either behaviour by editing the cache:
+    # clear() to exercise the probe itself, or write a server_id to pretend
+    # Zotero 10 is running.
+    monkeypatch.setattr(
+        _client,
+        "_local_probe_cache",
+        {"server_id": None, "checked_at": time.monotonic()},
+    )
+    for var in ("ZOTERO_LOCAL_API_KEY", "ZOTERO_LOCAL_SERVER_ID", "ZOTERO_LOCAL_WRITE"):
+        monkeypatch.delenv(var, raising=False)
+
+
 class DummyContext:
     """No-op MCP context for unit tests."""
 
@@ -49,12 +80,19 @@ class DummyContext:
 class FakeZotero:
     """Minimal pyzotero client stub. Extend per test file as needed."""
 
+    # pyzotero sets this on the instance; several helpers branch on it to tell
+    # a local client from a web one.
+    local = False
+    endpoint = "https://api.zotero.org"
+
     def __init__(self):
         self.created = []
         self.updated = []
         self._items = []
         self._collections = []
         self._children = {}
+        self.attached = []
+        self.uploaded = []
         self.library_id = "12345"
         self.library_type = "user"
 
@@ -91,7 +129,7 @@ class FakeZotero:
         # Simulate httpx.Response
         return _FakeResponse(204)
 
-    def item_template(self, item_type):
+    def item_template(self, item_type, linkmode=None):
         """Return a minimal Zotero item template."""
         base = {
             "itemType": item_type,
@@ -174,6 +212,62 @@ class FakeZotero:
     def num_collectionitems(self, key):
         return len(self.collection_items(key))
 
+    def attachment_both(self, pairs, parentid=None):
+        self.attached.append((list(pairs), parentid))
+        return {"success": [{"key": "ATT00001"}], "unchanged": [], "failure": []}
+
+    def upload_attachments(self, attachments, parentid=None, basedir=None):
+        self.uploaded.append((list(attachments), parentid))
+        return {"success": [{"key": "ATT00001"}], "unchanged": [], "failure": []}
+
+    def item_types(self):
+        return [{"itemType": "journalArticle", "localized": "Journal Article"}]
+
+    def item_type_fields(self, item_type):
+        return [{"field": "title"}, {"field": "date"}, {"field": "abstractNote"}]
+
+    def item_creator_types(self, item_type):
+        return [{"creatorType": "author", "localized": "Author"}]
+
+
+class FakeLocalZotero(FakeZotero):
+    """A FakeZotero that behaves like a client talking to the local API.
+
+    The local API has no /items/new, so pyzotero raises CallDoesNotExistError
+    from item_template() — and, transitively, from attachment_both(). Writes
+    go through _write(), which is what attaches the server-id and key headers.
+    """
+
+    local = True
+    endpoint = "http://localhost:23119/api"
+
+    def __init__(self, write_status=204):
+        super().__init__()
+        self.library_id = "0"
+        self.library_type = "users"
+        self.server_id = "test-server-id"
+        self.local_api_key = "test-key"
+        self.writes = []
+        self.authorized = []
+        self._write_status = write_status
+
+    def item_template(self, item_type, linkmode=None):
+        raise CallDoesNotExistError(
+            "The local Zotero API doesn't implement the /items/new template endpoint"
+        )
+
+    def attachment_both(self, pairs, parentid=None):
+        # Fails transitively through item_template, exactly as pyzotero does.
+        return self.item_template("attachment", "imported_file")
+
+    def _write(self, method, url, **kwargs):
+        self.writes.append((method, url, kwargs))
+        return _FakeResponse(self._write_status)
+
+    def authorize_local(self, app_name):
+        self.authorized.append(app_name)
+        return {"key": "granted-key", "remember": True}
+
 
 class _FakeResponse:
     """Minimal httpx.Response stub."""
@@ -247,3 +341,8 @@ def dummy_ctx():
 @pytest.fixture
 def fake_zot():
     return FakeZotero()
+
+
+@pytest.fixture
+def fake_local_zot():
+    return FakeLocalZotero()

--- a/tests/test_add_by_bibtex.py
+++ b/tests/test_add_by_bibtex.py
@@ -15,7 +15,11 @@ class FakeZoteroWithAttach(FakeZotero):
 
     def attachment_both(self, files, parentid=None, **kwargs):
         self.attachments.append({"files": files, "parentid": parentid})
-        return {"success": {"0": "ATCH0001"}, "successful": {}, "failed": {}}
+        # Shape matches pyzotero's Zupload.upload(): each status maps to a
+        # list of payload dicts carrying the registered attachment key. A
+        # create_items-shaped dict here reads as an upload that landed no
+        # file, which sends the caller down the two-step retry.
+        return {"success": [{"key": "ATCH0001"}], "unchanged": [], "failure": []}
 
 
 def _patch_hybrid(monkeypatch):
@@ -240,10 +244,14 @@ class TestFilePath:
         result = write.add_item(source=str(f), source_type="bibtex", ctx=dummy_ctx)
         assert "Unsupported file extension" in result
 
-    def test_rejects_missing_file(self, monkeypatch, dummy_ctx):
+    def test_rejects_missing_file(self, monkeypatch, dummy_ctx, tmp_path):
         _patch_hybrid(monkeypatch)
+        # Absolute on whichever platform is running: a POSIX literal is not
+        # absolute on Windows, so the reader rejected it for its shape and
+        # the missing-file branch under test never ran.
+        missing = tmp_path / "no-such-file.bib"
         result = write.add_item(
-            source="/absolutely/no/such/file.bib",
+            source=str(missing),
             source_type="bibtex",
             ctx=dummy_ctx,
         )

--- a/tests/test_add_by_csl_json.py
+++ b/tests/test_add_by_csl_json.py
@@ -16,7 +16,11 @@ class FakeZoteroWithAttach(FakeZotero):
 
     def attachment_both(self, files, parentid=None, **kwargs):
         self.attachments.append({"files": files, "parentid": parentid})
-        return {"success": {"0": "ATCH0001"}, "successful": {}, "failed": {}}
+        # Shape matches pyzotero's Zupload.upload(): each status maps to a
+        # list of payload dicts carrying the registered attachment key. A
+        # create_items-shaped dict here reads as an upload that landed no
+        # file, which sends the caller down the two-step retry.
+        return {"success": [{"key": "ATCH0001"}], "unchanged": [], "failure": []}
 
 
 def _patch_hybrid(monkeypatch):
@@ -258,10 +262,14 @@ class TestFilePath:
         result = write.add_item(source=str(f), source_type="csl_json", ctx=dummy_ctx)
         assert "Unsupported file extension" in result
 
-    def test_rejects_missing_file(self, monkeypatch, dummy_ctx):
+    def test_rejects_missing_file(self, monkeypatch, dummy_ctx, tmp_path):
         _patch_hybrid(monkeypatch)
+        # Absolute on whichever platform is running: a POSIX literal is not
+        # absolute on Windows, so the reader rejected it for its shape and
+        # the missing-file branch under test never ran.
+        missing = tmp_path / "no-such-file.json"
         result = write.add_item(
-            source="/absolutely/no/such/file.json",
+            source=str(missing),
             source_type="csl_json",
             ctx=dummy_ctx,
         )

--- a/tests/test_add_from_file.py
+++ b/tests/test_add_from_file.py
@@ -1,5 +1,6 @@
 """Tests for the local-file source of zotero_add_item (write.add_from_file)."""
 
+import os
 import sys
 import types
 import pytest
@@ -22,7 +23,11 @@ class FakeZoteroForFile(FakeZotero):
 
     def attachment_both(self, files, parentid=None, **kwargs):
         self.attachments.append({"files": files, "parentid": parentid})
-        return {"success": {"0": "ATCH0001"}, "successful": {}, "failed": {}}
+        # Shape matches pyzotero's Zupload.upload(): each status maps to a
+        # list of payload dicts carrying the registered attachment key. A
+        # create_items-shaped dict here reads as an upload that landed no
+        # file, which sends the caller down the two-step retry.
+        return {"success": [{"key": "ATCH0001"}], "unchanged": [], "failure": []}
 
 
 class FakeFitzDocument:
@@ -91,7 +96,7 @@ def _patch_path_valid(monkeypatch):
     monkeypatch.setattr("os.path.exists", lambda p: True)
     monkeypatch.setattr("os.path.isfile", lambda p: True)
     monkeypatch.setattr("os.path.islink", lambda p: False)
-    monkeypatch.setattr("os.path.isabs", lambda p: p.startswith("/"))
+    monkeypatch.setattr("os.path.isabs", lambda p: str(p).startswith("/"))
 
 
 def _patch_hybrid_mode(monkeypatch, fake_write_zot):
@@ -143,7 +148,12 @@ class TestHappyPathNoDoi:
         # Should have called attachment_both
         assert len(fake_zot.attachments) == 1
         att = fake_zot.attachments[0]
-        assert att["files"][0] == ("paper.pdf", "/Users/test/Documents/paper.pdf")
+        # realpath rewrites a POSIX-style path on Windows, so resolve the
+        # expectation the same way the tool does.
+        assert att["files"][0] == (
+            "paper.pdf",
+            os.path.realpath("/Users/test/Documents/paper.pdf"),
+        )
         assert att["parentid"] is not None
 
     def test_uses_filename_as_title_when_none(self, monkeypatch, dummy_ctx):
@@ -473,7 +483,7 @@ class TestNonAbsolutePath:
     def test_dot_relative_path_rejected(self, monkeypatch, dummy_ctx):
         fake_zot = FakeZoteroForFile()
         _patch_hybrid_mode(monkeypatch, fake_zot)
-        monkeypatch.setattr("os.path.isabs", lambda p: not p.startswith("."))
+        monkeypatch.setattr("os.path.isabs", lambda p: not str(p).startswith("."))
 
         result = write.add_item(
             source="./Documents/paper.pdf",
@@ -708,7 +718,9 @@ class TestAttachmentBoth:
         assert len(files_arg) == 1
         basename, full_path = files_arg[0]
         assert basename == "my_paper.pdf"
-        assert full_path == "/Users/test/Documents/my_paper.pdf"
+        # The tool resolves the path before attaching, and realpath rewrites a
+        # POSIX-style path on Windows — compare against the same resolution.
+        assert full_path == os.path.realpath("/Users/test/Documents/my_paper.pdf")
 
     def test_attachment_both_receives_parent_item_key(self, monkeypatch, dummy_ctx):
         """The parentid kwarg should be the key of the newly created item."""

--- a/tests/test_area_annotations.py
+++ b/tests/test_area_annotations.py
@@ -65,6 +65,7 @@ def _pdf_attachment(key="ATTACH01", content_type="application/pdf"):
 def test_create_area_annotation_happy_path(monkeypatch, fake_zot):
     fake_zot._items = [_pdf_attachment()]
 
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake_zot)
     monkeypatch.setattr("zotero_mcp.client.get_web_zotero_client", lambda: fake_zot)
     monkeypatch.setattr("zotero_mcp.client.get_local_zotero_client", lambda: None)
     monkeypatch.setattr("zotero_mcp.client.get_active_library", lambda: None)
@@ -109,6 +110,7 @@ def test_create_area_annotation_offset_mediabox(monkeypatch, fake_zot):
     """
     fake_zot._items = [_pdf_attachment()]
 
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake_zot)
     monkeypatch.setattr("zotero_mcp.client.get_web_zotero_client", lambda: fake_zot)
     monkeypatch.setattr("zotero_mcp.client.get_local_zotero_client", lambda: None)
     monkeypatch.setattr("zotero_mcp.client.get_active_library", lambda: None)
@@ -172,6 +174,7 @@ def test_create_area_annotation_rejects_invalid_rectangles(kwargs, message):
 def test_create_area_annotation_rejects_non_pdf_attachment(monkeypatch, fake_zot):
     fake_zot._items = [_pdf_attachment(content_type="text/html")]
 
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake_zot)
     monkeypatch.setattr("zotero_mcp.client.get_web_zotero_client", lambda: fake_zot)
     monkeypatch.setattr("zotero_mcp.client.get_local_zotero_client", lambda: None)
     monkeypatch.setattr("zotero_mcp.client.get_active_library", lambda: None)
@@ -189,7 +192,10 @@ def test_create_area_annotation_rejects_non_pdf_attachment(monkeypatch, fake_zot
     assert "not a PDF attachment" in result
 
 
-def test_create_area_annotation_requires_web_api(monkeypatch):
+def test_create_area_annotation_requires_a_writable_backend(monkeypatch):
+    """With no local key and no web credentials there is nowhere to write."""
+    monkeypatch.setenv("ZOTERO_LOCAL", "true")
+    monkeypatch.setattr("zotero_mcp.client.get_local_write_client", lambda: None)
     monkeypatch.setattr("zotero_mcp.client.get_web_zotero_client", lambda: None)
     monkeypatch.setattr("zotero_mcp.client.get_local_zotero_client", lambda: None)
 
@@ -203,7 +209,10 @@ def test_create_area_annotation_requires_web_api(monkeypatch):
         ctx=DummyContext(),
     )
 
-    assert "Web API credentials required for creating annotations" in result
+    assert "Cannot perform write operations" in result
+    # Both routes out are named, so the caller can pick the one that applies.
+    assert "authorize-local" in result
+    assert "ZOTERO_API_KEY" in result
 
 
 # ---------------------------------------------------------------------------
@@ -215,6 +224,7 @@ def test_create_annotation_rect_creates_area_annotation(monkeypatch, fake_zot):
     """rect= must reach the area path with the geometry intact."""
     fake_zot._items = [_pdf_attachment()]
 
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake_zot)
     monkeypatch.setattr("zotero_mcp.client.get_web_zotero_client", lambda: fake_zot)
     monkeypatch.setattr("zotero_mcp.client.get_local_zotero_client", lambda: None)
     monkeypatch.setattr("zotero_mcp.client.get_active_library", lambda: None)
@@ -314,6 +324,7 @@ def test_create_annotation_rect_accepts_stringified_json(monkeypatch, fake_zot):
     """
     fake_zot._items = [_pdf_attachment()]
 
+    monkeypatch.setattr("zotero_mcp.client.get_zotero_client", lambda: fake_zot)
     monkeypatch.setattr("zotero_mcp.client.get_web_zotero_client", lambda: fake_zot)
     monkeypatch.setattr("zotero_mcp.client.get_local_zotero_client", lambda: None)
     monkeypatch.setattr("zotero_mcp.client.get_active_library", lambda: None)

--- a/tests/test_attach_file.py
+++ b/tests/test_attach_file.py
@@ -395,6 +395,21 @@ class TestAttachFileLocal:
         )
         assert "absolute path" in result
 
+    @pytest.mark.parametrize(
+        "name", ["notes.docx", "draft.odt", "memo.rtf", "scan.djvu", "book.epub"]
+    )
+    def test_accepts_supplementary_types(self, name, monkeypatch, dummy_ctx):
+        """Not PDF-only: the supporting-document types are attachable too."""
+        fake = FakeZoteroForAttach()
+        _patch_write_client(monkeypatch, fake)
+        _patch_path_valid(monkeypatch)
+
+        result = server.attach_file(
+            item_key="ITEM1", file_path=f"/Users/test/{name}", ctx=dummy_ctx
+        )
+        assert "Unsupported file type" not in result
+        assert fake.attachments[0]["files"][0][0] == name
+
     def test_rejects_bad_extension(self, monkeypatch, dummy_ctx):
         fake = FakeZoteroForAttach()
         _patch_write_client(monkeypatch, fake)

--- a/tests/test_attach_verification.py
+++ b/tests/test_attach_verification.py
@@ -98,11 +98,20 @@ class TestDescribeAttachFailure:
 
 
 class TestAssertUploadCapable:
-    def test_rejects_local_client(self):
+    def test_rejects_unauthorized_local_client(self):
         zot = FakeZotero()
         zot.local = True
-        with pytest.raises(ValueError, match="local API"):
+        zot.local_api_key = None
+        with pytest.raises(ValueError, match="no writable Zotero backend"):
             _helpers._assert_upload_capable(zot)
+
+    def test_allows_authorized_local_client(self):
+        # Zotero 10 uploads through the local API once a key has been
+        # granted; only a keyless local client cannot.
+        zot = FakeZotero()
+        zot.local = True
+        zot.local_api_key = "LOCALKEY0"
+        _helpers._assert_upload_capable(zot)
 
     def test_allows_web_client(self):
         zot = FakeZotero()
@@ -164,10 +173,11 @@ class TestAttachAndVerify:
         assert ok is False
         assert zot.deleted == [{"key": "NEWATCH1", "version": 7}]
 
-    def test_local_client_fails_fast(self, dummy_ctx):
+    def test_unauthorized_local_client_fails_fast(self, dummy_ctx):
         zot = _AttachFake()
         zot.local = True
-        with pytest.raises(ValueError, match="local API"):
+        zot.local_api_key = None
+        with pytest.raises(ValueError, match="no writable Zotero backend"):
             _helpers._attach_and_verify(
                 zot, "paper.pdf", "/abs/paper.pdf", "ITEM1", dummy_ctx
             )

--- a/tests/test_authorize_local.py
+++ b/tests/test_authorize_local.py
@@ -1,0 +1,267 @@
+"""Tests for the local-write authorization CLI command and MCP tools."""
+
+import argparse
+import json
+import time
+
+import httpx
+import pytest
+from conftest import DummyContext
+from pyzotero.errors import LocalAPIDeniedError, TooManyRequestsError, UnsupportedParamsError
+
+from zotero_mcp import cli as _cli
+from zotero_mcp import client as _client
+from zotero_mcp import server
+
+
+@pytest.fixture
+def local_mode(monkeypatch):
+    monkeypatch.setenv("ZOTERO_LOCAL", "true")
+    monkeypatch.delenv("ZOTERO_API_KEY", raising=False)
+    monkeypatch.delenv("ZOTERO_LIBRARY_ID", raising=False)
+
+
+def _server_supports_local_writes():
+    _client._local_probe_cache.update(
+        {"server_id": "srv-1", "checked_at": time.monotonic()}
+    )
+
+
+def _args(**overrides):
+    defaults = {
+        "app_name": None, "timeout": 120.0, "status": False,
+        "revoke": False, "print_key": False, "no_save": False,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestCliCommand:
+    def test_parser_and_dispatch_agree(self, monkeypatch):
+        """The parser and the handler have to stay in step — a CLI subcommand
+        shipped broken for exactly this reason (#335)."""
+        called = {}
+
+        def _capture(parsed):
+            called["args"] = parsed
+            return 0
+
+        monkeypatch.setattr(_cli, "setup_zotero_environment", lambda: None)
+        monkeypatch.setattr(_cli, "cmd_authorize_local", _capture)
+        monkeypatch.setattr("sys.argv", ["zotero-mcp", "authorize-local", "--status"])
+        with pytest.raises(SystemExit) as exc:
+            _cli.main()
+        assert exc.value.code == 0
+        assert called["args"].status is True
+        # Every flag the handler reads must exist on the parsed namespace.
+        for flag in ("app_name", "timeout", "status", "revoke", "print_key", "no_save"):
+            assert hasattr(called["args"], flag), flag
+
+    def test_status_does_not_open_a_dialog(self, local_mode, monkeypatch, capsys):
+        monkeypatch.setattr(
+            _client, "authorize_local_api",
+            lambda **k: pytest.fail("status must not authorize"),
+        )
+        assert _cli.cmd_authorize_local(_args(status=True)) == 0
+        assert "Write mode:" in capsys.readouterr().out
+
+    def test_revoke_clears_the_stored_key(self, local_mode, capsys):
+        _client.store_local_write_credentials("k", "srv", remember=True)
+        assert _cli.cmd_authorize_local(_args(revoke=True)) == 0
+        assert _client.get_local_write_credentials() == (None, None, None)
+        out = capsys.readouterr().out
+        assert "removed" in out
+        # Zotero keeps its own record; say so rather than implying we cleared it.
+        assert "Clear Write Authorizations" in out
+
+    def test_revoke_warns_about_a_key_it_cannot_reach(self, local_mode, monkeypatch, capsys):
+        """Revoke can't unset a variable in someone else's environment, and
+        staying quiet would make it look like the key was gone."""
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "from-env")
+        _cli.cmd_authorize_local(_args(revoke=True))
+        out = capsys.readouterr().out
+        assert "ZOTERO_LOCAL_API_KEY is still set" in out
+        assert _client.get_local_write_credentials()[0] == "from-env"
+
+    def test_refuses_outside_local_mode(self, monkeypatch, capsys):
+        monkeypatch.delenv("ZOTERO_LOCAL", raising=False)
+        assert _cli.cmd_authorize_local(_args()) == 7
+        assert "ZOTERO_LOCAL is not enabled" in capsys.readouterr().out
+
+    def test_reports_an_older_zotero_without_prompting(self, local_mode, capsys):
+        assert _cli.cmd_authorize_local(_args()) == 5
+        assert "Zotero 10" in capsys.readouterr().out
+
+    def test_grants_and_saves(self, local_mode, monkeypatch, capsys):
+        _server_supports_local_writes()
+        monkeypatch.setattr(
+            _client, "authorize_local_api",
+            lambda **k: {"key": "kk", "remember": True, "server_id": "srv-1",
+                         "stored_at": "/tmp/config.json"},
+        )
+        assert _cli.cmd_authorize_local(_args()) == 0
+        out = capsys.readouterr().out
+        assert "Always Allow" in out  # instructions shown before blocking
+        assert "reusable key" in out
+        assert "Saved to" in out
+
+    def test_warns_loudly_about_a_single_use_key(self, local_mode, monkeypatch, capsys):
+        _server_supports_local_writes()
+        monkeypatch.setattr(
+            _client, "authorize_local_api",
+            lambda **k: {"key": "kk", "remember": False, "stored_at": "/tmp/c.json"},
+        )
+        assert _cli.cmd_authorize_local(_args()) == 0
+        assert "SINGLE-USE" in capsys.readouterr().out
+
+    def test_does_not_print_the_key_by_default(self, local_mode, monkeypatch, capsys):
+        _server_supports_local_writes()
+        monkeypatch.setattr(
+            _client, "authorize_local_api",
+            lambda **k: {"key": "super-secret", "remember": True, "stored_at": "/x"},
+        )
+        _cli.cmd_authorize_local(_args())
+        assert "super-secret" not in capsys.readouterr().out
+
+    def test_print_flag_emits_exportable_variables(self, local_mode, monkeypatch, capsys):
+        _server_supports_local_writes()
+        monkeypatch.setattr(
+            _client, "authorize_local_api",
+            lambda **k: {"key": "kk", "remember": True, "server_id": "srv-1",
+                         "stored_at": "/x"},
+        )
+        _cli.cmd_authorize_local(_args(print_key=True))
+        out = capsys.readouterr().out
+        assert "ZOTERO_LOCAL_API_KEY=kk" in out
+        assert "ZOTERO_LOCAL_SERVER_ID=srv-1" in out
+
+    @pytest.mark.parametrize(
+        ("error", "code"),
+        [
+            (LocalAPIDeniedError("denied"), 3),
+            (TooManyRequestsError("slow"), 4),
+            (UnsupportedParamsError("no server id"), 5),
+        ],
+    )
+    def test_distinct_exit_codes_per_failure(self, local_mode, monkeypatch, error, code):
+        _server_supports_local_writes()
+
+        def _raise(**_kwargs):
+            raise error
+
+        monkeypatch.setattr(_client, "authorize_local_api", _raise)
+        assert _cli.cmd_authorize_local(_args()) == code
+
+
+class TestAuthorizeTool:
+    def test_explains_that_local_mode_is_off(self, monkeypatch):
+        monkeypatch.delenv("ZOTERO_LOCAL", raising=False)
+        result = server.authorize_local_writes(ctx=DummyContext())
+        assert "not in local mode" in result
+
+    def test_reports_a_persistent_grant(self, local_mode, monkeypatch):
+        monkeypatch.setattr(
+            _client, "authorize_local_api", lambda **k: {"key": "kk", "remember": True}
+        )
+        result = server.authorize_local_writes(ctx=DummyContext())
+        assert "granted and saved" in result
+
+    def test_reports_a_single_use_grant(self, local_mode, monkeypatch):
+        monkeypatch.setattr(
+            _client, "authorize_local_api", lambda **k: {"key": "kk", "remember": False}
+        )
+        result = server.authorize_local_writes(ctx=DummyContext())
+        assert "SINGLE write" in result
+        assert "Always Allow" in result
+
+    def test_timeout_is_clamped_under_the_client_deadline(self, local_mode, monkeypatch):
+        """Past FastMCP's ~60s timeout the transport dies first and the user
+        sees an opaque failure instead of 'you didn't answer the dialog'."""
+        seen = {}
+
+        def _record(**kwargs):
+            seen.update(kwargs)
+            return {"key": "kk", "remember": True}
+
+        monkeypatch.setattr(_client, "authorize_local_api", _record)
+        server.authorize_local_writes(timeout=9999, ctx=DummyContext())
+        assert seen["timeout"] == 55
+
+    def test_never_raises(self, local_mode, monkeypatch):
+        for error in (
+            LocalAPIDeniedError("d"),
+            TooManyRequestsError("r"),
+            UnsupportedParamsError("u"),
+            httpx.ReadTimeout("t"),
+            RuntimeError("boom"),
+            _client.ZoteroAuthInProgressError("busy"),
+        ):
+            def _raise(_e=error, **_kwargs):
+                raise _e
+
+            monkeypatch.setattr(_client, "authorize_local_api", _raise)
+            result = server.authorize_local_writes(ctx=DummyContext())
+            assert isinstance(result, str) and result
+
+    def test_timeout_says_the_dialog_is_probably_still_open(self, local_mode, monkeypatch):
+        def _raise(**_kwargs):
+            raise httpx.ReadTimeout("timed out")
+
+        monkeypatch.setattr(_client, "authorize_local_api", _raise)
+        assert "still open" in server.authorize_local_writes(ctx=DummyContext())
+
+
+class TestCapabilitiesTool:
+    def test_points_at_authorizing_when_that_is_the_fix(self, local_mode):
+        _server_supports_local_writes()
+        result = server.write_capabilities(ctx=DummyContext())
+        assert "**Mode:** none" in result
+        assert "zotero_authorize_local_writes" in result
+
+    def test_points_at_web_credentials_on_an_older_zotero(self, local_mode):
+        result = server.write_capabilities(ctx=DummyContext())
+        assert "needs Zotero 10 or newer" in result
+        assert "ZOTERO_API_KEY" in result
+
+    def test_flags_a_single_use_key(self, local_mode):
+        _server_supports_local_writes()
+        _client.store_local_write_credentials("k", "srv-1", remember=False)
+        result = server.write_capabilities(ctx=DummyContext())
+        assert "SINGLE USE" in result
+
+    def test_nudges_hybrid_users_who_could_go_local(self, local_mode, monkeypatch):
+        _server_supports_local_writes()
+        monkeypatch.setenv("ZOTERO_API_KEY", "webkey")
+        monkeypatch.setenv("ZOTERO_LIBRARY_ID", "123")
+        result = server.write_capabilities(ctx=DummyContext())
+        assert "**Mode:** hybrid" in result
+        assert "zotero_authorize_local_writes" in result
+
+    def test_never_leaks_the_key(self, local_mode):
+        _client.store_local_write_credentials("super-secret", "srv-1", remember=True)
+        assert "super-secret" not in server.write_capabilities(ctx=DummyContext())
+
+
+class TestSetupDoesNotClobberTheKey:
+    def test_standalone_config_rewrite_preserves_local_api(self, tmp_path, monkeypatch):
+        """`zotero-mcp setup` rebuilds client_env from scratch; the key lives
+        in its own section precisely so that rewrite cannot drop it."""
+        from zotero_mcp import setup_helper
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            _client, "ZOTERO_MCP_CONFIG_PATH",
+            tmp_path / ".config" / "zotero-mcp" / "config.json",
+        )
+        _client.store_local_write_credentials("keep-me", "srv", remember=True)
+
+        setup_helper._write_standalone_config(
+            local=True, api_key="", library_id="", library_type="user",
+            semantic_config={}, no_claude=True,
+        )
+
+        stored = json.loads(
+            (tmp_path / ".config" / "zotero-mcp" / "config.json").read_text(encoding="utf-8")
+        )
+        assert stored["local_api"]["key"] == "keep-me"
+        assert "keep-me" not in json.dumps(stored["client_env"])

--- a/tests/test_description_tokens.py
+++ b/tests/test_description_tokens.py
@@ -32,6 +32,9 @@ TOOL_BUDGETS = {
     "zotero_get_notes":                (119, 267),
     "zotero_manage_note":              (139, 312),
     "zotero_create_annotation":        (196, 439),
+    # tools/local_auth.py
+    "zotero_authorize_local_writes":   (115, 260),
+    "zotero_write_capabilities":       ( 70, 165),
     # tools/retrieval.py
     "zotero_get_tags":                 ( 85, 195),
     "zotero_get_item_children":        (138, 310),

--- a/tests/test_local_write_client.py
+++ b/tests/test_local_write_client.py
@@ -1,0 +1,340 @@
+"""Tests for local API write credentials, capability probing and the client factory."""
+
+import json
+
+import pytest
+from pyzotero.errors import LocalAPIDeniedError, TooManyRequestsError
+
+from zotero_mcp import client as _client
+
+
+@pytest.fixture
+def local_mode(monkeypatch):
+    monkeypatch.setenv("ZOTERO_LOCAL", "true")
+    monkeypatch.delenv("ZOTERO_LIBRARY_ID", raising=False)
+    monkeypatch.delenv("ZOTERO_LIBRARY_TYPE", raising=False)
+    monkeypatch.delenv("ZOTERO_API_KEY", raising=False)
+
+
+def _write_config(payload):
+    """Write the isolated config file the autouse fixture points us at."""
+    _client.ZOTERO_MCP_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _client.ZOTERO_MCP_CONFIG_PATH.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestCredentialPrecedence:
+    def test_no_credentials_anywhere(self):
+        assert _client.get_local_write_credentials() == (None, None, None)
+
+    def test_config_file(self):
+        _write_config({"local_api": {"key": "from-config", "server_id": "srv-1"}})
+        assert _client.get_local_write_credentials() == ("from-config", "srv-1", "config")
+
+    def test_env_beats_config(self, monkeypatch):
+        _write_config({"local_api": {"key": "from-config", "server_id": "srv-1"}})
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "from-env")
+        monkeypatch.setenv("ZOTERO_LOCAL_SERVER_ID", "srv-2")
+        assert _client.get_local_write_credentials() == ("from-env", "srv-2", "env")
+
+    def test_session_beats_env(self, monkeypatch):
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "from-env")
+        _client.store_local_write_credentials("from-session", "srv-3", remember=True)
+        key, server_id, source = _client.get_local_write_credentials()
+        assert (key, server_id, source) == ("from-session", "srv-3", "session")
+
+    def test_unrelated_config_sections_survive_a_grant(self):
+        _write_config({"semantic_search": {"model": "default"}})
+        _client.store_local_write_credentials("k", "srv", remember=True)
+        stored = json.loads(_client.ZOTERO_MCP_CONFIG_PATH.read_text(encoding="utf-8"))
+        assert stored["semantic_search"] == {"model": "default"}
+        assert stored["local_api"]["key"] == "k"
+
+    def test_key_is_not_written_to_client_env(self):
+        """client_env is rebuilt wholesale by `zotero-mcp setup`, and is the
+        section copied out to MCP clients. The key must not live there."""
+        _write_config({"client_env": {"ZOTERO_LOCAL": "true"}})
+        _client.store_local_write_credentials("secret-key", "srv", remember=True)
+        stored = json.loads(_client.ZOTERO_MCP_CONFIG_PATH.read_text(encoding="utf-8"))
+        assert "secret-key" not in json.dumps(stored["client_env"])
+        assert stored["client_env"] == {"ZOTERO_LOCAL": "true"}
+
+    def test_clear_removes_key_from_disk_and_session(self):
+        _client.store_local_write_credentials("k", "srv", remember=True)
+        assert _client.clear_local_write_credentials() is True
+        assert _client.get_local_write_credentials() == (None, None, None)
+        stored = json.loads(_client.ZOTERO_MCP_CONFIG_PATH.read_text(encoding="utf-8"))
+        assert "local_api" not in stored
+
+    def test_clear_is_a_no_op_without_stored_credentials(self):
+        assert _client.clear_local_write_credentials() is False
+
+    def test_clear_reports_a_session_only_key_honestly(self, monkeypatch):
+        """A key granted this run lives in memory, not the config file — saying
+        'nothing to remove' would make revoke look broken."""
+        monkeypatch.setattr(
+            _client, "_local_write_state", {"key": "k", "server_id": "s", "remember": False}
+        )
+        assert _client.clear_local_write_credentials() is True
+
+    def test_an_unparseable_config_is_never_overwritten(self):
+        """It also holds semantic_search and client_env; rewriting a file we
+        failed to read would silently discard both."""
+        _client.ZOTERO_MCP_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        broken = '{"semantic_search": {"model": "x"} THIS IS NOT JSON'
+        _client.ZOTERO_MCP_CONFIG_PATH.write_text(broken, encoding="utf-8")
+
+        assert _client.store_local_write_credentials("k", "s", remember=True) is None
+        assert _client.ZOTERO_MCP_CONFIG_PATH.read_text(encoding="utf-8") == broken
+        # The session copy is still set, so the caller can carry on and warn.
+        assert _client.get_local_write_credentials()[0] == "k"
+
+    def test_clearing_leaves_an_unparseable_config_alone_too(self):
+        _client.ZOTERO_MCP_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        broken = "{not json"
+        _client.ZOTERO_MCP_CONFIG_PATH.write_text(broken, encoding="utf-8")
+        _client.clear_local_write_credentials()
+        assert _client.ZOTERO_MCP_CONFIG_PATH.read_text(encoding="utf-8") == broken
+
+    def test_no_partial_file_is_left_behind_on_write(self):
+        _client.store_local_write_credentials("k", "s", remember=True)
+        leftovers = list(_client.ZOTERO_MCP_CONFIG_PATH.parent.glob("*.tmp"))
+        assert leftovers == []
+
+
+class TestProbe:
+    def _stub_response(self, monkeypatch, headers):
+        class _Resp:
+            def __init__(self):
+                self.headers = headers
+
+        class _Client:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def get(self, url):
+                self.url = url
+                return _Resp()
+
+        monkeypatch.setattr(_client, "_make_local_http_client", lambda *a, **k: _Client())
+
+    def test_reports_the_server_id_header(self, monkeypatch):
+        _client._local_probe_cache.clear()
+        self._stub_response(monkeypatch, {"zotero-server-id": "abc123"})
+        assert _client.probe_local_server_id() == "abc123"
+
+    def test_absent_header_means_no_local_write_support(self, monkeypatch):
+        _client._local_probe_cache.clear()
+        self._stub_response(monkeypatch, {})
+        assert _client.probe_local_server_id() is None
+
+    def test_positive_result_is_cached(self, monkeypatch):
+        _client._local_probe_cache.clear()
+        calls = []
+
+        class _Client:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def get(self, url):
+                calls.append(url)
+                return type("R", (), {"headers": {"zotero-server-id": "abc"}})()
+
+        monkeypatch.setattr(_client, "_make_local_http_client", lambda *a, **k: _Client())
+        assert _client.probe_local_server_id() == "abc"
+        assert _client.probe_local_server_id() == "abc"
+        assert len(calls) == 1
+        # The trailing slash matters: bare /api is a 404.
+        assert calls[0].endswith("/api/")
+
+
+class TestGetLocalWriteClient:
+    def test_none_without_a_key(self, local_mode):
+        assert _client.get_local_write_client() is None
+
+    def test_none_outside_local_mode(self, monkeypatch):
+        monkeypatch.delenv("ZOTERO_LOCAL", raising=False)
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "k")
+        assert _client.get_local_write_client() is None
+
+    def test_kill_switch(self, local_mode, monkeypatch):
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "k")
+        monkeypatch.setenv("ZOTERO_LOCAL_WRITE", "false")
+        assert _client.get_local_write_client() is None
+
+    def test_kill_switch_default_and_auto_are_on(self, local_mode, monkeypatch):
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "k")
+        assert _client.get_local_write_client() is not None
+        monkeypatch.setenv("ZOTERO_LOCAL_WRITE", "auto")
+        assert _client.get_local_write_client() is not None
+
+    def test_carries_the_key_and_server_id(self, local_mode, monkeypatch):
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "k")
+        monkeypatch.setenv("ZOTERO_LOCAL_SERVER_ID", "srv-9")
+        zot = _client.get_local_write_client()
+        assert zot.local is True
+        assert zot.local_api_key == "k"
+        # Cached so the first write of each call doesn't re-probe.
+        assert zot.server_id == "srv-9"
+        assert zot.endpoint == "http://localhost:23119/api"
+
+    def test_user_library_is_always_users_zero(self, local_mode, monkeypatch):
+        """The local API addresses the user library as users/0, whatever the
+        web user id happens to be — hybrid setups do configure a real one."""
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "k")
+        monkeypatch.setenv("ZOTERO_LIBRARY_ID", "7654321")
+        zot = _client.get_local_write_client()
+        assert zot.library_id == "0"
+        assert zot.library_type == "users"
+
+    def test_group_library_keeps_its_real_id(self, local_mode, monkeypatch):
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "k")
+        _client.set_active_library("555666", "group")
+        try:
+            zot = _client.get_local_write_client()
+            assert zot.library_id == "555666"
+            assert zot.library_type == "groups"
+        finally:
+            _client.clear_active_library()
+
+    def test_cloud_api_key_is_never_sent_to_localhost(self, local_mode, monkeypatch):
+        """In hybrid mode the read client is built with the zotero.org key, and
+        pyzotero's default headers would turn that into an Authorization
+        bearer aimed at a local HTTP server that has no use for it."""
+        monkeypatch.setenv("ZOTERO_API_KEY", "WEBKEYSECRET")
+        monkeypatch.setenv("ZOTERO_LIBRARY_ID", "7654321")
+        for zot in (_client.get_zotero_client(), _client.get_local_zotero_client()):
+            if zot is None:
+                continue  # no local Zotero running; the probe client is optional
+            assert "authorization" not in {k.lower() for k in zot.client.headers}
+            # The headers worth restoring are still there.
+            assert zot.client.headers.get("zotero-api-version") == "3"
+
+    def test_group_library_without_an_id_returns_none(self, local_mode, monkeypatch):
+        """Documented never to raise — the caller reads None as 'fall back'."""
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "k")
+        monkeypatch.setenv("ZOTERO_LIBRARY_TYPE", "group")
+        monkeypatch.delenv("ZOTERO_LIBRARY_ID", raising=False)
+        assert _client.get_local_write_client() is None
+
+    def test_write_client_gets_a_usable_timeout(self, local_mode, monkeypatch):
+        """A write inherits the injected client's timeout — pyzotero passes
+        none of its own on _write — so the httpx 5s default would be fatal."""
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "k")
+        zot = _client.get_local_write_client()
+        assert zot.client.timeout.read == _client._LOCAL_WRITE_TIMEOUT
+
+
+class TestAuthorize:
+    def _stub_zotero(self, monkeypatch, behaviour):
+        class _Zot:
+            def __init__(self, *a, **k):
+                self.server_id = "srv-new"
+                self.client = None
+
+            def authorize_local(self, app_name):
+                return behaviour(app_name)
+
+        monkeypatch.setattr(_client.zotero, "Zotero", _Zot)
+
+    def test_persists_a_remembered_key(self, local_mode, monkeypatch):
+        self._stub_zotero(monkeypatch, lambda n: {"key": "kk", "remember": True})
+        result = _client.authorize_local_api("Tester")
+        assert result["key"] == "kk"
+        assert result["server_id"] == "srv-new"
+        assert _client.get_local_write_credentials()[0] == "kk"
+        stored = json.loads(_client.ZOTERO_MCP_CONFIG_PATH.read_text(encoding="utf-8"))
+        assert stored["local_api"]["app_name"] == "Tester"
+
+    def test_single_use_key_never_reaches_the_disk(self, local_mode, monkeypatch):
+        """It is consumed by the first write, and a dead key on disk would
+        outrank working web credentials on every later run."""
+        self._stub_zotero(monkeypatch, lambda n: {"key": "kk", "remember": False})
+        _client.authorize_local_api()
+        assert not _client.ZOTERO_MCP_CONFIG_PATH.exists()
+        # Still usable for the one write it is good for, and still flagged so
+        # the resulting 401 can explain itself.
+        assert _client.get_local_write_credentials() == ("kk", "srv-new", "session")
+        assert _client.get_write_capabilities(probe=False)["local_key_remember"] is False
+
+    def test_single_use_key_does_not_overwrite_a_stored_one(self, local_mode, monkeypatch):
+        _client.store_local_write_credentials("good-key", "srv", remember=True)
+        self._stub_zotero(monkeypatch, lambda n: {"key": "throwaway", "remember": False})
+        _client.authorize_local_api()
+        stored = json.loads(_client.ZOTERO_MCP_CONFIG_PATH.read_text(encoding="utf-8"))
+        assert stored["local_api"]["key"] == "good-key"
+
+    def test_no_save_keeps_the_key_out_of_the_config(self, local_mode, monkeypatch):
+        self._stub_zotero(monkeypatch, lambda n: {"key": "kk", "remember": True})
+        _client.authorize_local_api(persist=False)
+        assert not _client.ZOTERO_MCP_CONFIG_PATH.exists()
+        assert _client.get_local_write_credentials()[0] == "kk"
+
+    def test_denial_propagates(self, local_mode, monkeypatch):
+        def _deny(_name):
+            raise LocalAPIDeniedError("denied")
+
+        self._stub_zotero(monkeypatch, _deny)
+        with pytest.raises(LocalAPIDeniedError):
+            _client.authorize_local_api()
+        assert _client.get_local_write_credentials() == (None, None, None)
+
+    def test_rate_limit_propagates(self, local_mode, monkeypatch):
+        def _limit(_name):
+            raise TooManyRequestsError("slow down")
+
+        self._stub_zotero(monkeypatch, _limit)
+        with pytest.raises(TooManyRequestsError):
+            _client.authorize_local_api()
+
+    def test_second_concurrent_request_is_refused(self, local_mode, monkeypatch):
+        """Two dialogs at once is the failure mode worth preventing."""
+        def _reentrant(_name):
+            with pytest.raises(_client.ZoteroAuthInProgressError):
+                _client.authorize_local_api()
+            return {"key": "kk", "remember": True}
+
+        self._stub_zotero(monkeypatch, _reentrant)
+        _client.authorize_local_api()
+
+    def test_lock_is_released_after_a_failure(self, local_mode, monkeypatch):
+        def _boom(_name):
+            raise LocalAPIDeniedError("denied")
+
+        self._stub_zotero(monkeypatch, _boom)
+        for _ in range(2):
+            with pytest.raises(LocalAPIDeniedError):
+                _client.authorize_local_api()
+
+
+class TestWriteCapabilities:
+    def test_local_when_a_key_is_held(self, local_mode, monkeypatch):
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "k")
+        caps = _client.get_write_capabilities()
+        assert caps["mode"] == "local"
+        assert caps["has_local_key"] is True
+        assert caps["local_key_source"] == "env"
+
+    def test_hybrid_when_only_web_credentials_exist(self, local_mode, monkeypatch):
+        monkeypatch.setenv("ZOTERO_API_KEY", "webkey")
+        monkeypatch.setenv("ZOTERO_LIBRARY_ID", "123")
+        caps = _client.get_write_capabilities()
+        assert caps["mode"] == "hybrid"
+
+    def test_none_when_nothing_is_configured(self, local_mode):
+        assert _client.get_write_capabilities()["mode"] == "none"
+
+    def test_web_outside_local_mode(self, monkeypatch):
+        monkeypatch.delenv("ZOTERO_LOCAL", raising=False)
+        monkeypatch.setenv("ZOTERO_API_KEY", "webkey")
+        monkeypatch.setenv("ZOTERO_LIBRARY_ID", "123")
+        assert _client.get_write_capabilities()["mode"] == "web"
+
+    def test_reports_single_use_keys(self, local_mode):
+        _client.store_local_write_credentials("k", "srv", remember=False)
+        assert _client.get_write_capabilities()["local_key_remember"] is False

--- a/tests/test_local_write_endtoend.py
+++ b/tests/test_local_write_endtoend.py
@@ -1,0 +1,213 @@
+"""End-to-end checks against a stub of Zotero 10's local API.
+
+The unit tests replace pyzotero with fakes, which means they never exercise
+the part most likely to be wrong: whether a real pyzotero client actually puts
+Zotero-Server-ID and Zotero-API-Key on the wire, and whether it addresses the
+paths the local API expects. This module runs a small HTTP server that speaks
+enough of the local API to answer that, and asserts on the requests it saw.
+
+It cannot prove Zotero itself accepts these requests — only a live Zotero 10
+can — but it does prove the client is sending what the spec describes.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from zotero_mcp import client as _client
+from zotero_mcp.tools import _helpers
+
+SERVER_ID = "stub-server-id"
+GRANTED_KEY = "0123456789abcdef0123456789abcdef"
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Enough of the local API to observe what a client sends."""
+
+    def log_message(self, *_args):
+        pass  # keep pytest output clean
+
+    def _record(self, method):
+        body = b""
+        if length := int(self.headers.get("Content-Length") or 0):
+            body = self.rfile.read(length)
+        self.server.requests.append(
+            {
+                "method": method,
+                "path": self.path,
+                "headers": dict(self.headers),
+                "body": body.decode("utf-8") if body else "",
+            }
+        )
+        return body
+
+    def _respond(self, status, payload=None, headers=None):
+        body = json.dumps(payload).encode() if payload is not None else b""
+        self.send_response(status)
+        # Every local API response carries the server id, errors included.
+        self.send_header("Zotero-Server-ID", SERVER_ID)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        for name, value in (headers or {}).items():
+            self.send_header(name, value)
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def do_GET(self):
+        self._record("GET")
+        self._respond(200, {})
+
+    def do_POST(self):
+        body = self._record("POST")
+        if self.path.endswith("/local/authorize"):
+            payload = json.loads(body)
+            self._respond(200, {"key": GRANTED_KEY, "remember": bool(payload)})
+            return
+        # A write: refuse it the way the real server does if the headers the
+        # spec requires are missing, so the test can tell them apart.
+        if not self.headers.get("Zotero-Server-ID"):
+            self._respond(428, {"error": "Zotero-Server-ID not provided"})
+            return
+        if not self.headers.get("Zotero-API-Key"):
+            self._respond(401, {"error": "API key required"})
+            return
+        self._respond(200, {"success": {"0": "NEWKEY01"}, "unchanged": {}, "failed": {}})
+
+    def do_PATCH(self):
+        body = self._record("PATCH")
+        if not self.headers.get("Zotero-Server-ID"):
+            self._respond(428, {"error": "Zotero-Server-ID not provided"})
+            return
+        if not self.headers.get("Zotero-API-Key"):
+            self._respond(401, {"error": "API key required"})
+            return
+        # The real local API answers "400 Empty request body" when a PATCH
+        # arrives without a JSON content type, even though the bytes are
+        # there. The web API does not, so only a strict stub catches it.
+        if "json" not in (self.headers.get("Content-Type") or ""):
+            self._respond(400, {"error": "Empty request body"})
+            return
+        if not body:
+            self._respond(400, {"error": "Empty request body"})
+            return
+        self._respond(204)
+
+
+@pytest.fixture
+def stub_zotero():
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    server.requests = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def local_write_client(stub_zotero, monkeypatch):
+    """A real pyzotero client, pointed at the stub instead of port 23119."""
+    monkeypatch.setenv("ZOTERO_LOCAL", "true")
+    monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", GRANTED_KEY)
+    monkeypatch.setenv("ZOTERO_LOCAL_SERVER_ID", SERVER_ID)
+    zot = _client.get_local_write_client()
+    host, port = stub_zotero.server_address
+    zot.endpoint = f"http://{host}:{port}/api"
+    return zot
+
+
+def _writes(server):
+    return [r for r in server.requests if r["method"] in ("POST", "PATCH")]
+
+
+class TestHeadersOnTheWire:
+    def test_create_items_carries_both_required_headers(self, stub_zotero, local_write_client):
+        result = local_write_client.create_items(
+            [{"itemType": "journalArticle", "title": "Test"}]
+        )
+        assert result["success"] == {"0": "NEWKEY01"}
+
+        write = _writes(stub_zotero)[0]
+        assert write["headers"]["Zotero-Server-ID"] == SERVER_ID
+        assert write["headers"]["Zotero-API-Key"] == GRANTED_KEY
+        assert write["path"] == "/api/users/0/items"
+
+    def test_trash_shim_carries_them_too(self, stub_zotero, local_write_client):
+        """The old inline client.patch bypassed pyzotero's write dispatcher, so
+        it would have sent neither header and earned a 428."""
+        ok, detail = _helpers.trash_item(
+            local_write_client, {"key": "ITEM01", "version": 3}
+        )
+        assert (ok, detail) == (True, "")
+
+        write = _writes(stub_zotero)[0]
+        assert write["method"] == "PATCH"
+        assert write["headers"]["Zotero-Server-ID"] == SERVER_ID
+        assert write["headers"]["Zotero-API-Key"] == GRANTED_KEY
+        assert write["headers"]["If-Unmodified-Since-Version"] == "3"
+        # Without this the local API reports "400 Empty request body" even
+        # though the bytes are present.
+        assert "json" in write["headers"]["Content-Type"]
+        assert json.loads(write["body"]) == {"deleted": 1}
+
+    def test_a_write_without_the_key_is_reported_usefully(
+        self, stub_zotero, local_write_client
+    ):
+        local_write_client.local_api_key = None
+        ok, detail = _helpers.trash_item(
+            local_write_client, {"key": "ITEM01", "version": 3}
+        )
+        assert ok is False
+        assert "Always Allow" in detail
+
+
+class TestAuthorizeOverHttp:
+    def test_round_trip(self, stub_zotero, monkeypatch):
+        monkeypatch.setenv("ZOTERO_LOCAL", "true")
+        host, port = stub_zotero.server_address
+
+        real_zotero = _client.zotero.Zotero
+
+        def _pointed_at_stub(*args, **kwargs):
+            zot = real_zotero(*args, **kwargs)
+            zot.endpoint = f"http://{host}:{port}/api"
+            return zot
+
+        monkeypatch.setattr(_client.zotero, "Zotero", _pointed_at_stub)
+
+        result = _client.authorize_local_api("Test App")
+        assert result["key"] == GRANTED_KEY
+        assert result["server_id"] == SERVER_ID
+
+        request = next(r for r in stub_zotero.requests if "authorize" in r["path"])
+        assert request["path"] == "/api/local/authorize"
+        assert json.loads(request["body"]) == {"appName": "Test App"}
+        # The spec requires the server id on the authorize call as well.
+        assert request["headers"]["Zotero-Server-ID"] == SERVER_ID
+
+        # And the granted key is what later writes will pick up.
+        assert _client.get_local_write_credentials()[0] == GRANTED_KEY
+
+    def test_server_id_is_discovered_when_not_supplied(self, stub_zotero, monkeypatch):
+        """pyzotero reads it off any response; GET /api/ is the cheap one."""
+        monkeypatch.setenv("ZOTERO_LOCAL", "true")
+        host, port = stub_zotero.server_address
+
+        real_zotero = _client.zotero.Zotero
+
+        def _pointed_at_stub(*args, **kwargs):
+            kwargs.pop("server_id", None)
+            zot = real_zotero(*args, **kwargs)
+            zot.endpoint = f"http://{host}:{port}/api"
+            return zot
+
+        monkeypatch.setattr(_client.zotero, "Zotero", _pointed_at_stub)
+        result = _client.authorize_local_api("Test App")
+        assert result["server_id"] == SERVER_ID
+        assert any(r["path"] == "/api/" for r in stub_zotero.requests)

--- a/tests/test_local_write_shims.py
+++ b/tests/test_local_write_shims.py
@@ -1,0 +1,267 @@
+"""Tests for the shims that let one call site drive either Zotero backend."""
+
+import json
+
+import pytest
+from conftest import DummyContext, FakeLocalZotero, _FakeResponse
+from pyzotero.errors import CallDoesNotExistError, LocalAPIKeyRequiredError
+
+from zotero_mcp import client as _client
+from zotero_mcp.tools import _helpers
+
+
+@pytest.fixture(autouse=True)
+def _clear_template_cache():
+    _helpers._local_template_cache.clear()
+    yield
+    _helpers._local_template_cache.clear()
+
+
+class TestItemTemplateFor:
+    def test_uses_the_endpoint_when_it_exists(self, fake_zot):
+        template = _helpers.item_template_for(fake_zot, "journalArticle")
+        assert template["itemType"] == "journalArticle"
+        assert "publicationTitle" in template
+
+    def test_passes_the_link_mode_through(self, fake_zot):
+        calls = []
+        fake_zot.item_template = (
+            lambda t, linkmode=None: calls.append((t, linkmode)) or {"itemType": t}
+        )
+        _helpers.item_template_for(fake_zot, "attachment", "linked_url")
+        assert calls == [("attachment", "linked_url")]
+
+    def test_synthesizes_when_items_new_is_missing(self, fake_local_zot):
+        template = _helpers.item_template_for(fake_local_zot, "journalArticle")
+        assert template["itemType"] == "journalArticle"
+        # Built from item_type_fields, which the local API does implement.
+        assert template["title"] == ""
+        assert template["abstractNote"] == ""
+        # Universal keys no field endpoint reports.
+        assert template["creators"] == []
+        assert template["collections"] == []
+        assert template["relations"] == {}
+
+    def test_attachment_templates_match_the_web_response(self, fake_local_zot):
+        imported = _helpers.item_template_for(fake_local_zot, "attachment", "imported_file")
+        assert imported["linkMode"] == "imported_file"
+        assert set(imported) == {
+            "itemType", "linkMode", "title", "accessDate", "note", "tags",
+            "collections", "relations", "contentType", "charset", "filename",
+            "md5", "mtime",
+        }
+
+        linked = _helpers.item_template_for(fake_local_zot, "attachment", "linked_url")
+        assert linked["linkMode"] == "linked_url"
+        assert "url" in linked
+        assert "filename" not in linked
+
+    def test_note_template(self, fake_local_zot):
+        assert _helpers.item_template_for(fake_local_zot, "note") == {
+            "itemType": "note", "note": "", "tags": [], "collections": [], "relations": {},
+        }
+
+    def test_synthesized_templates_are_cached(self, fake_local_zot):
+        calls = []
+        fake_local_zot.item_type_fields = lambda t: calls.append(t) or [{"field": "title"}]
+        for _ in range(3):
+            _helpers.item_template_for(fake_local_zot, "journalArticle")
+        assert calls == ["journalArticle"]
+
+    def test_callers_cannot_corrupt_the_cache(self, fake_local_zot):
+        first = _helpers.item_template_for(fake_local_zot, "journalArticle")
+        first["title"] = "mutated"
+        second = _helpers.item_template_for(fake_local_zot, "journalArticle")
+        assert second["title"] == ""
+
+    def test_unrelated_errors_are_not_swallowed(self, fake_zot):
+        def _boom(item_type, link_mode=None):
+            raise RuntimeError("network down")
+
+        fake_zot.item_template = _boom
+        with pytest.raises(RuntimeError, match="network down"):
+            _helpers.item_template_for(fake_zot, "journalArticle")
+
+
+class TestAttachFiles:
+    def test_uses_attachment_both_on_the_web_api(self, fake_zot, tmp_path):
+        pdf = tmp_path / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+        result = _helpers.attach_files(fake_zot, [("Paper", str(pdf))], parentid="P1")
+        assert result["success"] == [{"key": "ATT00001"}]
+        assert fake_zot.attached == [([("Paper", str(pdf))], "P1")]
+        assert fake_zot.uploaded == []
+
+    def test_uploads_hand_built_items_on_the_local_api(self, fake_local_zot, tmp_path):
+        pdf = tmp_path / "paper.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+        result = _helpers.attach_files(fake_local_zot, [("Paper", str(pdf))], parentid="P1")
+        assert result["success"] == [{"key": "ATT00001"}]
+
+        (payload, parentid) = fake_local_zot.uploaded[0]
+        assert parentid == "P1"
+        attachment = payload[0]
+        assert attachment["title"] == "Paper"
+        assert attachment["linkMode"] == "imported_file"
+        assert attachment["contentType"] == "application/pdf"
+        # Zupload resolves filename against basedir to read the bytes, so it
+        # needs the path, not the display name.
+        assert attachment["filename"] == str(pdf)
+
+    def test_unknown_extension_falls_back_to_octet_stream(self, fake_local_zot, tmp_path):
+        blob = tmp_path / "data.zzz"
+        blob.write_bytes(b"x")
+        _helpers.attach_files(fake_local_zot, [("Data", str(blob))])
+        assert fake_local_zot.uploaded[0][0][0]["contentType"] == "application/octet-stream"
+
+    def test_both_backends_return_the_same_shape(self, fake_zot, fake_local_zot, tmp_path):
+        pdf = tmp_path / "p.pdf"
+        pdf.write_bytes(b"%PDF")
+        web = _helpers.attach_files(fake_zot, [("P", str(pdf))])
+        local = _helpers.attach_files(fake_local_zot, [("P", str(pdf))])
+        assert set(web) == set(local) == {"success", "unchanged", "failure"}
+
+
+class TestWebdavSkip:
+    def test_skipped_for_local_uploads(self, monkeypatch, fake_local_zot):
+        """Bytes uploaded through the local API are already in Zotero's own
+        storage; the desktop syncs them to WebDAV itself."""
+        monkeypatch.setattr("zotero_mcp.webdav.is_webdav_configured", lambda: True)
+        result = _helpers._maybe_upload_to_webdav(
+            {"success": [{"key": "ATT1"}]}, "/tmp/x.pdf", DummyContext(),
+            write_zot=fake_local_zot,
+        )
+        assert result == ""
+
+    def test_still_runs_for_web_uploads(self, monkeypatch, fake_zot):
+        monkeypatch.setattr("zotero_mcp.webdav.is_webdav_configured", lambda: True)
+        uploaded = []
+        monkeypatch.setattr(
+            "zotero_mcp.webdav.upload_attachment_to_webdav",
+            lambda attachment_key, file_path: uploaded.append(attachment_key),
+        )
+        result = _helpers._maybe_upload_to_webdav(
+            {"success": [{"key": "ATT1"}]}, "/tmp/x.pdf", DummyContext(),
+            write_zot=fake_zot,
+        )
+        assert uploaded == ["ATT1"]
+        assert "uploaded to WebDAV" in result
+
+
+class TestTrashItem:
+    def _item(self):
+        return {"key": "ITEM01", "version": 7, "data": {"key": "ITEM01"}}
+
+    def test_routes_through_write_so_the_headers_are_attached(self, fake_local_zot):
+        ok, detail = _helpers.trash_item(fake_local_zot, self._item())
+        assert (ok, detail) == (True, "")
+        method, url, kwargs = fake_local_zot.writes[0]
+        assert method == "PATCH"
+        assert url.endswith("/users/0/items/ITEM01")
+        assert kwargs["headers"]["If-Unmodified-Since-Version"] == "7"
+        assert json.loads(kwargs["content"]) == {"deleted": 1}
+
+    def test_falls_back_to_client_patch_without_write(self):
+        """Keeps working against clients (and test doubles) that predate the
+        _write dispatcher."""
+        calls = []
+
+        class _Legacy:
+            local = False
+            endpoint = "https://api.zotero.org"
+            library_type = "users"
+            library_id = "123"
+
+            class client:
+                @staticmethod
+                def patch(url, headers, content):
+                    calls.append((url, headers, content))
+                    return _FakeResponse(204)
+
+        ok, _detail = _helpers.trash_item(_Legacy(), self._item())
+        assert ok is True
+        assert len(calls) == 1
+
+    def test_maps_a_local_401_to_advice(self):
+        """_write returns the response without raising, so the status has to
+        be interpreted here."""
+        zot = FakeLocalZotero(write_status=401)
+        ok, detail = _helpers.trash_item(zot, self._item())
+        assert ok is False
+        assert "Always Allow" in detail
+
+    def test_reports_a_version_conflict_plainly(self):
+        zot = FakeLocalZotero(write_status=412)
+        ok, detail = _helpers.trash_item(zot, self._item())
+        assert ok is False
+        assert "changed in Zotero" in detail
+
+
+class TestErrorMessages:
+    def test_local_key_required(self):
+        msg = _helpers.format_zotero_error(LocalAPIKeyRequiredError("401"))
+        assert "single-use" in msg
+        assert "authorize-local" in msg
+
+    def test_a_generic_401_from_a_local_client_still_gets_advice(self, fake_local_zot):
+        """pyzotero picks the specific class by matching the response body, so
+        a 401 whose body doesn't match arrives as a plain error."""
+        msg = _helpers.describe_write_failure(_FakeResponse(401), fake_local_zot)
+        assert "Always Allow" in msg
+
+    def test_a_401_from_the_web_api_is_left_alone(self, fake_zot):
+        msg = _helpers.describe_write_failure(_FakeResponse(401, "Forbidden"), fake_zot)
+        assert "Always Allow" not in msg
+        assert "401" in msg
+
+    def test_server_id_mismatch_drops_the_unusable_key(self, fake_local_zot):
+        _client.store_local_write_credentials("stale", "old-srv", remember=True)
+        msg = _helpers.describe_write_failure(
+            _FakeResponse(412, "Zotero-Server-ID does not match"), fake_local_zot
+        )
+        assert "different Zotero database" in msg
+        assert _client.get_local_write_credentials() == (None, None, None)
+
+    def test_missing_server_id_reads_as_a_bug(self, fake_local_zot):
+        msg = _helpers.describe_write_failure(_FakeResponse(428), fake_local_zot)
+        assert "Internal error" in msg
+
+    def test_single_use_note_is_added_when_we_know(self, fake_local_zot, monkeypatch):
+        monkeypatch.setattr(_client, "_local_write_state",
+                            {"key": "k", "server_id": "srv", "remember": False})
+        msg = _helpers.describe_write_failure(_FakeResponse(401), fake_local_zot)
+        assert "granted with \"Allow\"" in msg
+
+    def test_a_rejected_key_is_dropped_so_the_next_write_can_fall_back(
+        self, fake_local_zot
+    ):
+        """A local 401 means the key is dead. Keeping it would outrank working
+        web credentials on every subsequent write."""
+        _client.store_local_write_credentials("dead", "srv", remember=True)
+        _helpers.describe_write_failure(_FakeResponse(401), fake_local_zot)
+        assert _client.get_local_write_credentials() == (None, None, None)
+
+    def test_points_at_the_web_fallback_when_one_exists(self, fake_local_zot, monkeypatch):
+        monkeypatch.setenv("ZOTERO_API_KEY", "webkey")
+        monkeypatch.setenv("ZOTERO_LIBRARY_ID", "123")
+        _client.store_local_write_credentials("dead", "srv", remember=True)
+        msg = _helpers.describe_write_failure(_FakeResponse(401), fake_local_zot)
+        assert "next write will use those" in msg
+
+    def test_asks_for_reauthorization_when_there_is_no_fallback(
+        self, fake_local_zot, monkeypatch
+    ):
+        monkeypatch.delenv("ZOTERO_API_KEY", raising=False)
+        monkeypatch.delenv("ZOTERO_LIBRARY_ID", raising=False)
+        _client.store_local_write_credentials("dead", "srv", remember=True)
+        msg = _helpers.describe_write_failure(_FakeResponse(401), fake_local_zot)
+        assert "authorize-local" in msg
+
+    def test_unknown_errors_pass_through_unchanged(self):
+        assert _helpers.format_zotero_error(ValueError("something else")) == "something else"
+
+    def test_missing_items_new_endpoint_should_never_surface(self, fake_local_zot):
+        msg = _helpers.format_zotero_error(
+            CallDoesNotExistError("no /items/new"), fake_local_zot
+        )
+        assert "report" in msg

--- a/tests/test_skill_reference_current.py
+++ b/tests/test_skill_reference_current.py
@@ -110,15 +110,42 @@ class TestSkillAccuracy:
 
 def test_generator_is_executable_and_idempotent(tmp_path):
     """Running it twice must not produce a diff -- otherwise the staleness
-    test above would fail on every second commit."""
+    test above would fail on every second commit.
+
+    Generated into tmp_path, never over the checked-in copy: writing to the
+    tracked file left the working tree dirty after every test run, and on
+    Windows it rewrote the whole file in CRLF as it went.
+    """
+    out = tmp_path / "reference.md"
+
     first = subprocess.run(
-        [sys.executable, str(GENERATOR)], capture_output=True, text=True, cwd=REPO
+        [sys.executable, str(GENERATOR), str(out)],
+        capture_output=True, text=True, cwd=REPO,
     )
     assert first.returncode == 0, first.stderr
-    after_first = REFERENCE.read_text(encoding="utf-8")
+    after_first = out.read_bytes()
 
     second = subprocess.run(
-        [sys.executable, str(GENERATOR)], capture_output=True, text=True, cwd=REPO
+        [sys.executable, str(GENERATOR), str(out)],
+        capture_output=True, text=True, cwd=REPO,
     )
     assert second.returncode == 0, second.stderr
-    assert REFERENCE.read_text(encoding="utf-8") == after_first
+    assert out.read_bytes() == after_first
+
+
+def test_generator_writes_lf_line_endings(tmp_path):
+    """Compared on bytes, deliberately: read_text() turns CRLF into LF on the
+    way in, so a text comparison can never see the drift it is meant to catch.
+    """
+    out = tmp_path / "reference.md"
+    proc = subprocess.run(
+        [sys.executable, str(GENERATOR), str(out)],
+        capture_output=True, text=True, cwd=REPO,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert b"\r\n" not in out.read_bytes()
+
+
+def test_checked_in_reference_uses_lf_line_endings():
+    """The tracked copy is LF like the rest of the repo."""
+    assert b"\r\n" not in REFERENCE.read_bytes()

--- a/tests/test_update_lock_reliability.py
+++ b/tests/test_update_lock_reliability.py
@@ -32,6 +32,36 @@ def test_read_lock_holder_live_pid(tmp_path):
     assert alive is True
 
 
+def test_pid_is_alive_never_calls_os_kill_on_windows(monkeypatch):
+    """``os.kill(pid, 0)`` is a Ctrl+C broadcast on Windows, not a probe.
+
+    ``signal.CTRL_C_EVENT`` is 0, so the POSIX idiom hands
+    ``GenerateConsoleCtrlEvent`` a real console control event, which lands on
+    every process sharing the console. It interrupted this suite at 97% and
+    took down whatever shell launched it. Nothing on this path may reach
+    ``os.kill`` while the platform is Windows.
+    """
+    if sys.platform != "win32":
+        pytest.skip("the os.kill routing under test is Windows-only")
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError("os.kill must never run on Windows")
+
+    monkeypatch.setattr(os, "kill", _forbidden)
+    assert semantic_search._pid_is_alive(os.getpid()) is True
+
+
+@skip_on_ci
+def test_pid_is_alive_agrees_with_reality():
+    """Own pid is alive; a pid that cannot exist is not.
+
+    Shares ``test_read_lock_holder_dead_pid``'s 999999 and so shares its
+    skip: the value is only *essentially* certain to be free.
+    """
+    assert semantic_search._pid_is_alive(os.getpid()) is True
+    assert semantic_search._pid_is_alive(999999) is False
+
+
 @skip_on_ci
 def test_read_lock_holder_dead_pid(tmp_path):
     lock = tmp_path / "update.lock"

--- a/tests/test_write_client_resolution.py
+++ b/tests/test_write_client_resolution.py
@@ -1,0 +1,180 @@
+"""Tests for the single write-client resolution path and its error message."""
+
+import time
+
+import pytest
+from conftest import DummyContext
+
+from zotero_mcp import client as _client
+from zotero_mcp.tools import _helpers
+
+
+@pytest.fixture
+def local_mode(monkeypatch):
+    monkeypatch.setenv("ZOTERO_LOCAL", "true")
+    monkeypatch.delenv("ZOTERO_API_KEY", raising=False)
+    monkeypatch.delenv("ZOTERO_LIBRARY_ID", raising=False)
+
+
+@pytest.fixture
+def web_mode(monkeypatch):
+    monkeypatch.delenv("ZOTERO_LOCAL", raising=False)
+    monkeypatch.setenv("ZOTERO_API_KEY", "webkey")
+    monkeypatch.setenv("ZOTERO_LIBRARY_ID", "123")
+
+
+def _server_supports_local_writes():
+    _client._local_probe_cache.update(
+        {"server_id": "srv-1", "checked_at": time.monotonic()}
+    )
+
+
+class TestResolutionOrder:
+    def test_web_mode_uses_one_client_for_both(self, web_mode, monkeypatch, fake_zot):
+        monkeypatch.setattr(_client, "get_zotero_client", lambda: fake_zot)
+        read, write, mode = _helpers.resolve_write_client()
+        assert mode == "web"
+        assert read is write is fake_zot
+
+    def test_local_key_wins_over_web_credentials(
+        self, local_mode, monkeypatch, fake_zot, fake_local_zot
+    ):
+        monkeypatch.setenv("ZOTERO_API_KEY", "webkey")
+        monkeypatch.setenv("ZOTERO_LIBRARY_ID", "123")
+        monkeypatch.setattr(_client, "get_local_write_client", lambda: fake_local_zot)
+        monkeypatch.setattr(_client, "get_web_zotero_client", lambda: fake_zot)
+        _read, write, mode = _helpers.resolve_write_client()
+        assert mode == "local"
+        assert write is fake_local_zot
+
+    def test_local_mode_reads_and_writes_through_the_same_client(
+        self, local_mode, monkeypatch, fake_local_zot
+    ):
+        """Local object versions are scoped to the Zotero database that issued
+        them, so a read from one backend can't validate a write to another."""
+        monkeypatch.setattr(_client, "get_local_write_client", lambda: fake_local_zot)
+        read, write, _mode = _helpers.resolve_write_client()
+        assert read is write is fake_local_zot
+
+    def test_falls_back_to_hybrid_without_a_local_key(
+        self, local_mode, monkeypatch, fake_zot
+    ):
+        web = object()
+        monkeypatch.setattr(_client, "get_local_write_client", lambda: None)
+        monkeypatch.setattr(_client, "get_web_zotero_client", lambda: web)
+        monkeypatch.setattr(_client, "get_zotero_client", lambda: fake_zot)
+        read, write, mode = _helpers.resolve_write_client()
+        assert mode == "hybrid"
+        assert read is fake_zot
+        assert write is web
+
+    def test_raises_when_nothing_can_write(self, local_mode, monkeypatch):
+        monkeypatch.setattr(_client, "get_local_write_client", lambda: None)
+        monkeypatch.setattr(_client, "get_web_zotero_client", lambda: None)
+        with pytest.raises(ValueError, match="Cannot perform write"):
+            _helpers.resolve_write_client()
+
+    def test_group_override_reaches_the_local_write_client(
+        self, local_mode, monkeypatch
+    ):
+        """Uses the real factory: it is the thing that reads the override."""
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "k")
+        _client.set_active_library("99", "group")
+        try:
+            _read, write, _mode = _helpers.resolve_write_client()
+            assert write.library_id == "99"
+            # Singular in the override, plural in the URL path pyzotero builds.
+            assert write.library_type == "groups"
+        finally:
+            _client.clear_active_library()
+
+    def test_a_user_library_override_cannot_break_the_users_zero_mapping(
+        self, local_mode, monkeypatch
+    ):
+        """zotero_switch_library reports the SQLite libraryID (typically 1) for
+        the local user library, but the local API only serves users/0. Applying
+        the override on top of the factory's mapping sent every write to a
+        library that does not exist."""
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "k")
+        _client.set_active_library("1", "user")
+        try:
+            _read, write, mode = _helpers.resolve_write_client()
+            assert mode == "local"
+            assert (write.library_type, write.library_id) == ("users", "0")
+        finally:
+            _client.clear_active_library()
+
+
+class TestBackwardCompatibleWrapper:
+    def test_still_returns_a_pair(self, web_mode, monkeypatch, fake_zot):
+        monkeypatch.setattr(_client, "get_zotero_client", lambda: fake_zot)
+        assert _helpers._get_write_client(None) == (fake_zot, fake_zot)
+
+    def test_raises_valueerror_for_the_tools_to_catch(self, local_mode, monkeypatch):
+        monkeypatch.setattr(_client, "get_local_write_client", lambda: None)
+        monkeypatch.setattr(_client, "get_web_zotero_client", lambda: None)
+        with pytest.raises(ValueError):
+            _helpers._get_write_client(None)
+
+
+class TestRecoveryAfterARejectedKey:
+    def test_next_write_falls_back_to_the_web_api(self, local_mode, monkeypatch, fake_zot):
+        """A consumed single-use key must not permanently shadow working web
+        credentials — that would be a regression for existing hybrid users."""
+        from conftest import FakeLocalZotero, _FakeResponse
+
+        monkeypatch.setenv("ZOTERO_API_KEY", "webkey")
+        monkeypatch.setenv("ZOTERO_LIBRARY_ID", "123")
+        monkeypatch.setenv("ZOTERO_LOCAL_API_KEY", "consumed")
+        monkeypatch.setattr(_client, "get_web_zotero_client", lambda: fake_zot)
+        monkeypatch.setattr(_client, "get_zotero_client", lambda: fake_zot)
+
+        assert _helpers.resolve_write_client()[2] == "local"
+
+        # The write comes back 401: the key is dead and gets dropped.
+        _helpers.describe_write_failure(_FakeResponse(401), FakeLocalZotero())
+        monkeypatch.delenv("ZOTERO_LOCAL_API_KEY")
+
+        assert _helpers.resolve_write_client()[2] == "hybrid"
+
+
+class TestCallersUseTheResolver:
+    def test_batch_update_tags_does_not_build_its_own_read_client(
+        self, monkeypatch, fake_zot
+    ):
+        """A separately-built read client makes `write_zot is not zot` always
+        true, so every item pays for a re-fetch it doesn't need."""
+        from zotero_mcp import server
+
+        def _forbidden():
+            raise AssertionError("should take the read client from the resolver")
+
+        monkeypatch.setattr(
+            "zotero_mcp.tools._helpers._get_write_client", lambda ctx: (fake_zot, fake_zot)
+        )
+        monkeypatch.setattr(_client, "get_zotero_client", _forbidden)
+
+        fake_zot.add_parameters = lambda **kwargs: None
+        result = server.batch_update_tags(
+            query="anything", add_tags=["x"], ctx=DummyContext()
+        )
+        assert "Error" not in result
+
+
+class TestUnavailableMessage:
+    def test_leads_with_authorizing_when_the_server_supports_it(self):
+        _server_supports_local_writes()
+        msg = _helpers.write_unavailable_message()
+        assert "Cannot perform write operations" in msg
+        assert msg.index("authorize-local") < msg.index("ZOTERO_API_KEY")
+
+    def test_leads_with_web_credentials_on_an_older_zotero(self):
+        msg = _helpers.write_unavailable_message()
+        assert "Zotero 10 or newer" in msg
+        assert msg.index("ZOTERO_API_KEY") < msg.index("authorize-local")
+
+    def test_names_the_operation(self):
+        assert "creating notes" in _helpers.write_unavailable_message("creating notes")
+
+    def test_keeps_the_phrase_the_write_tools_are_tested_against(self):
+        assert "local-only mode" in _helpers.write_unavailable_message()


### PR DESCRIPTION
Zotero's local API was read-only for most of its life, so every mutation in this server went through the Zotero web API — meaning local-mode users needed cloud credentials to write at all, and writes that did land took a sync round-trip to come back. Zotero 10 added local write endpoints, and pyzotero 1.14.0 wraps them.

On Zotero 10 a local-only user can now create items, edit metadata, manage collections and tags, write notes and annotations, trash things, and attach files with no zotero.org account. That also sidesteps the Zotero Storage quota behind the HTTP 413 attachment failures (#399) and the cloud-only attachments of #463. Users on older Zotero are unaffected: the existing hybrid path stays as the automatic fallback, chosen by a runtime capability probe rather than a version guess.

Getting the key
  Writes need a local API key, unrelated to a zotero.org key and impossible to
  create in advance — Zotero grants it through a dialog. `zotero-mcp
  authorize-local` drives that, and the zotero_authorize_local_writes and
  zotero_write_capabilities tools let an MCP client do the same without a
  shell. A remembered key is stored in its own `local_api` section of
  ~/.config/zotero-mcp/config.json, not in `client_env`, which `zotero-mcp
  setup` rebuilds from scratch and would silently drop.

  A single-use key (plain "Allow") is deliberately never written to disk: it is
  consumed by the first write, and a dead key on disk would outrank working web
  credentials on every later run. A key Zotero rejects is dropped for the same
  reason, so the next write can fall back instead of failing forever.

Three shims, because the local API has no /items/new
  item_template() raises there, and attachment_simple/attachment_both fail
  transitively through it. Templates are synthesized from the field endpoints,
  with the attachment and note shapes reproduced verbatim from
  api.zotero.org/items/new; attachments route to upload_attachments; and the
  four trash PATCHes now go through pyzotero's write dispatcher, which is what
  attaches the headers a local write requires.

  Those PATCHes also needed an explicit Content-Type: httpx infers none for a
  raw body, and the local API answers "400 Empty request body" without it. The
  web API tolerates its absence, which is why it went unnoticed while writes
  were cloud-only.

One write path
  The three divergent gateways in write.py, annotations.py and the two inline
  annotation checks collapse into one resolver returning (read, write, mode).
  When nothing can write, the message names both remedies and leads with
  whichever one applies to the running Zotero.

Also fixed
  - The injected local httpx client had no timeout and inherited httpx's 5s default. Reads were unaffected (pyzotero passes its own on read paths) but every write shared that budget, and it made the authorization dialog impossible to answer in time.
  - The zotero.org API key is no longer sent to localhost:23119. Restoring pyzotero's default headers would have turned it into an Authorization bearer aimed at a server that has no use for it.
  - A config file that exists but cannot be parsed is no longer silently replaced, and writes are atomic — the same file holds semantic_search and client_env.
  - test_description_tokens.py and test_add_from_file.py could not run on Windows at all (locale codec, and a monkeypatch assuming str paths).
  - The bibtex place-field tests depended on whether Zotero happened to be running, since generate_bibtex prefers Better BibTeX.

Verified against a live Zotero 10.0: authorization, item/collection/tag/note creation and edits, a file attachment landing in Zotero's own storage with a matching MD5, trashing, and a rejected key producing an actionable error and self-healing. 1,020 tests pass.