### PR TITLE
fix: accept a stringified rect in zotero_create_annotation (#459)

### DIFF
--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -366,6 +366,37 @@ def _parse_library_id_param(value: int | str | None) -> int | None:
     return int(value)
 
 
+def _normalize_float_list_input(value, length, field_name="value"):
+    """Normalize a fixed-length numeric list that MCP clients may stringify.
+
+    Mirrors ``_normalize_str_list_input``: some MCP transports stringify
+    untyped/loosely-typed arguments before dispatch, so a client-side
+    ``[x, y, w, h]`` list can arrive here as the JSON text ``"[x, y, w, h]"``
+    instead. Returns ``None`` (never raises) when ``value`` is not a JSON
+    array of exactly ``length`` numbers, so callers keep their own
+    user-facing error message for the invalid-shape case.
+    """
+    if isinstance(value, (list, tuple)):
+        candidate = value
+    elif isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(parsed, list):
+            return None
+        candidate = parsed
+    else:
+        return None
+
+    if len(candidate) != length:
+        return None
+    try:
+        return [float(v) for v in candidate]
+    except (TypeError, ValueError):
+        return None
+
+
 def _normalize_str_list_input(value, field_name="value"):
     """Normalize list-like user input into a list of non-empty strings."""
     if value is None:

--- a/src/zotero_mcp/tools/annotations.py
+++ b/src/zotero_mcp/tools/annotations.py
@@ -1444,7 +1444,7 @@ def create_annotation(
     attachment_key: str,
     page: int,
     text: str | None = None,
-    rect: list[float] | None = None,
+    rect: list[float] | str | None = None,
     comment: str | None = None,
     color: str = "#ffd400",
     tags: list[str] | str | None = None,
@@ -1468,13 +1468,17 @@ def create_annotation(
         )
 
     if rect is not None:
-        if not isinstance(rect, (list, tuple)) or len(rect) != 4:
+        # MCP clients that stringify untyped params (same as the sibling
+        # `tags` parameter, see _helpers._normalize_str_list_input) may send
+        # rect as JSON text rather than a list.
+        normalized_rect = _helpers._normalize_float_list_input(rect, 4, "rect")
+        if normalized_rect is None:
             return (
                 "Error: rect must be exactly four numbers, "
                 "[x, y, width, height], normalized to 0-1. "
                 f"Got: {rect!r}"
             )
-        x, y, width, height = rect
+        x, y, width, height = normalized_rect
         return create_area_annotation(
             attachment_key=attachment_key,
             page=page,

--- a/tests/test_area_annotations.py
+++ b/tests/test_area_annotations.py
@@ -304,3 +304,83 @@ def test_create_annotation_rect_still_validates_geometry(monkeypatch):
     )
 
     assert "Rectangle must fit within the page width" in result
+
+
+def test_create_annotation_rect_accepts_stringified_json(monkeypatch, fake_zot):
+    """MCP clients that stringify untyped params send rect as a JSON string.
+
+    The sibling ``tags`` parameter on this same tool already tolerates this
+    (see ``_helpers._normalize_str_list_input``); rect must too.
+    """
+    fake_zot._items = [_pdf_attachment()]
+
+    monkeypatch.setattr("zotero_mcp.client.get_web_zotero_client", lambda: fake_zot)
+    monkeypatch.setattr("zotero_mcp.client.get_local_zotero_client", lambda: None)
+    monkeypatch.setattr("zotero_mcp.client.get_active_library", lambda: None)
+    _patch_fitz(monkeypatch, [FakePage(width=600, height=800, label="7")])
+
+    result = annotations.create_annotation(
+        attachment_key="ATTACH01",
+        page=1,
+        rect="[0.1, 0.2, 0.3, 0.4]",
+        comment="Figure detail",
+        ctx=DummyContext(),
+    )
+
+    assert "Successfully created area annotation" in result
+    created = fake_zot.created[0]
+    assert json.loads(created["annotationPosition"]) == {
+        "pageIndex": 0,
+        "rects": [[60.0, 320.0, 240.0, 640.0]],
+    }
+
+
+def test_create_annotation_rect_rejects_malformed_json_string():
+    result = annotations.create_annotation(
+        attachment_key="ATTACH01",
+        page=1,
+        rect="[0.1, 0.2, 0.3]",
+        ctx=DummyContext(),
+    )
+
+    assert "exactly four numbers" in result
+
+
+def test_create_annotation_rect_rejects_non_json_string():
+    result = annotations.create_annotation(
+        attachment_key="ATTACH01",
+        page=1,
+        rect="not json at all",
+        ctx=DummyContext(),
+    )
+
+    assert "exactly four numbers" in result
+
+
+def test_create_annotation_rect_rejects_non_list_json_string():
+    result = annotations.create_annotation(
+        attachment_key="ATTACH01",
+        page=1,
+        rect='{"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.4}',
+        ctx=DummyContext(),
+    )
+
+    assert "exactly four numbers" in result
+
+
+def test_create_annotation_rect_rejects_non_numeric_entries():
+    result = annotations.create_annotation(
+        attachment_key="ATTACH01",
+        page=1,
+        rect='["a", "b", "c", "d"]',
+        ctx=DummyContext(),
+    )
+
+    assert "exactly four numbers" in result
+
+
+def test_normalize_float_list_input_rejects_unsupported_type():
+    from zotero_mcp.tools._helpers import _normalize_float_list_input
+
+    assert _normalize_float_list_input(42, 4, "rect") is None
+    assert _normalize_float_list_input(None, 4, "rect") is None


### PR DESCRIPTION
## Root cause

`zotero_create_annotation`'s `rect` parameter was typed as `list[float] | None`
and dispatch checked `isinstance(rect, (list, tuple))`. The sibling `tags`
parameter on the same tool already tolerates a client that stringifies
untyped/loosely-typed arguments before dispatch (a common behavior for
JSON-schema-strict MCP transports), via `_helpers._normalize_str_list_input`.
`rect` had no equivalent, so a client sending `rect="[0.15, 0.22, 0.6, 0.35]"`
(JSON text) instead of an actual list got "rect must be exactly four numbers"
and area-mode annotation was unreachable through that transport.

## Fix

Added `_normalize_float_list_input` in `_helpers.py`, mirroring
`_normalize_str_list_input`'s JSON-parse fallback for a fixed-length numeric
list, and routed `rect` through it before the length/type check in
`create_annotation`. Invalid shapes (wrong length, non-numeric entries,
malformed JSON, unsupported types) still return the same "rect must be
exactly four numbers" message as before.

## Verified

- New regression tests in `tests/test_area_annotations.py`: fail on `main`
  (stringified rect rejected), pass on this branch, run in Docker
  (`python:3.10-slim` and `python:3.12-slim`, the CI matrix floor and ceiling).
- Full suite (`pytest --ignore=tests/test_lifespan.py`, matching CI's own
  command): 2379 passed, 16 skipped on both Python versions.
- Coverage: every changed/added line in `_helpers.py` and `annotations.py` is
  hit by the new tests (`coverage run --source=src/zotero_mcp/tools`).
- Not verified: macOS/Windows runners (CI's matrix includes both at 3.12).
  This change has no OS-specific dependency, but I only ran Linux containers.

Fixes #459.
