### PR TITLE
fix: parse the detailed children listing's - Key: line in _keys_from_markdown

### DIFF
--- a/src/zotero_mcp/cli_standalone.py
+++ b/src/zotero_mcp/cli_standalone.py
@@ -114,18 +114,21 @@ def _keys_from_markdown(markdown: str) -> list[str]:
     ranking, the collection scoping -- instead of reimplementing it and
     drifting from what markdown mode returns. The two modes therefore always
     agree on *which* items matched; JSON only changes how they are rendered.
+    A detailed children listing writes a third shape, `   - Key: KEY`.
     """
     global _ITEM_KEY_RE
     if _ITEM_KEY_RE is None:
         import re
         _ITEM_KEY_RE = re.compile(
-            r"^\*\*Item Key:\*\*\s*`?([A-Z0-9]{8})`?\s*$|^- `([A-Z0-9]{8})`",
+            r"^\*\*Item Key:\*\*\s*`?([A-Z0-9]{8})`?\s*$"
+            r"|^- `([A-Z0-9]{8})`"
+            r"|^\s*- Key:\s*([A-Z0-9]{8})\s*$",
             re.MULTILINE,
         )
     keys: list[str] = []
     seen: set[str] = set()
     for match in _ITEM_KEY_RE.finditer(markdown or ""):
-        key = match.group(1) or match.group(2)
+        key = match.group(1) or match.group(2) or match.group(3)
         if key and key not in seen:
             seen.add(key)
             keys.append(key)

--- a/tests/test_cli_json_output.py
+++ b/tests/test_cli_json_output.py
@@ -10,6 +10,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+from conftest import DummyContext, FakeZotero
 
 from zotero_mcp import cli_json
 from zotero_mcp.cli_standalone import (
@@ -19,6 +20,7 @@ from zotero_mcp.cli_standalone import (
     cmd_get,
     cmd_search,
 )
+from zotero_mcp.tools.retrieval import _format_children_detailed
 
 
 def _raw(key, item_type="journalArticle", title="A Paper", **fields):
@@ -150,6 +152,20 @@ class TestKeyExtraction:
     def test_prose_mentioning_no_keys_yields_none(self):
         assert _keys_from_markdown("No items found matching the criteria.") == []
         assert _keys_from_markdown("") == []
+
+    def test_reads_keys_from_a_detailed_children_listing(self):
+        zot = FakeZotero()
+        zot._items = [{"key": "PAR00001", "data": {"title": "Parent"}}]
+        zot._children = {
+            "PAR00001": [
+                {"key": "NOTE0001", "data": {"itemType": "note", "note": "hi"}},
+                {"key": "ATT00001", "data": {
+                    "itemType": "attachment", "contentType": "application/pdf",
+                }},
+            ],
+        }
+        md = _format_children_detailed(zot, "PAR00001", DummyContext())
+        assert _keys_from_markdown(md) == ["ATT00001", "NOTE0001"]
 
 
 class TestFetchProjected:


### PR DESCRIPTION
## Root cause

`zotero-cli --json get children <parent_key>` reports `count: 0` even when
markdown mode lists real children. The JSON path extracts item keys from
the tool's own markdown output with `_keys_from_markdown()`, whose regex
recognizes `**Item Key:** KEY` and the keys-only `` - `KEY` `` form, but
`_format_children_detailed()` (the single-parent path `get_item_children`
takes) writes each child's key on its own indented `   - Key: KEY` line, a
third shape the regex never matched. The fetch step then runs on an empty
key list and returns nothing.

## Fix

Add a third alternative to `_ITEM_KEY_RE` for the indented `- Key: KEY`
form and read it into the extracted key list alongside the other two.

## Verification

- New regression test (`test_reads_keys_from_a_detailed_children_listing`)
  builds a fake parent with one note and one attachment child, renders it
  through the real `_format_children_detailed()`, and asserts
  `_keys_from_markdown()` recovers both keys. Confirmed it fails on `main`
  (`count: 0`) and passes on this branch.
- Full suite (`pytest --ignore=tests/test_lifespan.py`, Python 3.11):
  2709 passed, 42 skipped, same 7 pre-existing failures as on unmodified
  `main` (rate-limit-guard and webdav tests that depend on network/timing,
  unrelated to this change).
- Checked every other place in the codebase that emits an indented
  `- Key:` line: only the three call sites inside
  `_format_children_detailed` (attachments, notes, other items) do, so no
  other markdown shape is affected by the new alternative.
- Not verified: the batch form (`get_item_children` called with several
  keys) renders through `_format_children_grouped`, which uses a different
  `- [KEY] ...` line shape that this regex still does not match, so
  `--json get children` with multiple keys likely has the same symptom.
  That path is not part of this issue's reproduction and is out of scope
  here.
