### PR TITLE
fix: map CrossRef's whole type vocabulary in add_by_doi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **`zotero_set_item_parent` sets or clears an item's parent.** It can parent standalone notes and attachments, move them between parents, or make them top-level again.
 
+### Fixed
+- **`zotero_add_by_doi` maps CrossRef's whole type vocabulary, instead of dropping fields for seventeen of its thirty types.** An unmapped type is not a labelling problem: the item is built from a Zotero template, and the `document` template has no `publicationTitle`, `volume`, `issue` or `pages`, so everything type-specific was discarded on the way in and nothing said so. `journal-issue`, `journal-volume`, `book-part`, `book-section`, `book-track`, `proceedings`, `reference-book`, `report-series` and nine others were all missing. The case that surfaced it was an ordinary journal article whose publisher registered it with CrossRef as `journal-issue`, sitting in a real library as a `document` with no journal, volume, issue or pages. `dataset` and `standard` now use Zotero's native types rather than `document`. Types with no Zotero equivalent (`component`, `grant`, `peer-review`, `other`) still become `document`, but by decision rather than by fallthrough — and a type outside the table entirely is now named in the result, with the `zotero_update_item(item_type=...)` remedy, so the next vocabulary addition cannot repeat the silent loss. Reported by the systematic-review agent, which found the mistyped items by cross-checking its library against CrossRef.
+
 ## [0.9.1] - 2026-08-05
 
 ### Changed

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -20,21 +20,79 @@ from zotero_mcp.utils import _paginate
 # Constants
 # ---------------------------------------------------------------------------
 
+# Crossref's own type vocabulary -> Zotero item types.
+#
+# An unmapped type does not merely get a wrong label: the caller writes
+# fields into an item template, and ``document`` has no publicationTitle,
+# volume, issue or pages, so everything type-specific is dropped on the
+# floor. Seventeen of Crossref's thirty types used to be missing here — a
+# journal article registered by its publisher as ``journal-issue`` arrived
+# as a ``document`` with the journal name, volume, issue and page range gone
+# and nothing said. So the table covers the whole vocabulary, and anything
+# genuinely outside it is reported rather than quietly defaulted (see
+# ``crossref_type_note``).
 CROSSREF_TYPE_MAP = {
     "journal-article": "journalArticle",
+    # Container types. Zotero has no record for "a whole issue" or "a whole
+    # volume", and publishers do mis-register ordinary articles as these —
+    # journalArticle keeps the journal, volume, issue and pages that the
+    # metadata actually carries, where document would discard all four.
+    "journal-issue": "journalArticle",
+    "journal-volume": "journalArticle",
+    "journal": "journalArticle",
     "book": "book",
+    "monograph": "book",
+    "edited-book": "book",
+    "reference-book": "book",
+    "book-set": "book",
+    "book-series": "book",
     "book-chapter": "bookSection",
+    "book-part": "bookSection",
+    "book-section": "bookSection",
+    "book-track": "bookSection",
     "proceedings-article": "conferencePaper",
+    # A proceedings volume is a book; the paper inside it is the
+    # conferencePaper above.
+    "proceedings": "book",
+    "proceedings-series": "book",
     "report": "report",
+    "report-series": "report",
+    "report-component": "report",
     "dissertation": "thesis",
     "posted-content": "preprint",
-    "monograph": "book",
     "reference-entry": "encyclopediaArticle",
-    "dataset": "document",
+    # Zotero grew native dataset and standard types; both used to land on
+    # document and lose their type-specific fields.
+    "dataset": "dataset",
+    "database": "dataset",
+    "standard": "standard",
+    # No Zotero equivalent, and document is the honest answer rather than a
+    # lossy guess: a component is a figure or supplement, not a work; a
+    # grant is funding; peer-review is a review of something else; "other"
+    # is Crossref saying it does not know either.
+    "component": "document",
+    "grant": "document",
     "peer-review": "document",
-    "edited-book": "book",
-    "standard": "document",
+    "other": "document",
 }
+
+
+def crossref_type_note(cr_type: str) -> str:
+    """A one-line warning when *cr_type* is outside the mapped vocabulary.
+
+    Returns "" for a mapped type. Crossref adds types over time, and the
+    failure mode of a lookup miss here is silent data loss — the item is
+    created as a ``document`` and every type-specific field is dropped — so
+    a miss is surfaced to the caller instead of being absorbed.
+    """
+    if not cr_type or cr_type in CROSSREF_TYPE_MAP:
+        return ""
+    return (
+        f"\nNote: CrossRef type '{cr_type}' is not one this version maps to a "
+        "Zotero type, so the item was created as 'document' and any journal, "
+        "volume, issue or page values were dropped. Set the right type with "
+        "zotero_update_item(item_type=...)."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1015,9 +1015,12 @@ def add_by_doi(
 
         cr = resp.json().get("message", {})
 
-        # Determine Zotero item type
+        # Determine Zotero item type. An unmapped type still becomes a
+        # document, but the caller is told so — the fields a document has no
+        # room for are dropped silently otherwise.
         cr_type = cr.get("type", "")
         zot_type = CROSSREF_TYPE_MAP.get(cr_type, "document")
+        type_note = _helpers.crossref_type_note(cr_type)
 
         # Get valid fields from item template
         template = write_zot.item_template(zot_type)
@@ -1121,7 +1124,8 @@ def add_by_doi(
                 f"Type: {zot_type}\n"
                 f"DOI: {normalized}\n"
                 f"Collections: {collections_status}\n"
-                f"PDF: {pdf_status}\n\n"
+                f"PDF: {pdf_status}\n"
+                f"{type_note}\n"
                 "_Note: To include this item in semantic search, run "
                 "zotero_update_search_database._"
             )

--- a/tests/test_crossref_type_coverage.py
+++ b/tests/test_crossref_type_coverage.py
@@ -1,0 +1,104 @@
+"""Every CrossRef type must map to a Zotero type, or say that it did not.
+
+An unmapped CrossRef type is not a labelling problem. ``add_by_doi`` writes
+its fields into an item template, and the ``document`` template has no
+``publicationTitle``, ``volume``, ``issue`` or ``pages`` — so an article that
+fell through arrived with all four missing and nothing reported.
+
+Seventeen of CrossRef's thirty types were missing from the table. The one
+that surfaced it: DOI 10.13165/vpa-20-19-2-04, an ordinary journal article
+its publisher registered as ``journal-issue``, sitting in a real library as a
+``document`` with no journal, volume, issue or pages.
+"""
+
+import pytest
+
+from zotero_mcp.tools._helpers import CROSSREF_TYPE_MAP, crossref_type_note
+
+# https://api.crossref.org/types
+CROSSREF_VOCABULARY = [
+    "book-section", "monograph", "report-component", "report", "peer-review",
+    "book-track", "journal-article", "book-part", "other", "book",
+    "journal-volume", "book-set", "reference-entry", "proceedings-article",
+    "journal", "component", "book-chapter", "proceedings-series",
+    "report-series", "proceedings", "database", "standard", "reference-book",
+    "posted-content", "journal-issue", "dissertation", "grant", "dataset",
+    "book-series", "edited-book",
+]
+
+# Zotero's item types, as of schema version 41.
+ZOTERO_ITEM_TYPES = {
+    "artwork", "audioRecording", "bill", "blogPost", "book", "bookSection",
+    "case", "computerProgram", "conferencePaper", "dataset", "dictionaryEntry",
+    "document", "email", "encyclopediaArticle", "film", "forumPost", "hearing",
+    "instantMessage", "interview", "journalArticle", "letter",
+    "magazineArticle", "manuscript", "map", "newspaperArticle", "patent",
+    "podcast", "preprint", "presentation", "radioBroadcast", "report",
+    "standard", "statute", "thesis", "tvBroadcast", "videoRecording",
+    "webpage",
+}
+
+
+class TestVocabularyCoverage:
+    @pytest.mark.parametrize("cr_type", CROSSREF_VOCABULARY)
+    def test_every_crossref_type_is_mapped(self, cr_type):
+        assert cr_type in CROSSREF_TYPE_MAP, (
+            f"CrossRef type {cr_type!r} falls through to 'document', which "
+            "has no publicationTitle/volume/issue/pages — those values are "
+            "dropped silently"
+        )
+
+    @pytest.mark.parametrize("zot_type", sorted(set(CROSSREF_TYPE_MAP.values())))
+    def test_every_target_is_a_real_zotero_type(self, zot_type):
+        assert zot_type in ZOTERO_ITEM_TYPES
+
+
+class TestSpecificMappings:
+    def test_journal_issue_keeps_article_fields(self):
+        """The reported case. Publishers do register articles as
+        'journal-issue'; journalArticle has somewhere to put the journal,
+        volume, issue and pages that document does not."""
+        assert CROSSREF_TYPE_MAP["journal-issue"] == "journalArticle"
+
+    def test_book_chapter_is_a_book_section(self):
+        assert CROSSREF_TYPE_MAP["book-chapter"] == "bookSection"
+
+    def test_every_book_part_spelling_agrees(self):
+        targets = {
+            CROSSREF_TYPE_MAP[t]
+            for t in ("book-chapter", "book-part", "book-section", "book-track")
+        }
+        assert targets == {"bookSection"}
+
+    def test_proceedings_article_is_not_the_proceedings_volume(self):
+        assert CROSSREF_TYPE_MAP["proceedings-article"] == "conferencePaper"
+        assert CROSSREF_TYPE_MAP["proceedings"] == "book"
+
+    def test_native_zotero_types_are_used(self):
+        """dataset and standard used to land on 'document' even though Zotero
+        has both types."""
+        assert CROSSREF_TYPE_MAP["dataset"] == "dataset"
+        assert CROSSREF_TYPE_MAP["standard"] == "standard"
+
+    def test_types_with_no_equivalent_stay_document(self):
+        """document is honest for these — a component is a figure, a grant is
+        funding. The point is that they are decided, not defaulted."""
+        for cr_type in ("component", "grant", "peer-review", "other"):
+            assert CROSSREF_TYPE_MAP[cr_type] == "document"
+
+
+class TestUnmappedTypeIsReported:
+    def test_mapped_type_produces_no_note(self):
+        assert crossref_type_note("journal-article") == ""
+
+    def test_empty_type_produces_no_note(self):
+        assert crossref_type_note("") == ""
+
+    def test_unknown_type_is_named_with_the_remedy(self):
+        """CrossRef adds types over time. A future one must not repeat the
+        silent-loss failure — the caller is told what happened and how to fix
+        it."""
+        note = crossref_type_note("holographic-monograph")
+        assert "holographic-monograph" in note
+        assert "document" in note
+        assert "item_type" in note

--- a/tests/test_shared_helpers.py
+++ b/tests/test_shared_helpers.py
@@ -298,8 +298,13 @@ class TestCrossrefTypeMap:
     def test_edited_book(self):
         assert server.CROSSREF_TYPE_MAP["edited-book"] == "book"
 
-    def test_standard_is_document(self):
-        assert server.CROSSREF_TYPE_MAP["standard"] == "document"
+    def test_standard_uses_the_native_zotero_type(self):
+        """Zotero has a `standard` item type; routing CrossRef's `standard`
+        to `document` discarded the fields that type exists to hold."""
+        assert server.CROSSREF_TYPE_MAP["standard"] == "standard"
+
+    def test_dataset_uses_the_native_zotero_type(self):
+        assert server.CROSSREF_TYPE_MAP["dataset"] == "dataset"
 
     def test_unknown_type_fallback(self):
         assert server.CROSSREF_TYPE_MAP.get("unknown-type", "document") == "document"


### PR DESCRIPTION
Fixes #476 — 17 of CrossRef's 30 types fell through to `document`, dropping journal, volume, issue and pages.

**Best reviewed together with the `fix/add-by-url-embedded-metadata` PR (#474).** See that PR's note; the two complete each other on the reported DOI.

## What was wrong

`add_by_doi` writes fields into an item template and keeps only what the template has room for. A `document` template has no `publicationTitle`, `volume`, `issue` or `pages` — so an article that missed the table arrived with all four gone, no warning, and no way to tell from the item that anything had been lost.

The case that surfaced it: an ordinary journal article whose publisher registered it with CrossRef as `journal-issue`, sitting in a real 15k-item library as a `document` with no journal, volume, issue or pages.

## What changed

- **Container types** (`journal-issue`, `journal-volume`, `journal`) → `journalArticle`. Zotero has no record for "a whole issue", publishers do register articles as these, and `journalArticle` has somewhere to put the values the metadata carries.
- **Book part spellings** (`book-part`, `book-section`, `book-track`) join `book-chapter` on `bookSection`.
- **`proceedings` / `proceedings-series`** → `book`, distinct from `proceedings-article`, which is the paper inside.
- **`dataset` and `standard`** → Zotero's native item types instead of `document`. Both existed all along while the table dropped their fields.
- Types with no Zotero equivalent (`component`, `grant`, `other`) still resolve to `document` — but by decision, not fallthrough.
- **An unmapped type is now reported.** CrossRef adds types over time, so full coverage today is not a fix on its own. A miss names the type, what was dropped, and the `zotero_update_item(item_type=...)` remedy.

The suggestion to stop treating a lookup miss as a confident assertion came from the reporting agent, and is the part of this worth keeping.

## Relationship to #465

Same defect, different table and different code path: #465 is `CSL_TYPE_MAP` in `citation_import.py` on the `csl_json` path, this is `CROSSREF_TYPE_MAP` in `tools/_helpers.py` on the `add_by_doi` path. #466 covers the other one, and has been extended with the same container types.

## Note for the reviewer

One existing test asserted `standard -> document` with no rationale, pinning the lossy behaviour. Updated, with the reasoning stated.

## Testing

50 new tests in `tests/test_crossref_type_coverage.py`, including a parametrised check that every type in CrossRef's published vocabulary is mapped and every target is a real Zotero item type — so the next vocabulary addition fails a test rather than silently dropping fields. Full suite green.

Verified against live CrossRef for the three DOIs in the report.
