### PR TITLE
fix: hydrate cross-library hits through a client scoped to their library (#492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cross-library semantic hits are hydrated through a client scoped to their own library when the local database cannot serve them (#492).** The `zotero.sqlite` fallback that #487 added for foreign hits does not exist outside local mode, so a web-API user with group libraries got every cross-library hit back as a bare item key with a 404 — the bound client was asked for a key its library never held, and there was no second chance. Enrichment now falls through to a per-library pyzotero client, built from the same credentials and cached per `group_id`, so ten hits from one group cost one client and an unreachable library fails once rather than per hit. Local mode keeps the batched single-query sqlite path first and only reaches the scoped client for a key the snapshot could not serve, such as an item newer than the copy on disk. When a hit genuinely cannot be served — no credentials, or a key the credentials cannot see — the error now names the library and what is missing, instead of surfacing a 404 from a library that was never going to have the item.
+
 ## [0.11.0] - 2026-08-25
 
 **Upgrading:** `zotero_semantic_search` now defaults to the active library instead of every indexed library. If you relied on the old implicit behaviour, pass `search_all_libraries=True`.

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -3763,8 +3763,9 @@ class ZoteroSemanticSearch:
         if client is None:
             result["_enrich_error"] = RuntimeError(
                 f"item belongs to library {group_id}, which cannot be "
-                "reached — no local Zotero database, and no ZOTERO_API_KEY "
-                "to open that library over the web API"
+                "reached from this configuration — no local Zotero "
+                "database, and the web API needs ZOTERO_API_KEY plus, for "
+                "the personal library, a user-scoped ZOTERO_LIBRARY_ID"
             )
             return
         try:
@@ -3796,7 +3797,14 @@ class ZoteroSemanticSearch:
         local = is_local_mode()
         api_key = os.getenv("ZOTERO_API_KEY")
         if group_id == PERSONAL_LIBRARY_GROUP_ID:
-            library_id = os.getenv("ZOTERO_LIBRARY_ID") or ("0" if local else None)
+            if not local and os.getenv("ZOTERO_LIBRARY_TYPE", "user") == "group":
+                # Group-primary configuration: ZOTERO_LIBRARY_ID names a
+                # group, so the personal user ID is unknowable here. A
+                # client built from it would ask the wrong library and 404
+                # misleadingly; better no client and the explicit message.
+                library_id = None
+            else:
+                library_id = os.getenv("ZOTERO_LIBRARY_ID") or ("0" if local else None)
             library_type = "user"
         else:
             library_id, library_type = str(group_id), "group"

--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -31,9 +31,6 @@ except Exception:
 from . import batch_common, fulltext_cache, gemini_batch, openai_batch
 from .chroma_client import ChromaClient, create_chroma_client
 from .client import get_active_group_id, get_zotero_client
-from .embeddings.registry import batch_capable_providers
-from .extract import PAGE_SEPARATOR
-from .local_db import PERSONAL_LIBRARY_GROUP_ID, LocalZoteroReader
 
 # Re-exported so callers keep importing them from here, while the
 # ChromaDB-free definitions stay importable without this module (#485).
@@ -45,6 +42,9 @@ from .config_light import (  # noqa: F401
     reranker_enabled,
     should_update,
 )
+from .embeddings.registry import batch_capable_providers
+from .extract import PAGE_SEPARATOR
+from .local_db import PERSONAL_LIBRARY_GROUP_ID, LocalZoteroReader
 from .utils import _paginate, format_creators, is_local_mode, suppress_stdout
 
 logger = logging.getLogger(__name__)
@@ -491,6 +491,18 @@ def get_cached_reranker(model_name: str) -> CrossEncoderReranker:
         return cached
 
 
+def _new_scoped_client(library_id: str, library_type: str, api_key: str | None, local: bool):
+    """Construct a pyzotero client scoped to one library — seam for tests."""
+    from pyzotero import zotero
+
+    return zotero.Zotero(
+        library_id=library_id,
+        library_type=library_type,
+        api_key=api_key,
+        local=local,
+    )
+
+
 class ZoteroSemanticSearch:
     """Semantic search interface for Zotero libraries using ChromaDB."""
 
@@ -534,6 +546,10 @@ class ZoteroSemanticSearch:
         # Item keys seen by the most recent local sqlite scan (set by
         # _get_items_from_local_db); used to verify watermark promotion.
         self._last_scan_snapshot_keys: set[str] | None = None
+        # Per-library clients for cross-library result enrichment (#492).
+        # Keyed by group_id; None records that a library was found
+        # unreachable so a batch of hits from it fails once, not per item.
+        self._scoped_clients: dict[int, Any] = {}
 
         # Load update configuration
         self.update_config = self._load_update_config()
@@ -3665,6 +3681,12 @@ class ZoteroSemanticSearch:
         from ``zotero.sqlite`` instead, in one batched query, and arrive
         already carrying their ``library`` attribution.
 
+        Where the local database cannot serve a foreign hit — every web-API
+        install, since there is no ``zotero.sqlite`` there — a client scoped
+        to the hit's *own* library is tried instead (#492). Failures on that
+        path name the library and the credential requirement, because the
+        alternative is the silent 404 this exists to remove.
+
         A document whose ``group_id`` is missing cannot be recognised as
         foreign up front — every index built before #396 is untagged, which
         is most of them. Those go to the client first and fall back to the
@@ -3690,6 +3712,14 @@ class ZoteroSemanticSearch:
             item_key = result["item_key"]
             if item_key in local_items:
                 result["zotero_item"] = local_items[item_key]
+                continue
+            if _is_foreign(result):
+                # Local hydration came up empty for a hit known to be
+                # foreign. The bound client cannot serve it — that 404 is
+                # the #492 symptom — so ask a client scoped to the hit's own
+                # library instead. Outside local mode this is the only path
+                # that can serve the hit at all.
+                self._fetch_via_scoped_client(result)
                 continue
             try:
                 result["zotero_item"] = self.zotero_client.item(item_key)
@@ -3717,6 +3747,71 @@ class ZoteroSemanticSearch:
                     f"Error enriching result for item {result['item_key']}: {error}"
                 )
                 result["error"] = f"Could not fetch full item data: {error}"
+
+    def _fetch_via_scoped_client(self, result: dict[str, Any]) -> None:
+        """Hydrate one foreign hit through a client scoped to its library.
+
+        Reached only when ``_hydrate_locally`` could not serve a hit whose
+        ``group_id`` names a library other than the bound client's. Fills in
+        ``zotero_item`` on success; on failure records an ``_enrich_error``
+        that names the library and, where relevant, the credential
+        requirement — a foreign hit must never surface as a bare 404 from a
+        library that was never going to have it.
+        """
+        group_id = int((result.get("metadata") or {})["group_id"])
+        client = self._client_for_group(group_id)
+        if client is None:
+            result["_enrich_error"] = RuntimeError(
+                f"item belongs to library {group_id}, which cannot be "
+                "reached — no local Zotero database, and no ZOTERO_API_KEY "
+                "to open that library over the web API"
+            )
+            return
+        try:
+            result["zotero_item"] = client.item(result["item_key"])
+        except Exception as e:
+            result["_enrich_error"] = RuntimeError(
+                f"item belongs to library {group_id}, and the configured "
+                f"credentials could not read it from there: {e}"
+            )
+
+    def _client_for_group(self, group_id: int):
+        """A pyzotero client scoped to the library ``group_id`` names, or None.
+
+        The per-library complement of ``_hydrate_locally`` (#492): the bound
+        client can only serve its own library, and outside local mode there
+        is no ``zotero.sqlite`` to fall back on, so a foreign hit needs a
+        client of its own. 0 is the personal library; anything else is a
+        Zotero groupID. Cached per id for this instance's lifetime — a search
+        returning ten hits from one group builds one client, and a library
+        found unreachable is recorded as None so it fails once, not per hit.
+
+        In local mode the local API serves group libraries too, so the
+        resolver also acts as a last resort when ``zotero.sqlite`` did not
+        hold a key (e.g. the snapshot predates the item).
+        """
+        if group_id in self._scoped_clients:
+            return self._scoped_clients[group_id]
+
+        local = is_local_mode()
+        api_key = os.getenv("ZOTERO_API_KEY")
+        if group_id == PERSONAL_LIBRARY_GROUP_ID:
+            library_id = os.getenv("ZOTERO_LIBRARY_ID") or ("0" if local else None)
+            library_type = "user"
+        else:
+            library_id, library_type = str(group_id), "group"
+
+        client = None
+        if library_id and (local or api_key):
+            try:
+                client = _new_scoped_client(library_id, library_type, api_key, local)
+            except Exception as e:
+                logger.warning(
+                    f"Cross-library enrichment: could not build a client for "
+                    f"library {group_id}: {e}"
+                )
+        self._scoped_clients[group_id] = client
+        return client
 
     def _hydrate_locally(self, keys: list[str]) -> dict[str, dict]:
         """Hydrate `keys` from zotero.sqlite, or {} if that is not possible."""

--- a/tests/test_semantic_multilibrary.py
+++ b/tests/test_semantic_multilibrary.py
@@ -675,8 +675,40 @@ def test_same_library_hit_still_uses_the_zotero_client(monkeypatch):
     assert reader.asked_for == []
 
 
-def test_foreign_hit_without_a_local_db_keeps_reporting_the_error(monkeypatch):
-    monkeypatch.setattr(semantic_search, "is_local_mode", lambda: False)
+def test_foreign_hit_web_mode_is_served_by_a_client_scoped_to_its_library(monkeypatch):
+    """Web-API mode has no zotero.sqlite, so before #492 a group hit was a
+    dead end: the bound client 404'd and there was no fallback at all. A
+    client scoped to the hit's own library serves it."""
+    group_item = {
+        "key": "GRPKEY01",
+        "library": {"id": GROUP_ID, "type": "group", "name": "Test Group"},
+        "data": {"itemType": "journalArticle", "title": "Group Paper"},
+    }
+    built = []
+
+    def _fake_scoped_client(library_id, library_type, api_key, local):
+        built.append((library_id, library_type, api_key, local))
+        return _ScopedZot(library_type, library_id, {"GRPKEY01": group_item})
+
+    monkeypatch.setenv("ZOTERO_API_KEY", "test-key")
+    monkeypatch.setattr(semantic_search, "_new_scoped_client", _fake_scoped_client)
+    search = _build_search(
+        monkeypatch, _FakeChromaClient(),
+        get_zotero_client_fn=lambda: _ScopedZot("user", "14786213", {}),
+    )
+
+    enriched = search._enrich_search_results(_chroma_hit("GRPKEY01", GROUP_ID), "quantum")
+
+    assert "error" not in enriched[0]
+    assert enriched[0]["zotero_item"]["data"]["title"] == "Group Paper"
+    assert built == [(str(GROUP_ID), "group", "test-key", False)]
+
+
+def test_foreign_hit_web_mode_without_credentials_names_the_library(monkeypatch):
+    """No local database and no API key means the hit genuinely cannot be
+    served — but the error must say which library holds the item and what is
+    missing, not surface as a 404 from a library that never had it."""
+    monkeypatch.delenv("ZOTERO_API_KEY", raising=False)
     search = _build_search(
         monkeypatch, _FakeChromaClient(),
         get_zotero_client_fn=lambda: _ScopedZot("user", "0", {}),
@@ -684,7 +716,85 @@ def test_foreign_hit_without_a_local_db_keeps_reporting_the_error(monkeypatch):
 
     enriched = search._enrich_search_results(_chroma_hit("GRPKEY01", GROUP_ID), "quantum")
 
-    assert "error" in enriched[0]
+    assert str(GROUP_ID) in enriched[0]["error"]
+    assert "ZOTERO_API_KEY" in enriched[0]["error"]
+
+
+def test_foreign_hit_credentials_cannot_see_the_group_names_the_library(monkeypatch):
+    """A key that cannot read the group must produce an error naming the
+    library, per #492 — the silent 404 is exactly the failure being removed."""
+    monkeypatch.setenv("ZOTERO_API_KEY", "test-key")
+    monkeypatch.setattr(
+        semantic_search, "_new_scoped_client",
+        lambda *a: _ScopedZot("group", str(GROUP_ID), {}),  # key not visible
+    )
+    search = _build_search(
+        monkeypatch, _FakeChromaClient(),
+        get_zotero_client_fn=lambda: _ScopedZot("user", "0", {}),
+    )
+
+    enriched = search._enrich_search_results(_chroma_hit("GRPKEY01", GROUP_ID), "quantum")
+
+    assert str(GROUP_ID) in enriched[0]["error"]
+
+
+def test_scoped_client_is_built_once_per_library(monkeypatch):
+    """Ten hits from one group must not cost ten client constructions, and an
+    unreachable library must fail once for the batch, not once per hit."""
+    items = {
+        f"GRPKEY0{n}": {"key": f"GRPKEY0{n}", "data": {"title": f"Paper {n}"}}
+        for n in (1, 2)
+    }
+    built = []
+
+    def _fake_scoped_client(library_id, library_type, api_key, local):
+        built.append(library_id)
+        return _ScopedZot(library_type, library_id, items)
+
+    monkeypatch.setenv("ZOTERO_API_KEY", "test-key")
+    monkeypatch.setattr(semantic_search, "_new_scoped_client", _fake_scoped_client)
+    search = _build_search(
+        monkeypatch, _FakeChromaClient(),
+        get_zotero_client_fn=lambda: _ScopedZot("user", "0", {}),
+    )
+
+    two_hits = {
+        "ids": [["GRPKEY01", "GRPKEY02"]],
+        "documents": [["passage one", "passage two"]],
+        "metadatas": [[{"group_id": GROUP_ID}, {"group_id": GROUP_ID}]],
+        "distances": [[0.1, 0.2]],
+    }
+    enriched = search._enrich_search_results(two_hits, "quantum")
+
+    assert [r["zotero_item"]["data"]["title"] for r in enriched] == ["Paper 1", "Paper 2"]
+    assert built == [str(GROUP_ID)]
+
+
+def test_local_mode_scoped_client_is_the_last_resort_after_the_local_db(monkeypatch):
+    """In local mode the batched sqlite path stays first (#487) — the scoped
+    client only steps in for a foreign key the snapshot could not serve."""
+    group_item = {"key": "GRPKEY01", "data": {"title": "Newer Than Snapshot"}}
+    reader = _FakeReader({})  # sqlite predates the item
+    monkeypatch.setattr(semantic_search, "is_local_mode", lambda: True)
+    monkeypatch.setattr(semantic_search, "LocalZoteroReader", lambda **kw: reader)
+    built = []
+
+    def _fake_scoped_client(library_id, library_type, api_key, local):
+        built.append((library_id, library_type, local))
+        return _ScopedZot(library_type, library_id, {"GRPKEY01": group_item})
+
+    monkeypatch.setattr(semantic_search, "_new_scoped_client", _fake_scoped_client)
+    search = _build_search(
+        monkeypatch, _FakeChromaClient(), is_local=True,
+        get_zotero_client_fn=lambda: _ScopedZot("user", "0", {}),
+    )
+
+    enriched = search._enrich_search_results(_chroma_hit("GRPKEY01", GROUP_ID), "quantum")
+
+    assert "error" not in enriched[0]
+    assert enriched[0]["zotero_item"]["data"]["title"] == "Newer Than Snapshot"
+    assert reader.asked_for == [["GRPKEY01"]]
+    assert built == [(str(GROUP_ID), "group", True)]
 
 
 def test_untagged_hit_the_client_cannot_serve_falls_back_to_the_local_db(monkeypatch):

--- a/tests/test_semantic_multilibrary.py
+++ b/tests/test_semantic_multilibrary.py
@@ -738,6 +738,31 @@ def test_foreign_hit_credentials_cannot_see_the_group_names_the_library(monkeypa
     assert str(GROUP_ID) in enriched[0]["error"]
 
 
+def test_group_primary_web_config_never_builds_a_wrong_personal_client(monkeypatch):
+    """A group-primary web config (ZOTERO_LIBRARY_TYPE=group) stores a
+    groupID in ZOTERO_LIBRARY_ID, so the personal user ID is unknowable. A
+    personal-library hit must get the explicit unreachable message, not a
+    client built for users/<groupID> whose 404 would blame the wrong
+    library."""
+    def _exploding_scoped_client(*a):
+        raise AssertionError("no client must be constructed here")
+
+    monkeypatch.setenv("ZOTERO_API_KEY", "test-key")
+    monkeypatch.setenv("ZOTERO_LIBRARY_TYPE", "group")
+    monkeypatch.setenv("ZOTERO_LIBRARY_ID", str(GROUP_ID))
+    monkeypatch.setattr(semantic_search, "_new_scoped_client", _exploding_scoped_client)
+    search = _build_search(
+        monkeypatch, _FakeChromaClient(),
+        # Bound client is the group; a personal (group_id=0) hit is foreign.
+        get_zotero_client_fn=lambda: _ScopedZot("group", str(GROUP_ID), {}),
+    )
+
+    enriched = search._enrich_search_results(_chroma_hit("PERSKEY1", 0), "quantum")
+
+    assert "library 0" in enriched[0]["error"]
+    assert "zotero_item" not in enriched[0]
+
+
 def test_scoped_client_is_built_once_per_library(monkeypatch):
     """Ten hits from one group must not cost ten client constructions, and an
     unreachable library must fail once for the batch, not once per hit."""


### PR DESCRIPTION
Fixes the web-API half of #492, in the shape discussed there: the per-library client resolver is used where `_hydrate_locally` comes up empty, so local mode keeps the batched single-query sqlite path and web-API mode stops being a dead end.

## What changes

`_attach_zotero_items` gains a third source for foreign hits. The order is unchanged for everything that worked before:

1. Foreign hits are batch-hydrated from `zotero.sqlite` (#487) — untouched, still first in local mode.
2. A foreign hit the local database could not serve goes to `_fetch_via_scoped_client`, which resolves a pyzotero client scoped to the hit's own `group_id` — built from the same credentials, cached per id on the instance, with an unreachable library recorded once rather than failing per hit.
3. In-scope hits keep going to the bound client, and the untagged-index retry path is untouched.

Per the credential point raised in the issue: when a hit cannot be served, the error now names the library and what is missing — no local database and no usable credentials, or "the configured credentials could not read it from there: ..." — instead of a bare 404 from a library that was never going to have the item.

One deliberate refusal: under a group-primary web config (`ZOTERO_LIBRARY_TYPE=group`), `ZOTERO_LIBRARY_ID` names a group, so the personal user ID is unknowable and a personal-library (`group_id=0`) hit gets the explicit unreachable message rather than a client built for `users/<groupID>`, whose 404 would blame the wrong library.

Known boundary, unchanged from your fallback: an untagged hit (index predating #396) carries no `group_id`, so web mode has no way to pick a client for it and it still errors; reindexing is the fix there.

## Verification

Unit tests — 6 new/updated in `tests/test_semantic_multilibrary.py`, following the existing `_ScopedZot`/`_FakeReader` conventions, via a `_new_scoped_client` seam:

- web mode, credentials present: foreign hit served by a client built as `(group_id, "group", key, local=False)`
- web mode, no credentials: error names the library and `ZOTERO_API_KEY` (replaces `test_foreign_hit_without_a_local_db_keeps_reporting_the_error`, whose asserted behavior is the bug being fixed)
- credentials that cannot see the group: error names the library
- one client construction per library across multiple hits
- local mode: sqlite stays first; the scoped client only serves a key the snapshot missed
- group-primary web config: a personal-library hit constructs no client and gets the named-library message (an exploding seam proves nothing is built)

Live, against api.zotero.org with a real key on the 4-library index from my #492 report, one query happened to exercise both designed paths:

- hits from a group the key can read: enriched with full metadata over the web API (previously bare keys)
- hits from a group the key genuinely cannot read (verified: 403 on that group's listing, and the group is absent from the key's `/users/<id>/groups`): the named-library credential error, not a silent 404

Full test suite minus `tests/live` passes (2648 passed; the 4 failures in `test_pdf_coordinates.py` fail identically on pristine `main` in my environment). `ruff check` clean — includes one import-order fix in `semantic_search.py` that the `I` rules flag after #485's insertion.
