### PR TITLE
fix: report a partly-skipped update as partial, not as success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **`zotero_set_item_parent` sets or clears an item's parent.** It can parent standalone notes and attachments, move them between parents, or make them top-level again.
 
+### Fixed
+- **`zotero_update_item` no longer reports a write that dropped fields as a success.** Fields that are not valid for the item's type are skipped rather than written — correct — but the result still opened with "Successfully updated item", with the skip list appended below the diff. To a caller that reads as "done", which is how an item stays the wrong type indefinitely: the very fields that would repair it are discarded on every attempt and nothing in the outcome says the request failed. A partial write now says so in the headline (`Partially updated item \`KEY\` — 1 applied, 2 skipped`), a fully-rejected one returns "No fields applied" instead of "No changes to apply", and both name the remedy — `item_type` migrates the item so the fields become valid. A clean write is unchanged. A valid field whose value already matches still counts as accepted, so an unchanged value is never miscounted as a rejection. Reported by the systematic-review agent, which hit it repairing a `webpage` item that should have been a `journalArticle`.
+
 ## [0.9.1] - 2026-08-05
 
 ### Changed

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1961,6 +1961,10 @@ def update_item(
 
         known_fields = _schema.valid_fields(item_type)
         skipped = []
+        # Counted separately from ``changes``: a valid field whose value
+        # already matches records no change but was still accepted, so the
+        # request was not "every field invalid".
+        accepted = 0
         for field, value in field_updates.items():
             actual = _schema.resolve_field(item_type, field)
             param_name = _UPDATE_ITEM_API_TO_PARAM.get(field, field)
@@ -1968,6 +1972,7 @@ def update_item(
             if not is_valid:
                 skipped.append(param_name)
                 continue
+            accepted += 1
             if actual in data:
                 old = data[actual]
                 if old != value:
@@ -2030,24 +2035,44 @@ def update_item(
                     f"- **collections**: replaced {old_collections} -> {deduped}"
                 )
 
+        # A skipped field is a dropped write, not a footnote. Reporting it
+        # under a "Successfully updated" headline reads as "done" to a caller,
+        # which is how an item can sit in the wrong type indefinitely: the
+        # fields that would make it right are silently discarded on every
+        # attempt. The headline states the partial outcome instead, and names
+        # the remedy — item_type migrates the item so the fields become valid.
         skip_warning = ""
         if skipped:
             item_type = data.get("itemType", "unknown")
             skip_warning = (
                 f"\n\nSkipped (not valid for item type "
                 f"'{item_type}'): {', '.join(skipped)}"
+                f"\nIf '{item_type}' is the wrong type for this item, pass "
+                f"item_type=... to migrate it; these fields can then be "
+                f"written."
             )
 
         if not changes:
+            # Every requested field was rejected — distinct from "the values
+            # you asked for were already set", which is a genuine no-op.
+            if skipped and not accepted:
+                return (
+                    f"No fields applied to item `{item_key}`: every requested "
+                    f"field is invalid for item type "
+                    f"'{data.get('itemType', 'unknown')}'." + skip_warning
+                )
             return "No changes to apply." + skip_warning
 
         resp = write_zot.update_item(item)
         if _helpers._handle_write_response(resp, ctx):
-            result = (
-                f"Successfully updated item `{item_key}`:\n\n"
-                + "\n".join(changes)
-            )
-            return result + skip_warning
+            if skipped:
+                headline = (
+                    f"Partially updated item `{item_key}` — "
+                    f"{len(changes)} applied, {len(skipped)} skipped:"
+                )
+            else:
+                headline = f"Successfully updated item `{item_key}`:"
+            return f"{headline}\n\n" + "\n".join(changes) + skip_warning
         return "Failed to update item: write operation returned failure"
 
     except ValueError as e:

--- a/tests/test_update_item.py
+++ b/tests/test_update_item.py
@@ -1374,7 +1374,11 @@ class TestUpdateItemSkippedFields:
         # edition should be applied (valid for book)
         assert len(fake.update_calls) == 1
         assert fake.update_calls[0]["data"]["edition"] == "2nd"
-        assert "Successfully" in result
+        # A write that dropped two of three fields is not a success. The
+        # headline has to say so, or a caller reads "done" and never learns
+        # the fields went nowhere.
+        assert "Partially updated" in result
+        assert "Successfully" not in result
         # issue and pages should be skipped (not valid for book)
         assert "issue" in result
         assert "pages" in result
@@ -1394,9 +1398,81 @@ class TestUpdateItemSkippedFields:
         )
 
         assert len(fake.update_calls) == 0
-        assert "No changes" in result
+        # "No changes to apply" understates this: changes were requested and
+        # every one of them was discarded.
+        assert "No fields applied" in result
         assert "issue" in result
         assert "pages" in result
+        # And the caller is told how to make them writable.
+        assert "item_type" in result
+
+    def test_clean_update_still_reports_success(self, monkeypatch):
+        """No skips means no hedging — the headline stays "Successfully"."""
+        item = _make_book_item()
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="BOOK1234",
+            fields={"edition": "2nd"},
+            ctx=DummyContext(),
+        )
+
+        assert "Successfully updated" in result
+        assert "Partially" not in result
+        assert "Skipped" not in result
+
+    def test_partial_headline_counts_applied_and_skipped(self, monkeypatch):
+        item = _make_book_item()
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="BOOK1234",
+            fields={"edition": "2nd", "issue": "3", "pages": "1-10"},
+            ctx=DummyContext(),
+        )
+
+        assert "1 applied, 2 skipped" in result
+
+    def test_unchanged_valid_field_is_not_reported_as_invalid(self, monkeypatch):
+        """A valid field whose value already matches is a no-op, not a
+        rejection — the "every requested field is invalid" wording must not
+        claim otherwise just because nothing moved."""
+        item = _make_book_item(publisher="OUP")
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="BOOK1234",
+            fields={"publisher": "OUP", "issue": "2"},
+            ctx=DummyContext(),
+        )
+
+        assert "No changes to apply" in result
+        assert "every requested field is invalid" not in result
+        # The skip is still surfaced.
+        assert "issue" in result
+
+    def test_nothing_requested_is_not_a_skip_report(self, monkeypatch):
+        """An empty update is still plain "No changes to apply" — nothing was
+        dropped, so there is nothing to warn about."""
+        item = _make_book_item()
+        fake = FakeZoteroForUpdate(items=[item])
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (fake, fake))
+
+        result = server.update_item(
+            item_key="BOOK1234",
+            fields={},
+            ctx=DummyContext(),
+        )
+
+        assert "No changes to apply" in result
+        assert "Skipped" not in result
 
     def test_existing_field_skipped_on_wrong_type(self, monkeypatch):
         """Existing fields (e.g., publication_title) should also warn if not valid for type."""


### PR DESCRIPTION
Fixes #475 — a write that dropped four of six fields reported as `Successfully updated`.

## What was wrong

`zotero_update_item` skips fields that are not valid for the item's type rather than writing them, which is right. It then returned "Successfully updated item `KEY`", the diff of what applied, and the skip list appended underneath.

A caller reads the headline. "Success with four fields dropped" reads as done, so nothing prompts a retry and nothing records that the write was incomplete. That is how an item stays the wrong type indefinitely: a `webpage` that should be a `journalArticle` rejects exactly the fields that would repair it, on every attempt, reporting success each time. For an automated caller doing bulk metadata repair, it is silently wrong data at scale.

And when *every* requested field was rejected, the result was "No changes to apply" — which implies nothing was asked for, rather than that everything asked for was discarded.

## What changed

- A partial write says so: `Partially updated item \`KEY\` — 1 applied, 2 skipped:`
- A fully-rejected write returns `No fields applied` rather than `No changes to apply`.
- Both name the remedy, since one exists and is not obvious: `item_type` migrates the item and the skipped fields become writable.
- A clean write still says `Successfully updated`. Hedging an unqualified success would be its own kind of noise.

Accepted fields are counted separately from changed ones. A valid field whose value already matches records no change but was not *rejected*, so the "every requested field is invalid" wording must not claim it was — an existing test covering exactly that case is what surfaced the distinction.

## Note for the reviewer

Two existing tests asserted the old strings and are updated.

The original report also asked for an `item_type` argument so a mis-typed item could be migrated. **That already exists on `main`** and works — the reporter was running 0.3.0. No change was needed there, and none is made.

## Testing

4 new tests, 2 updated in `tests/test_update_item.py`. Full suite green.

Verified through the MCP tool path against a real library: migrating a `webpage` to `journalArticle` while writing `publication_title`, `volume`, `issue` and `pages` now applies all of them with zero skipped, and reports a clean success.
