### PR TITLE
refactor: extract and test the realtime slice-sizing rule

### DIFF
--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -87,6 +87,17 @@ def _report(message: str) -> None:
         pass
 
 
+def _realtime_slice_size(max_parallel: int) -> int:
+    """How many items one preparation pass hands to the embedding workers.
+
+    Scales with parallelism so a single pass yields enough payloads to keep
+    every worker busy, and is capped so the classify step — which holds
+    ``_chroma_call_lock`` — stays short. The floor of 25 is the historical
+    sequential batch size, so an unparallelized run slices exactly as before.
+    """
+    return min(25 * max(1, max_parallel), 200)
+
+
 def _pid_is_alive(pid: int) -> bool:
     """Best-effort liveness check for a process id (POSIX ``kill(pid, 0)``)."""
     try:
@@ -2933,10 +2944,7 @@ class ZoteroSemanticSearch:
         synchronous path does, so the caller's end-of-run retry pass is shared
         between both paths.
         """
-        # Slices scale with parallelism so one preparation pass yields enough
-        # payloads to keep every worker busy, and are capped so the classify
-        # step — which holds _chroma_call_lock — stays short.
-        slice_size = min(25 * max(1, max_parallel), 200)
+        slice_size = _realtime_slice_size(max_parallel)
         request_batch_size = (
             getattr(embedding_function, "request_batch_size", None) or 64
         )

--- a/tests/test_streaming_indexing.py
+++ b/tests/test_streaming_indexing.py
@@ -539,3 +539,40 @@ def test_splitter_skips_items_that_produced_no_documents():
 def test_splitter_yields_nothing_for_an_empty_slice():
     """No documents means no requests at all."""
     assert list(semantic_search._split_prepared_into_requests(_prepared([]), 10)) == []
+
+
+# ---------------------------------------------------------------------------
+# Slice sizing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("max_parallel", "expected"),
+    [(1, 25), (2, 50), (4, 100), (8, 200), (16, 200), (64, 200)],
+)
+def test_realtime_slice_size_scales_then_caps(max_parallel, expected):
+    """Slices grow with parallelism so every worker has payloads waiting.
+
+    The 200 cap is not cosmetic: the classify step for a slice holds
+    _chroma_call_lock, so an uncapped slice would lengthen the window during
+    which nothing else can touch the collection.
+    """
+    assert semantic_search._realtime_slice_size(max_parallel) == expected
+
+
+@pytest.mark.parametrize("degenerate", [0, -1])
+def test_realtime_slice_size_floors_at_the_sequential_batch(degenerate):
+    """A non-positive worker count must still yield a usable slice size.
+
+    Both degenerate inputs break the producer, differently, if the floor is
+    removed: the slice size becomes the step of ``range(0, len(all_items),
+    slice_size)``, so a negative gives an empty range — the producer emits
+    nothing and the run reports success having indexed no items — and a zero
+    raises ``ValueError: range() arg 3 must not be zero``.
+
+    Zero is unreachable today because the call site coerces it (``... or 1``),
+    but a negative is not: ``-2 or 1`` is ``-2``, so a hand-edited
+    ``max_parallel_requests: -2`` reaches this function intact. The silent
+    variant is the one worth guarding against.
+    """
+    assert semantic_search._realtime_slice_size(degenerate) == 25


### PR DESCRIPTION
Small follow-up to #488, rebased onto `main` now that it has merged.

## What this is

The streaming indexing path decides how many items one preparation pass hands to the embedding workers:

```python
slice_size = min(25 * max(1, max_parallel), 200)
```

Written inline, never tested directly. Each part of the expression carries a consequence:

- **the `25` floor** is the historical sequential batch size, so an unparallelized run slices exactly as it did before the streaming path existed;
- **the multiplier** is what keeps every worker supplied — too small a slice and workers idle waiting on the producer;
- **the `200` cap** bounds how long the classify step holds `_chroma_call_lock`, trading throughput against the window in which nothing else can touch the collection.

A regression in any of them surfaces as a throughput or contention problem partway through a multi-hour run, which is the least convenient place to find one.

## The degenerate cases

`slice_size` becomes the step of `range(0, len(all_items), slice_size)`, so without the `max(1, …)` floor both non-positive inputs break the producer — differently:

| `max_parallel` | without the floor | effect |
|---|---|---|
| negative | `range(0, N, -50)` → `[]` | producer emits nothing; **the run reports success having indexed no items** |
| zero | `range(0, N, 0)` | `ValueError: range() arg 3 must not be zero` |

Only one is reachable. The call site coerces with `... or 1`, which turns `0` into `1` — but `-2 or 1` is `-2`, so a hand-edited `max_parallel_requests: -2` arrives intact. The silent variant is the one the floor exists for, and the one the test names.

## Scope

Behaviour is unchanged — the expression is identical, only relocated. This was originally part of #488 and pulled back out to keep that PR to the pipeline itself; it is offered separately so the choice to take it or leave it is yours.

## Testing

- `2692 passed, 42 skipped`, no failures.
- 8 of those are new here: six for the scale-then-cap behaviour, two for the non-positive floor.

## Commits

| | |
|---|---|
| `13bafcb` | refactor: extract and test the realtime slice-sizing rule |

2 files changed, +49 / −4.
