### PR TITLE
fix: probe pid liveness without os.kill on Windows

### DIFF
--- a/src/zotero_mcp/semantic_search.py
+++ b/src/zotero_mcp/semantic_search.py
@@ -7,6 +7,7 @@ over research libraries.
 """
 
 import contextlib
+import functools
 import json
 import logging
 import os
@@ -101,8 +102,65 @@ def _realtime_slice_size(max_parallel: int) -> int:
     return min(25 * max(1, max_parallel), 200)
 
 
+_WIN_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+_WIN_STILL_ACTIVE = 259
+_WIN_ERROR_ACCESS_DENIED = 5
+
+
+@functools.lru_cache(maxsize=1)
+def _kernel32():
+    """kernel32 with the three entry points below given explicit signatures.
+
+    HANDLE must be declared: ctypes defaults a return type to C ``int``, which
+    truncates a 64-bit handle and leaks it.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    lib = ctypes.WinDLL("kernel32", use_last_error=True)
+    lib.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    lib.OpenProcess.restype = wintypes.HANDLE
+    lib.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+    lib.GetExitCodeProcess.restype = wintypes.BOOL
+    lib.CloseHandle.argtypes = (wintypes.HANDLE,)
+    lib.CloseHandle.restype = wintypes.BOOL
+    return lib
+
+
+def _pid_is_alive_windows(pid: int) -> bool:
+    """Liveness check for Windows, where ``os.kill(pid, 0)`` is not a probe.
+
+    ``signal.CTRL_C_EVENT`` is 0, so ``os.kill(pid, 0)`` never asks whether
+    *pid* exists: it calls ``GenerateConsoleCtrlEvent`` and delivers a real
+    Ctrl+C to every process sharing this console — the test run itself, and
+    whatever shell launched it. ``OpenProcess`` answers the actual question
+    and sends nothing.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    lib = _kernel32()
+    handle = lib.OpenProcess(_WIN_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        # Access denied means it exists but is owned by another user; that is
+        # the PermissionError branch below, so report it alive.
+        return ctypes.get_last_error() == _WIN_ERROR_ACCESS_DENIED
+    try:
+        code = wintypes.DWORD()
+        if not lib.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return True  # the handle opened, so the process object exists
+        return code.value == _WIN_STILL_ACTIVE
+    finally:
+        lib.CloseHandle(handle)
+
+
 def _pid_is_alive(pid: int) -> bool:
-    """Best-effort liveness check for a process id (POSIX ``kill(pid, 0)``)."""
+    """Best-effort liveness check for a process id."""
+    if sys.platform == "win32":
+        try:
+            return _pid_is_alive_windows(pid)
+        except Exception:
+            return False
     try:
         os.kill(pid, 0)
     except ProcessLookupError:

--- a/tests/test_update_lock_reliability.py
+++ b/tests/test_update_lock_reliability.py
@@ -32,6 +32,36 @@ def test_read_lock_holder_live_pid(tmp_path):
     assert alive is True
 
 
+def test_pid_is_alive_never_calls_os_kill_on_windows(monkeypatch):
+    """``os.kill(pid, 0)`` is a Ctrl+C broadcast on Windows, not a probe.
+
+    ``signal.CTRL_C_EVENT`` is 0, so the POSIX idiom hands
+    ``GenerateConsoleCtrlEvent`` a real console control event, which lands on
+    every process sharing the console. It interrupted this suite at 97% and
+    took down whatever shell launched it. Nothing on this path may reach
+    ``os.kill`` while the platform is Windows.
+    """
+    if sys.platform != "win32":
+        pytest.skip("the os.kill routing under test is Windows-only")
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError("os.kill must never run on Windows")
+
+    monkeypatch.setattr(os, "kill", _forbidden)
+    assert semantic_search._pid_is_alive(os.getpid()) is True
+
+
+@skip_on_ci
+def test_pid_is_alive_agrees_with_reality():
+    """Own pid is alive; a pid that cannot exist is not.
+
+    Shares ``test_read_lock_holder_dead_pid``'s 999999 and so shares its
+    skip: the value is only *essentially* certain to be free.
+    """
+    assert semantic_search._pid_is_alive(os.getpid()) is True
+    assert semantic_search._pid_is_alive(999999) is False
+
+
 @skip_on_ci
 def test_read_lock_holder_dead_pid(tmp_path):
     lock = tmp_path / "update.lock"


### PR DESCRIPTION
## The bug

`_pid_is_alive` in `semantic_search.py` uses the POSIX idiom, where signal 0 sends nothing and only reports whether the pid exists:

```python
def _pid_is_alive(pid: int) -> bool:
    """Best-effort liveness check for a process id (POSIX ``kill(pid, 0)``)."""
    try:
        os.kill(pid, 0)
```

Windows has no such probe. `signal.CTRL_C_EVENT` is `0`, so `os.kill(pid, 0)` does not ask whether the process exists — CPython routes it to `GenerateConsoleCtrlEvent`, which delivers a **real Ctrl+C to every process sharing the console**, not just the target pid.

## How it shows up

`tests/test_update_lock_reliability.py::test_read_lock_holder_live_pid` writes `os.getpid()` into the lock file, so `read_lock_holder` -> `_pid_is_alive` sends the test run a console control event. On Windows the suite dies at 97% with a `KeyboardInterrupt` nobody typed:

```
tests/test_update_lock_reliability.py::test_read_lock_holder_live_pid PASSED [ 97%]

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
pluggy/_hooks.py:482: KeyboardInterrupt
================ 2759 passed, 48 skipped in 162.77s =================
```

Because the event goes to the whole console group, it also takes down whatever launched the run — a terminal, an editor's test runner, or an MCP client. That is a graceful interrupt rather than a fault, so it leaves no crash record, which makes it fairly confusing to track down.

In production the same call sits on the `update-db` lock diagnostics path, so a Windows user with a stale lock file can Ctrl+C their own session.

CI never caught this because it runs on Linux, where the idiom does exactly what the docstring says.

## The fix

Windows now goes through `OpenProcess` / `GetExitCodeProcess`, which answers the liveness question and sends nothing. POSIX behaviour is unchanged.

- `ACCESS_DENIED` maps to "alive, owned by another user", mirroring the existing `PermissionError` branch.
- The three `kernel32` entry points get explicit `argtypes`/`restype`. `HANDLE` in particular must be declared, since ctypes defaults a return type to C `int`, which truncates a 64-bit handle and leaks it.
- `ctypes` is imported lazily inside the helper to keep module import light.
- No new dependency.

## Tests

Two regression tests: one asserts `os.kill` is never reached on Windows (monkeypatched to raise), one checks the answers match reality.

Verified on Windows 11 / Python 3.13:

| | result |
|---|---|
| before | 2,759 passed, then `KeyboardInterrupt` at 97% |
| after | 2,845 passed, 48 skipped, 100%, exit 0 |

Four unrelated tests fail on `main` on Windows (`test_add_by_bibtex`, `test_add_by_csl_json`, `test_add_item`, `test_local_db`) — all POSIX path assumptions such as `/Users/me/...` and `/home/user/...`. I confirmed they fail identically on `main` without this change, so they are out of scope here; happy to send a separate PR for them if useful.
