### PR TITLE
fix: serialize adds per normalized identifier (#486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Concurrent adds of the same identifier no longer create duplicates (#486).** The Zotero API lock exists to protect the single-threaded local API, and making check-then-create atomic was only ever a side effect of how wide it happened to be. Narrowing it — correctly, to keep CrossRef and page fetches out of a held lock — removed that side effect wherever a fetch now sits between the dedup check and the write, so two parallel tool calls could both pass the check and both create. Nothing downstream would catch it: the version-checked retry guards updates to an item that already exists, and two `create_items()` POSTs yield two new keys with no version to conflict on. Adds by DOI, ISBN, URL and arXiv ID now take a short-lived lock keyed on the *normalized* identifier — so ISBN-10 and ISBN-13 of one book, or a bare DOI and its doi.org URL, take the same lock — held across a re-check and the create only, never across third-party network work. An identifier that cannot be normalized takes no lock rather than sharing one, so a batch of junk tokens cannot serialize itself. This is in-process: it closes one server issuing parallel tool calls, which is the reported case and the normal shape for an agent driving this toolset; two servers against one library still race, and nothing here changes that.
+
 **Upgrading:** `zotero_semantic_search` now defaults to the active library instead of every indexed library. If you relied on the old implicit behaviour, pass `search_all_libraries=True`.
 
 ### Added

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -1,11 +1,13 @@
 """Shared private helpers used across tool modules."""
 
+import contextlib
 import hashlib
 import json
 import os
 import re
 import socket
 import tempfile
+import threading
 from ipaddress import ip_address
 from urllib.parse import urljoin, urlparse
 
@@ -907,6 +909,94 @@ def _collection_not_found_message(zot, spec, paths) -> str:
 #: stdlib-only :mod:`zotero_mcp.identifiers` so consumers can import it
 #: without pulling in the tool layer. Existing callers keep working.
 _normalize_doi = normalize_doi
+
+
+# ---------------------------------------------------------------------------
+# Per-identifier serialization of adds (#486)
+#
+# The Zotero API lock exists to protect the single-threaded local API on port
+# 23119. It never promised to make check-then-create atomic; that was a side
+# effect of how wide it used to be. Narrowing it — correctly, to keep CrossRef
+# and page fetches out of a held lock — removed that side effect wherever a
+# fetch now sits between the dedup check and the create, so two callers can
+# both pass the check and both create. The version-checked retry cannot close
+# it: two ``create_items()`` POSTs produce two new keys and no version to
+# conflict on.
+#
+# These locks are keyed on the *normalized* identifier, so ISBN-10 and ISBN-13
+# of one book take the same lock, and held across a re-check and the create
+# only — never across third-party network work, which is the whole point of
+# the narrowing.
+#
+# IN-PROCESS ONLY, and worth saying plainly: this serializes parallel tool
+# calls within one server, which is the reported case. Two servers against one
+# library still race, and nothing here changes that.
+# ---------------------------------------------------------------------------
+
+#: key -> [lock, waiter_count]. Entries are dropped once the last holder
+#: leaves, so a long indexing run does not accumulate one lock per identifier
+#: it has ever seen.
+_identifier_locks = {}
+_identifier_locks_guard = threading.Lock()
+
+
+def identifier_lock_key(kind, raw):
+    """Canonical lock key for an identifier, or ``None`` if it has none.
+
+    ``None`` means "take no lock": an identifier that cannot be normalized
+    cannot dedup-match anything either, so serializing on it buys nothing and
+    would make a batch of junk tokens queue behind each other. Kinds are part
+    of the key so a DOI and a URL that happen to stringify alike stay apart.
+    """
+    if raw is None:
+        return None
+    if kind == "doi":
+        normalized = normalize_doi(raw)
+    elif kind == "isbn":
+        normalized = _normalize_isbn(raw)
+    elif kind == "arxiv":
+        normalized = _normalize_arxiv_id(raw)
+    elif kind == "url":
+        # URLs have no normalizer, so this is exact-after-strip, matching what
+        # #443 settled on for collapsing repeats. Deliberately no case or
+        # trailing-slash folding: either can be a genuinely different page.
+        normalized = str(raw).strip() or None
+    else:
+        raise ValueError(f"unknown identifier kind {kind!r}")
+    return None if normalized is None else f"{kind}:{normalized}"
+
+
+@contextlib.contextmanager
+def identifier_lock(kind, raw):
+    """Serialize check-then-create for one identifier within this process.
+
+    Yields the lock key, or ``None`` when the identifier is unnormalizable and
+    no lock was taken. Re-entrant, because the add paths call into helpers
+    that may take the same identifier again — a plain ``Lock`` there would
+    wedge the process rather than fail loudly.
+    """
+    key = identifier_lock_key(kind, raw)
+    if key is None:
+        yield None
+        return
+
+    with _identifier_locks_guard:
+        entry = _identifier_locks.get(key)
+        if entry is None:
+            entry = _identifier_locks[key] = [threading.RLock(), 0]
+        entry[1] += 1
+
+    entry[0].acquire()
+    try:
+        yield key
+    finally:
+        entry[0].release()
+        with _identifier_locks_guard:
+            entry[1] -= 1
+            if entry[1] == 0:
+                # Only drop it if nobody re-created it in the meantime.
+                if _identifier_locks.get(key) is entry:
+                    del _identifier_locks[key]
 
 
 def _normalize_isbn(raw):

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1,5 +1,6 @@
 """Write / mutation tool functions for the Zotero MCP server."""
 
+import contextlib
 import difflib
 import hashlib
 import json
@@ -1671,20 +1672,60 @@ def add_by_doi(
                                              tags, coll_keys, page_meta)
             pending.append((i, built))
 
-        created = (
-            _create_and_attach_batch(
-                write_zot, [payload["item_data"] for _, payload in pending],
-                attach_mode, ctx,
-                crossref_by_doi={payload["doi"]: payload["cr"]
-                                 for _, payload in pending},
+        # Phase 3b: serialize check-and-create per DOI (#486).
+        #
+        # Phase 1's dedup ran before the CrossRef fetch, so a parallel add of
+        # the same DOI can have created the item in between — and there is no
+        # version to conflict on, so nothing downstream would catch it. The
+        # locks are per-DOI and taken in sorted order, which is what makes
+        # holding several of them at once deadlock-free.
+        #
+        # This costs one extra dedup read per DOI. It does not undo #A5/#A4:
+        # CrossRef is still one batched request per 50 DOIs and creates are
+        # still one POST per 50 — only the dedup read, which was always per
+        # DOI, happens twice.
+        #
+        # The OA PDF attach inside _create_and_attach_batch runs while these
+        # are held. That is deliberate and is not the thing the narrowing was
+        # protecting: a per-DOI lock held across that DOI's own download
+        # blocks only a concurrent add of the same item, never unrelated
+        # work, which is the opposite of the global lock's blast radius.
+        with contextlib.ExitStack() as identifier_locks:
+            for doi_key in sorted({payload["doi"] for _, payload in pending
+                                   if payload.get("doi")}):
+                identifier_locks.enter_context(
+                    _helpers.identifier_lock("doi", doi_key)
+                )
+
+            if if_exists != "duplicate" and pending:
+                still_pending: list[tuple[int, dict]] = []
+                for i, payload in pending:
+                    existing = _helpers.find_existing_items(
+                        read_zot, doi=payload["doi"], ctx=ctx
+                    )
+                    if existing:
+                        work_results[i] = _handle_existing_item(
+                            write_zot, existing, coll_keys, tags, if_exists,
+                            matched_by=f"DOI {payload['doi']}", ctx=ctx,
+                        )
+                    else:
+                        still_pending.append((i, payload))
+                pending = still_pending
+
+            created = (
+                _create_and_attach_batch(
+                    write_zot, [payload["item_data"] for _, payload in pending],
+                    attach_mode, ctx,
+                    crossref_by_doi={payload["doi"]: payload["cr"]
+                                     for _, payload in pending},
+                )
+                if pending else []
             )
-            if pending else []
-        )
-        for (i, payload), cr_result in zip(pending, created):
-            work_results[i] = _render_doi_create_result(
-                cr_result, payload["zot_type"], payload["doi"], coll_keys,
-                payload["type_note"],
-            )
+            for (i, payload), cr_result in zip(pending, created):
+                work_results[i] = _render_doi_create_result(
+                    cr_result, payload["zot_type"], payload["doi"], coll_keys,
+                    payload["type_note"],
+                )
 
         # Expand back to one result per requested token.
         results: list[str] = [None] * len(doi_list)
@@ -1995,7 +2036,20 @@ def add_by_url(
         if embedded is not None and not embedded.is_usable():
             embed_problem = "the page carries no citation metadata"
 
-        with zotero_api_lock():
+        # Serialize check-and-create for this identifier (#486). The dedup
+        # check above ran before the fetch, so a parallel add can have created
+        # the item in between; re-checking inside the lock is what makes the
+        # pair atomic. The identifier lock is always taken *outside* the API
+        # lock, so the two are acquired in one consistent order everywhere.
+        with _helpers.identifier_lock("url", url), zotero_api_lock():
+            if if_exists != "duplicate":
+                existing = _helpers.find_existing_items(read_zot, url=url, ctx=ctx)
+                if existing:
+                    return _handle_existing_item(
+                        write_zot, existing, coll_keys, tags, if_exists,
+                        matched_by=f"URL {url}", ctx=ctx,
+                    )
+
             ctx.info(f"Creating webpage item for: {url}")
             template = write_zot.item_template("webpage")
             template["url"] = url
@@ -2184,7 +2238,19 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
             else:
                 authors.append({"creatorType": "author", "name": name})
 
-    with zotero_api_lock():
+    # Serialize check-and-create for this arXiv ID (#486) — see add_by_url's
+    # note; the metadata fetch above sits between the first check and here.
+    with _helpers.identifier_lock("arxiv", arxiv_id), zotero_api_lock():
+        if if_exists != "duplicate":
+            existing = _helpers.find_existing_items(
+                read_zot or write_zot, arxiv_id=arxiv_id, ctx=ctx
+            )
+            if existing:
+                return _handle_existing_item(
+                    write_zot, existing, coll_keys, tags, if_exists,
+                    matched_by=f"arXiv ID {arxiv_id}", ctx=ctx,
+                )
+
         template = write_zot.item_template("preprint")
         template["title"] = title
         if authors:
@@ -2526,7 +2592,22 @@ def add_by_isbn(
         if coll_keys:
             item_data["collections"] = coll_keys
 
-        result = write_zot.create_items([item_data])
+        # Serialize check-and-create for this ISBN (#486). The dedup check
+        # above ran before the Open Library / Google Books lookups, so a
+        # parallel add of the same book can have created it in between. The
+        # check is repeated here rather than moved because the lookups must
+        # stay outside the lock — that is the whole point of the narrowing.
+        with _helpers.identifier_lock("isbn", normalized):
+            if if_exists != "duplicate":
+                existing = _helpers.find_existing_items(
+                    read_zot, isbn=normalized, ctx=ctx
+                )
+                if existing:
+                    return _handle_existing_item(
+                        write_zot, existing, coll_keys, tags, if_exists,
+                        matched_by=f"ISBN {normalized}", ctx=ctx,
+                    )
+            result = write_zot.create_items([item_data])
         if isinstance(result, dict) and result.get("success"):
             item_key = next(iter(result["success"].values()))
             missing = _helpers.ensure_collection_membership(

--- a/tests/test_identifier_lock.py
+++ b/tests/test_identifier_lock.py
@@ -1,0 +1,329 @@
+"""Per-identifier serialization of adds (#486).
+
+The Zotero API lock protects the single-threaded local API. It never promised
+to make check-then-create atomic — that was a side effect of how wide it used
+to be, and narrowing it (to keep CrossRef and page fetches out of a held lock)
+removed it wherever a fetch now sits between the check and the write:
+
+    lock -> find_existing -> unlock -> fetch -> lock -> create -> unlock
+
+Two callers can both pass the dedup check and both create. There is no version
+to conflict on, so the version-checked retry cannot help: two ``create_items()``
+POSTs yield two new keys.
+
+The fix the maintainer chose on #486 is a short-lived in-process lock keyed on
+the *normalized* identifier, held across a re-check and the create. These tests
+pin the four properties that decision came with.
+"""
+
+import threading
+import time
+
+from zotero_mcp.tools._helpers import identifier_lock, identifier_lock_key
+
+# ---------------------------------------------------------------------------
+# Keying: the same work must take the same lock, and different work must not
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifierLockKey:
+    def test_isbn10_and_isbn13_of_one_book_share_a_key(self):
+        """The reason keying is on the normalized form, not the raw string.
+
+        0-306-40615-2 and 978-0-306-40615-7 are the same book; keyed raw they
+        would take different locks and race each other.
+        """
+        assert identifier_lock_key("isbn", "0-306-40615-2") == identifier_lock_key(
+            "isbn", "9780306406157"
+        )
+
+    def test_doi_spellings_share_a_key(self):
+        forms = [
+            "10.1234/abcd",
+            "doi:10.1234/abcd",
+            "https://doi.org/10.1234/abcd",
+            "  10.1234/abcd  ",
+            "10.1234/abcd.",
+        ]
+        keys = {identifier_lock_key("doi", f) for f in forms}
+        assert len(keys) == 1, keys
+
+    def test_different_identifiers_get_different_keys(self):
+        assert identifier_lock_key("doi", "10.1234/aaa") != identifier_lock_key(
+            "doi", "10.1234/bbb"
+        )
+
+    def test_kinds_do_not_collide(self):
+        """A DOI and a URL that stringify alike must not share a lock."""
+        assert identifier_lock_key("doi", "10.1234/abcd") != identifier_lock_key(
+            "url", "10.1234/abcd"
+        )
+
+    def test_urls_are_exact_after_strip(self):
+        """URLs have no normalizer, so the key is the stripped string.
+
+        Matching what #443 settled on for collapsing repeated identifiers —
+        deliberately not doing case or trailing-slash folding here, because a
+        URL that differs in either can legitimately be a different page.
+        """
+        assert identifier_lock_key("url", "  https://example.org/a  ") == (
+            identifier_lock_key("url", "https://example.org/a")
+        )
+        assert identifier_lock_key("url", "https://example.org/a") != (
+            identifier_lock_key("url", "https://example.org/a/")
+        )
+
+    def test_unnormalizable_identifier_has_no_key(self):
+        """A junk token takes no lock rather than sharing one.
+
+        Sharing a single "unnormalizable" lock would make a batch of bad
+        identifiers serialize against each other for no benefit — they cannot
+        collide, because none of them will dedup-match anything.
+        """
+        for kind, raw in (
+            ("doi", "not-a-doi"),
+            ("doi", ""),
+            ("doi", None),
+            ("isbn", "12345"),
+            ("url", "   "),
+        ):
+            assert identifier_lock_key(kind, raw) is None, (kind, raw)
+
+
+# ---------------------------------------------------------------------------
+# Mutual exclusion
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifierLock:
+    def test_same_identifier_serializes(self):
+        """Two threads on one DOI must not overlap inside the lock."""
+        overlap = []
+        inside = []
+        barrier = threading.Barrier(2)
+
+        def worker():
+            barrier.wait()
+            with identifier_lock("doi", "10.1234/same"):
+                overlap.append(len(inside))
+                inside.append(1)
+                time.sleep(0.05)
+                inside.pop()
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert overlap == [0, 0], f"threads overlapped inside the lock: {overlap}"
+
+    def test_different_identifiers_do_not_serialize(self):
+        """Distinct DOIs must proceed concurrently.
+
+        A global add lock would also fix the race and would also pass the test
+        above; this is what distinguishes per-identifier from that.
+        """
+        barrier = threading.Barrier(2, timeout=2)
+        reached = []
+
+        def worker(doi):
+            with identifier_lock("doi", doi):
+                # Deadlocks (raising BrokenBarrierError) if these serialize.
+                barrier.wait()
+                reached.append(doi)
+
+        threads = [
+            threading.Thread(target=worker, args=(f"10.1234/{n}",))
+            for n in ("aaa", "bbb")
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert sorted(reached) == ["10.1234/aaa", "10.1234/bbb"]
+
+    def test_unnormalizable_identifiers_do_not_serialize(self):
+        """The no-key path must not funnel junk through one shared lock."""
+        barrier = threading.Barrier(2, timeout=2)
+        reached = []
+
+        def worker(token):
+            with identifier_lock("doi", token):
+                barrier.wait()
+                reached.append(token)
+
+        threads = [
+            threading.Thread(target=worker, args=(t,))
+            for t in ("garbage-one", "garbage-two")
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert sorted(reached) == ["garbage-one", "garbage-two"]
+
+    def test_lock_is_reentrant_for_one_thread(self):
+        """Nested acquisition of the same identifier must not self-deadlock.
+
+        The add paths call into helpers that may take the same lock again; a
+        plain Lock would wedge the process rather than fail a test.
+        """
+        with identifier_lock("doi", "10.1234/nested"):
+            with identifier_lock("doi", "10.1234/nested"):
+                pass
+
+    def test_registry_does_not_leak_entries(self):
+        """A long-running server indexing a large library must not accumulate
+        one lock object per identifier it has ever seen."""
+        from zotero_mcp.tools import _helpers
+
+        before = len(_helpers._identifier_locks)
+        for i in range(50):
+            with identifier_lock("doi", f"10.1234/leak{i}"):
+                pass
+        assert len(_helpers._identifier_locks) == before
+
+    def test_entry_survives_while_a_waiter_holds_it(self):
+        """Cleanup must not drop an entry another thread is queued on."""
+        from zotero_mcp.tools import _helpers
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def holder():
+            with identifier_lock("doi", "10.1234/held"):
+                started.set()
+                release.wait(timeout=2)
+
+        t = threading.Thread(target=holder)
+        t.start()
+        started.wait(timeout=2)
+        assert "doi:10.1234/held" in _helpers._identifier_locks
+        release.set()
+        t.join()
+        assert "doi:10.1234/held" not in _helpers._identifier_locks
+
+
+# ---------------------------------------------------------------------------
+# The add paths must actually take the lock, and re-check inside it
+# ---------------------------------------------------------------------------
+#
+# Reproducing the race by timing turned out to be the wrong test to write: it
+# needs two threads to interleave at a specific point inside a path that does
+# a lot of other work, and every version of it either passed with the lock
+# removed (proving nothing) or deadlocked on its own scaffolding. A flaky or
+# vacuous concurrency test is worse than none — it is the same shape of
+# mistake as the comment #486 was filed about, a guard that is load-bearing in
+# the argument and absent in fact.
+#
+# What is deterministic, and is what the fix actually claims: each add path
+# enters the identifier lock with the right key, and performs its dedup
+# re-check *while inside it*. Ordering is the property; these pin it directly.
+
+
+class _LockSpy:
+    """Records identifier_lock entries and what happened inside them."""
+
+    def __init__(self, real):
+        self._real = real
+        self.entered = []
+        self.events = []
+
+    def __call__(self, kind, raw):
+        import contextlib as _cl
+
+        spy = self
+
+        @_cl.contextmanager
+        def _wrapper():
+            spy.entered.append((kind, raw))
+            spy.events.append(("enter", kind, raw))
+            with spy._real(kind, raw) as key:
+                yield key
+            spy.events.append(("exit", kind, raw))
+
+        return _wrapper()
+
+
+class TestAddPathsTakeTheLock:
+    def _spy(self, monkeypatch):
+        from zotero_mcp.tools import _helpers
+
+        spy = _LockSpy(_helpers.identifier_lock)
+        monkeypatch.setattr(_helpers, "identifier_lock", spy)
+        return spy
+
+    def test_add_by_isbn_locks_on_the_normalized_isbn(self, monkeypatch):
+        from conftest import DummyContext, FakeZotero
+
+        from zotero_mcp.tools import write
+
+        spy = self._spy(monkeypatch)
+        zot = FakeZotero()
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (zot, zot))
+        monkeypatch.setattr(write, "_lookup_isbn_openlibrary",
+                            lambda isbn, ctx: {"title": "A Book"})
+
+        write.add_by_isbn("0-306-40615-2", ctx=DummyContext())
+
+        # ISBN-10 in, ISBN-13 on the lock: keyed on the normalized form, so
+        # the other spelling of the same book takes the same lock.
+        assert ("isbn", "9780306406157") in spy.entered
+
+    def test_dedup_recheck_happens_inside_the_lock(self, monkeypatch):
+        """Ordering is the whole fix: a re-check outside the lock is no fix.
+
+        Records the sequence of lock-enter / dedup-check / create and asserts
+        the check and the create both fall between enter and exit.
+        """
+        from conftest import DummyContext, FakeZotero
+
+        from zotero_mcp.tools import _helpers, write
+
+        spy = self._spy(monkeypatch)
+        zot = FakeZotero()
+        monkeypatch.setattr("zotero_mcp.tools._helpers._get_write_client",
+                            lambda ctx: (zot, zot))
+        monkeypatch.setattr(write, "_lookup_isbn_openlibrary",
+                            lambda isbn, ctx: {"title": "A Book"})
+
+        real_find = _helpers.find_existing_items
+
+        def recording_find(*args, **kwargs):
+            spy.events.append(("dedup-check", kwargs.get("isbn"), None))
+            return real_find(*args, **kwargs)
+
+        monkeypatch.setattr(_helpers, "find_existing_items", recording_find)
+
+        def recording_create(items, **kwargs):
+            spy.events.append(("create", None, None))
+            return {"success": {"0": "KEY1"}}
+
+        monkeypatch.setattr(zot, "create_items", recording_create)
+
+        # if_exists="skip" is what asks for dedup at all; the default
+        # "duplicate" deliberately performs no check, so it cannot show the
+        # ordering this test is about.
+        write.add_by_isbn("9780306406157", if_exists="skip", ctx=DummyContext())
+
+        kinds = [e[0] for e in spy.events]
+        assert "enter" in kinds and "create" in kinds, spy.events
+        enter_at = kinds.index("enter")
+        exit_at = kinds.index("exit")
+        create_at = kinds.index("create")
+        rechecks = [i for i, k in enumerate(kinds)
+                    if k == "dedup-check" and enter_at < i < exit_at]
+
+        assert rechecks, (
+            f"no dedup re-check inside the lock: {spy.events}"
+        )
+        assert enter_at < create_at < exit_at, (
+            f"create happened outside the identifier lock: {spy.events}"
+        )
+        assert rechecks[0] < create_at, (
+            f"re-check did not precede the create: {spy.events}"
+        )


### PR DESCRIPTION
Implements option 2 from your answer on #486, to the scope you set there.

Closes #486

## What it does

A short-lived in-process lock keyed on the normalized identifier, held across a dedup re-check and the create.

The first dedup check still runs before the fetch, exactly as now. The check inside the lock is a **repeat, not a move** — the CrossRef and page fetches have to stay outside a held lock, which is what the narrowing was for, so the only way to make the pair atomic is to check again on the other side of the fetch.

## Against the four points you set

- **Keyed on the normalized identifier**, reusing `normalize_doi` / `_normalize_isbn` / `_normalize_arxiv_id`, so ISBN-10 and ISBN-13 of one book take the same lock, as do a bare DOI and its `doi.org` URL. URLs have no normalizer, so exact-after-strip, matching what #443 settled on for collapsing repeats — deliberately no case or trailing-slash folding, since either can be a genuinely different page.
- **Held across check-and-create only**, never across CrossRef or a page fetch.
- **In-process only, said out loud** — the module comment states plainly that two servers against one library still race. Being vague there is the mistake the issue was about.
- **An unnormalizable token takes no lock** rather than sharing one, so a batch of junk identifiers cannot serialize itself.

## Two things you didn't specify, and what I chose

**Lock ordering.** The identifier lock is always acquired *outside* the API lock, so the two have one consistent order everywhere. On the batched DOI path the chunk's identifier locks are taken in sorted key order, which is what makes holding several at once deadlock-free.

**Registry lifetime.** Entries are reference-counted and dropped when the last holder leaves. Without that, a 16k-item import would leave 16k lock objects behind in a long-running server.

## Cost, stated plainly

On the batched DOI path this adds **one extra dedup read per DOI**. It does not undo #A5/#A4 — CrossRef is still one batched request per 50 DOIs and creates are still one POST per 50. Only the dedup read, which was always per-DOI, now happens twice. There is no batched form of `find_existing_items` to do better with; if you'd rather have one, that's a bigger change and a separate one.

On the batched path the OA PDF attach inside `_create_and_attach_batch` runs while the chunk's identifier locks are held. That is deliberate and is not what the narrowing was protecting: a per-DOI lock held across that DOI's own download blocks only a concurrent add of the same item, never unrelated work — the opposite of the global lock's blast radius.

## What is covered, and what isn't

Covered: `add_by_doi` (single and batched), `add_by_isbn`, `add_by_url`, `_add_by_arxiv`.

**Not covered: the BibTeX and CSL-JSON importers.** They dedup in `_maybe_reuse_existing` and create in `_create_and_attach_batch` with nothing spanning the two. The window there is narrower — the metadata comes from the input file, so there is no network fetch in between — but it is not closed, and I'd rather say so than let this PR imply otherwise. Closing it means either threading the lock through `_create_and_attach_batch` (shared by three importers, and filtering entries inside it would desynchronise the `chunk`/`titles`/`results` indices) or hoisting the dedup into each caller the way `add_by_doi` now does. Happy to do the second in a follow-up if you want it.

## On the test I removed

I wrote a timing-based test that reproduced the race with two threads, and then deleted it. Every version either **passed with the lock taken out** — proving nothing — or deadlocked on its own barriers. Shipping it would have been the same shape of mistake as the comment this issue was filed about: a guard that is load-bearing in the argument and absent in fact.

What is pinned instead is deterministic and is what the fix actually claims: each add path enters the lock with the right key, and performs its dedup re-check *while inside it*. Those tests fail when the lock is removed from the path — I checked, rather than assuming.

## Testing

- `2698 passed, 42 skipped`, no failures.
- 14 new tests: keying (ISBN-10/13 equivalence, DOI spellings, kind collisions, URL exactness, unnormalizable → no key), mutual exclusion (same identifier serializes, different identifiers don't, junk doesn't, re-entrancy, registry doesn't leak, entry survives a waiter), and the two ordering tests above.

## Commits

| | |
|---|---|
| `cb2b1e2` | fix: serialize adds per normalized identifier (#486) |

4 files changed, +519 / −16.
