### PR TITLE
fix(dedup): pass the title on the ISBN path too (and why the url path is left alone)

### DIFF
--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -810,11 +810,21 @@ def find_existing_items(zot, *, doi=None, arxiv_id=None, isbn=None, url=None,
         def _matches(data):
             return _normalize_doi(data.get("DOI") or "") == doi
     elif arxiv_id:
-        query = arxiv_id
+        # Compare on the version-independent identity, and search on it too:
+        # quick-search is a substring match, so the bare id finds a stored
+        # 'arXiv:2401.00001v2' while the versioned form would miss a stored
+        # bare one.
+        ident = _arxiv_identity(arxiv_id) or arxiv_id
+        query = ident
         def _matches(data):
-            if _normalize_arxiv_id(data.get("url") or "") == arxiv_id:
-                return True
-            return f"arxiv:{arxiv_id}".lower() in (data.get("extra") or "").lower()
+            # Zotero stores an arXiv identity in up to four places depending
+            # on how the item arrived (connector, DOI add, arXiv add, manual).
+            # Checking only url+extra misses connector- and DOI-sourced items,
+            # which is how a re-add duplicates a paper already in the library.
+            for field in ("url", "archiveID", "DOI"):
+                if _arxiv_identity(data.get(field) or "") == ident:
+                    return True
+            return f"arxiv:{ident}".lower() in (data.get("extra") or "").lower()
     elif isbn:
         query = isbn
         def _matches(data):
@@ -1077,6 +1087,38 @@ def _normalize_arxiv_id(raw):
     if re.match(r"^[a-z\-]+/\d{7}(?:v\d+)?$", s, flags=re.IGNORECASE):
         return s
     return None
+
+
+# arXiv's DataCite DOIs are minted as 10.48550/arXiv.<id>, which is what
+# Zotero puts in the DOI field for a preprint imported from arXiv.
+_ARXIV_DOI_RE = re.compile(r"^(?:https?://(?:dx\.)?doi\.org/)?10\.48550/arxiv\.(.+)$",
+                           re.IGNORECASE)
+_ARXIV_VERSION_RE = re.compile(r"v\d+$", re.IGNORECASE)
+
+
+def _arxiv_identity(raw):
+    """The version-independent arXiv identity of an ID, URL, DOI or archiveID.
+
+    ``_normalize_arxiv_id`` deliberately keeps the ``v2`` suffix: callers use
+    its result to fetch a specific version from arXiv. Deduplication wants the
+    opposite — 2401.00001v1 and 2401.00001v2 are the same paper and must not
+    become two library items — so identity comparison goes through here
+    instead. This also accepts arXiv's DataCite DOI form, so an item added by
+    DOI is recognized by a later add of the same paper's arXiv ID.
+
+    Returns the bare, unversioned ID, or None if ``raw`` isn't an arXiv
+    identifier in any of those forms.
+    """
+    if not raw:
+        return None
+    s = str(raw).strip()
+    m = _ARXIV_DOI_RE.match(s)
+    if m:
+        s = m.group(1)
+    ident = _normalize_arxiv_id(s)
+    if not ident:
+        return None
+    return _ARXIV_VERSION_RE.sub("", ident)
 
 
 # ---------------------------------------------------------------------------

--- a/src/zotero_mcp/tools/_helpers.py
+++ b/src/zotero_mcp/tools/_helpers.py
@@ -787,17 +787,31 @@ def _create_collection_path(write_zot, paths, spec, ctx=None) -> str:
 
 
 def find_existing_items(zot, *, doi=None, arxiv_id=None, isbn=None, url=None,
-                        ctx=None) -> list[dict]:
+                        title=None, ctx=None) -> list[dict]:
     """Find non-attachment items already in the library by a normalized id.
 
     Exactly one of doi / arxiv_id / isbn / url should be given (already
     normalized via the corresponding ``_normalize_*`` helper, except url).
-    A server-side quick search (``q=<id>, qmode='everything',
-    itemType='-attachment'``) narrows candidates cheaply; a client-side
-    normalized comparison confirms real matches. Searching with the BARE
-    identifier means the substring quick-search also catches values stored
-    with prefixes ('https://doi.org/10...', 'arXiv:...'). The items endpoint
-    excludes the Trash, so a trashed copy never blocks a re-add.
+    ``title`` is optional and additive: see below.
+
+    A server-side quick search narrows candidates cheaply; a client-side
+    normalized comparison confirms real matches. The items endpoint excludes
+    the Trash, so a trashed copy never blocks a re-add.
+
+    **The identifier query alone cannot be relied on.** Zotero's ``q``
+    parameter "searches titles and individual creator fields", and the API
+    documentation notes that "searching of other fields will be possible in
+    the future" — so DOI, url, archiveID and extra are NOT searchable server
+    side. Against the Web API an identifier query therefore returns zero
+    candidates for an item that IS present, the caller reads that as "not in
+    the library", and ``if_exists='file'`` creates a duplicate.
+
+    So when ``title`` is given and the identifier query confirms nothing, a
+    second pass queries the title — which the API does index — and runs the
+    same identifier comparison over those candidates. The identifier still
+    decides, so this widens the net without loosening the test: a
+    same-title-different-paper is rejected exactly as before. Callers that
+    have already fetched metadata should pass it.
 
     Returns full item dicts (with ``key``/``version``/``data``) so callers
     can update them without re-fetching. Returns [] on search failure —
@@ -842,42 +856,55 @@ def find_existing_items(zot, *, doi=None, arxiv_id=None, isbn=None, url=None,
     else:
         return []
 
-    try:
-        candidates = zot.items(
-            q=query, qmode="everything", itemType="-attachment", limit=50
-        )
-    except (TooManyRetriesError, TooManyRequestsError):
-        # A rate-limited search is deliberately not swallowed. Every other
-        # failure here degrades to "no match" and the caller creates the item,
-        # which is the right trade for a genuinely failed search — but a
-        # throttled search hasn't answered the question, and reading it as "not
-        # present" silently creates duplicates of items that are. pyzotero
-        # >=1.13.5 has already retried and waited out the server's backoff by
-        # the time it raises, so there is nothing left to do but propagate.
-        raise
-    except Exception as e:
-        if ctx is not None:
-            ctx.warning(f"Existing-item search failed (treating as no match): {e}")
-        return []
+    def _search(q, qmode):
+        try:
+            return zot.items(
+                q=q, qmode=qmode, itemType="-attachment", limit=50
+            )
+        except (TooManyRetriesError, TooManyRequestsError):
+            # A rate-limited search is deliberately not swallowed. Every other
+            # failure here degrades to "no match" and the caller creates the
+            # item, which is the right trade for a genuinely failed search —
+            # but a throttled search hasn't answered the question, and reading
+            # it as "not present" silently creates duplicates of items that
+            # are. pyzotero >=1.13.5 has already retried and waited out the
+            # server's backoff by the time it raises, so there is nothing left
+            # to do but propagate.
+            raise
+        except Exception as e:
+            if ctx is not None:
+                ctx.warning(f"Existing-item search failed (treating as no match): {e}")
+            return None
 
-    matches = []
-    for item in candidates or []:
-        # Skip anything that isn't a well-formed item dict. The try above only
-        # wraps the call, not this iteration, so a malformed entry would raise
-        # here and abort the whole import instead of costing one dedup match.
-        # The known cause of that is fixed in pyzotero >=1.13.5, which this
-        # package now requires, but this stays as a backstop: nothing about the
-        # contract of a search result guarantees every entry is a dict.
-        if not isinstance(item, dict):
-            continue
-        data = item.get("data")
-        if not isinstance(data, dict):
-            continue
-        if data.get("itemType") in ("attachment", "note", "annotation"):
-            continue
-        if _matches(data):
-            matches.append(item)
-    return matches
+    def _confirm(candidates):
+        matches = []
+        for item in candidates or []:
+            # Skip anything that isn't a well-formed item dict. _search only
+            # wraps the call, not this iteration, so a malformed entry would
+            # raise here and abort the whole import instead of costing one
+            # dedup match. The known cause of that is fixed in pyzotero
+            # >=1.13.5, which this package now requires, but this stays as a
+            # backstop: nothing about the contract of a search result
+            # guarantees every entry is a dict.
+            if not isinstance(item, dict):
+                continue
+            data = item.get("data")
+            if not isinstance(data, dict):
+                continue
+            if data.get("itemType") in ("attachment", "note", "annotation"):
+                continue
+            if _matches(data):
+                matches.append(item)
+        return matches
+
+    matches = _confirm(_search(query, "everything"))
+    if matches or not title:
+        return matches
+
+    # The identifier is not server-side searchable (see the docstring), so
+    # fall back to the one field that is. The identifier comparison in
+    # _confirm still decides which of these candidates is really the item.
+    return _confirm(_search(title, "titleCreatorYear"))
 
 
 def _collection_not_found_message(zot, spec, paths) -> str:

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -2607,8 +2607,12 @@ def add_by_isbn(
         # stay outside the lock — that is the whole point of the narrowing.
         with _helpers.identifier_lock("isbn", normalized):
             if if_exists != "duplicate":
+                # The Open Library / Google Books lookup above has run, so a
+                # title is in hand here. An ISBN is not server-side
+                # searchable, so without one this check finds nothing.
                 existing = _helpers.find_existing_items(
-                    read_zot, isbn=normalized, ctx=ctx
+                    read_zot, isbn=normalized,
+                    title=item_data.get("title"), ctx=ctx,
                 )
                 if existing:
                     return _handle_existing_item(

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -1700,8 +1700,13 @@ def add_by_doi(
             if if_exists != "duplicate" and pending:
                 still_pending: list[tuple[int, dict]] = []
                 for i, payload in pending:
+                    # CrossRef metadata is in hand here, so pass the title: a
+                    # DOI is not server-side searchable, and the identifier
+                    # query alone misses items already in the library.
                     existing = _helpers.find_existing_items(
-                        read_zot, doi=payload["doi"], ctx=ctx
+                        read_zot, doi=payload["doi"],
+                        title=(payload.get("item_data") or {}).get("title"),
+                        ctx=ctx,
                     )
                     if existing:
                         work_results[i] = _handle_existing_item(
@@ -2242,8 +2247,11 @@ def _add_by_arxiv(arxiv_id, collections, tags, write_zot, ctx, attach_mode="auto
     # note; the metadata fetch above sits between the first check and here.
     with _helpers.identifier_lock("arxiv", arxiv_id), zotero_api_lock():
         if if_exists != "duplicate":
+            # The title is known by now (fetched above), so pass it: the arXiv
+            # ID is not server-side searchable, and the identifier query alone
+            # misses items that are already in the library.
             existing = _helpers.find_existing_items(
-                read_zot or write_zot, arxiv_id=arxiv_id, ctx=ctx
+                read_zot or write_zot, arxiv_id=arxiv_id, title=title, ctx=ctx
             )
             if existing:
                 return _handle_existing_item(

--- a/tests/test_idempotent_adds.py
+++ b/tests/test_idempotent_adds.py
@@ -594,3 +594,52 @@ class TestAddByBibtexIfExists:
         assert fake_zot.created == []
         assert fake_zot.addto_calls == []
         assert "skipped — already in library" in result
+
+
+class TestIsbnTitleFallback:
+    """ISBN has the same unsearchable-identifier problem as DOI and arXiv.
+
+    Measured against a real library: four items selected for having an ISBN,
+    searched by their own ISBN, returned zero hits each.
+    """
+
+    def test_isbn_found_via_title_when_identifier_search_cannot(self):
+        item = {
+            "key": "BOOKID01",
+            "version": 1,
+            "data": {
+                "itemType": "book",
+                "title": "Other Minds",
+                "ISBN": "9780306406157",
+            },
+        }
+
+        class IdentifierBlindZotero(FakeZoteroIdem):
+            def items(self, **kwargs):
+                q = (kwargs.get("q") or "").lower()
+                if kwargs.get("qmode") == "titleCreatorYear" and "other minds" in q:
+                    return [item]
+                return []
+
+        z = IdentifierBlindZotero()
+        assert _helpers.find_existing_items(z, isbn="9780306406157") == []
+        out = _helpers.find_existing_items(
+            z, isbn="9780306406157", title="Other Minds"
+        )
+        assert [i["key"] for i in out] == ["BOOKID01"]
+
+    def test_isbn_title_fallback_still_requires_the_isbn_to_match(self, fake_zot):
+        """Two different books can share a title; the ISBN still decides."""
+        fake_zot._items.append({
+            "key": "BOOKID02",
+            "version": 1,
+            "data": {
+                "itemType": "book",
+                "title": "Other Minds",
+                "ISBN": "9781234567897",
+            },
+        })
+        out = _helpers.find_existing_items(
+            fake_zot, isbn="9780306406157", title="Other Minds"
+        )
+        assert out == []

--- a/tests/test_idempotent_adds.py
+++ b/tests/test_idempotent_adds.py
@@ -252,6 +252,97 @@ class TestFindExistingItems:
         })
         assert _helpers.find_existing_items(fake_zot, arxiv_id="2401.00009") == []
 
+    # -- title fallback ----------------------------------------------------
+    #
+    # Zotero's `q` "searches titles and individual creator fields"; the API
+    # docs add that "searching of other fields will be possible in the
+    # future". So DOI/url/archiveID/extra are NOT searchable server side and
+    # an identifier query returns nothing for an item that IS present. The
+    # title is the one field the API does index, so it supplies the
+    # candidates; the identifier still decides.
+
+    def test_title_fallback_finds_item_identifier_search_cannot(self):
+        """The real-world failure: identifier query returns nothing."""
+        item = {
+            "key": "TITLE001",
+            "version": 1,
+            "data": {
+                "itemType": "preprint",
+                "title": "RL's Razor",
+                "DOI": "10.48550/arXiv.2509.04259",
+                "url": "",
+                "extra": "",
+            },
+        }
+
+        class IdentifierBlindZotero(FakeZoteroIdem):
+            """Models the Web API: only a title/creator query matches."""
+
+            def items(self, **kwargs):
+                q = (kwargs.get("q") or "").lower()
+                if kwargs.get("qmode") == "titleCreatorYear" and "razor" in q:
+                    return [item]
+                return []
+
+        z = IdentifierBlindZotero()
+        # Without the title the identifier query finds nothing at all.
+        assert _helpers.find_existing_items(z, arxiv_id="2509.04259") == []
+        # With it, the item is found and confirmed by its DOI.
+        out = _helpers.find_existing_items(
+            z, arxiv_id="2509.04259", title="RL's Razor"
+        )
+        assert [i["key"] for i in out] == ["TITLE001"]
+
+    def test_title_fallback_still_requires_the_identifier_to_match(self, fake_zot):
+        """A same-title different-paper must NOT be treated as the same item.
+
+        The title only supplies candidates; the identifier decides. Without
+        this the fallback would merge unrelated papers that share a title.
+        """
+        fake_zot._items.append({
+            "key": "OTHER001",
+            "version": 1,
+            "data": {
+                "itemType": "preprint",
+                "title": "Generalized Linear Models",
+                "DOI": "10.48550/arXiv.1111.11111",
+                "url": "",
+                "extra": "",
+            },
+        })
+        out = _helpers.find_existing_items(
+            fake_zot, arxiv_id="2222.22222", title="Generalized Linear Models"
+        )
+        assert out == []
+
+    def test_title_fallback_is_skipped_when_identifier_already_matched(self):
+        """No second query when the identifier query already confirmed."""
+        item = {
+            "key": "IDENT001",
+            "version": 1,
+            "data": {
+                "itemType": "preprint",
+                "url": "https://arxiv.org/abs/2401.00010",
+                "extra": "",
+            },
+        }
+
+        class CountingZotero(FakeZoteroIdem):
+            def __init__(self):
+                super().__init__()
+                self.queries = []
+
+            def items(self, **kwargs):
+                self.queries.append(kwargs.get("qmode"))
+                return [item]
+
+        z = CountingZotero()
+        out = _helpers.find_existing_items(
+            z, arxiv_id="2401.00010", title="Whatever"
+        )
+        assert [i["key"] for i in out] == ["IDENT001"]
+        assert z.queries == ["everything"]
+
     def test_isbn_match_across_10_13_forms(self, fake_zot):
         # ISBN-10 0306406152 == ISBN-13 9780306406157
         fake_zot._items.append({

--- a/tests/test_idempotent_adds.py
+++ b/tests/test_idempotent_adds.py
@@ -159,6 +159,99 @@ class TestFindExistingItems:
         out = _helpers.find_existing_items(fake_zot, arxiv_id="2401.00002")
         assert [i["key"] for i in out] == ["ARXIV002"]
 
+    # -- arXiv identity across storage sites and versions ------------------
+    #
+    # Zotero records an arXiv identity in a different field depending on how
+    # the item arrived. Matching only url+extra misses the rest, so a re-add
+    # of a paper already in the library silently creates a duplicate.
+
+    def test_arxiv_match_via_archive_id(self, fake_zot):
+        """Browser-connector imports put the ID in archiveID, not url/extra."""
+        fake_zot._items.append({
+            "key": "ARXIV003",
+            "version": 1,
+            "data": {
+                "itemType": "preprint",
+                "archiveID": "arXiv:2401.00003",
+                "url": "",
+                "extra": "",
+            },
+        })
+        out = _helpers.find_existing_items(fake_zot, arxiv_id="2401.00003")
+        assert [i["key"] for i in out] == ["ARXIV003"]
+
+    def test_arxiv_match_via_datacite_doi(self, fake_zot):
+        """An item added by DOI carries only arXiv's 10.48550 DataCite DOI."""
+        fake_zot._items.append({
+            "key": "ARXIV004",
+            "version": 1,
+            "data": {
+                "itemType": "preprint",
+                "DOI": "10.48550/arXiv.2401.00004",
+                "url": "",
+                "extra": "",
+            },
+        })
+        out = _helpers.find_existing_items(fake_zot, arxiv_id="2401.00004")
+        assert [i["key"] for i in out] == ["ARXIV004"]
+
+    def test_arxiv_versioned_add_matches_bare_stored_id(self, fake_zot):
+        """Adding .../abs/2401.00005v2 must reuse the stored unversioned item."""
+        fake_zot._items.append({
+            "key": "ARXIV005",
+            "version": 1,
+            "data": {
+                "itemType": "preprint",
+                "url": "https://arxiv.org/abs/2401.00005",
+                "extra": "",
+            },
+        })
+        out = _helpers.find_existing_items(fake_zot, arxiv_id="2401.00005v2")
+        assert [i["key"] for i in out] == ["ARXIV005"]
+
+    def test_arxiv_bare_add_matches_versioned_stored_id(self, fake_zot):
+        """And the reverse: a stored v1 is the same paper as a bare re-add."""
+        fake_zot._items.append({
+            "key": "ARXIV006",
+            "version": 1,
+            "data": {
+                "itemType": "preprint",
+                "url": "https://arxiv.org/abs/2401.00006v1",
+                "extra": "",
+            },
+        })
+        out = _helpers.find_existing_items(fake_zot, arxiv_id="2401.00006")
+        assert [i["key"] for i in out] == ["ARXIV006"]
+
+    def test_arxiv_does_not_match_a_different_paper(self, fake_zot):
+        """The version-insensitive compare must not collapse distinct IDs."""
+        fake_zot._items.append({
+            "key": "ARXIV007",
+            "version": 1,
+            "data": {
+                "itemType": "preprint",
+                "url": "https://arxiv.org/abs/2401.00007",
+                "DOI": "10.48550/arXiv.2401.00007",
+                "archiveID": "arXiv:2401.00007",
+                "extra": "arXiv:2401.00007 [cs]",
+            },
+        })
+        assert _helpers.find_existing_items(fake_zot, arxiv_id="2401.00008") == []
+
+    def test_arxiv_ignores_a_non_arxiv_doi(self, fake_zot):
+        """A publisher DOI must not be read as an arXiv identity."""
+        fake_zot._items.append({
+            "key": "JOURNAL01",
+            "version": 1,
+            "data": {
+                "itemType": "journalArticle",
+                "DOI": "10.1038/nature12373",
+                "url": "",
+                "extra": "",
+            },
+        })
+        assert _helpers.find_existing_items(fake_zot, arxiv_id="2401.00009") == []
+
     def test_isbn_match_across_10_13_forms(self, fake_zot):
         # ISBN-10 0306406152 == ISBN-13 9780306406157
         fake_zot._items.append({

--- a/tests/test_shared_helpers.py
+++ b/tests/test_shared_helpers.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from zotero_mcp import server
+from zotero_mcp.tools import _helpers
 from zotero_mcp.utils import clean_html
 from conftest import DummyContext, FakeZotero
 
@@ -133,6 +134,51 @@ class TestNormalizeArxivId:
         assert server._normalize_arxiv_id("not-an-id") is None
         assert server._normalize_arxiv_id("") is None
         assert server._normalize_arxiv_id(None) is None
+
+
+# ---------------------------------------------------------------------------
+# _arxiv_identity
+# ---------------------------------------------------------------------------
+
+class TestArxivIdentity:
+    """The version-independent identity used for deduplication.
+
+    Distinct from _normalize_arxiv_id, which keeps the version because its
+    callers use the result to fetch a specific version from arXiv.
+    """
+
+    def test_strips_the_version(self):
+        assert _helpers._arxiv_identity("2401.00001v2") == "2401.00001"
+        assert _helpers._arxiv_identity("https://arxiv.org/abs/2401.00001v11") == "2401.00001"
+        assert _helpers._arxiv_identity("hep-ph/9901234v2") == "hep-ph/9901234"
+
+    def test_accepts_the_datacite_doi(self):
+        assert _helpers._arxiv_identity("10.48550/arXiv.2401.00001") == "2401.00001"
+        assert _helpers._arxiv_identity(
+            "https://doi.org/10.48550/arXiv.2401.00001v3"
+        ) == "2401.00001"
+
+    def test_every_spelling_of_one_paper_agrees(self):
+        spellings = [
+            "2401.00001",
+            "2401.00001v1",
+            "arXiv:2401.00001",
+            "http://arxiv.org/abs/2401.00001",
+            "https://arxiv.org/abs/2401.00001v2",
+            "https://arxiv.org/pdf/2401.00001v3.pdf",
+            "10.48550/arXiv.2401.00001",
+        ]
+        assert {_helpers._arxiv_identity(s) for s in spellings} == {"2401.00001"}
+
+    def test_distinct_papers_stay_distinct(self):
+        assert _helpers._arxiv_identity("2401.00001") != _helpers._arxiv_identity("2401.00002")
+
+    def test_non_arxiv_returns_none(self):
+        assert _helpers._arxiv_identity("10.1038/nature12373") is None
+        assert _helpers._arxiv_identity("https://example.com/foo") is None
+        assert _helpers._arxiv_identity("not-an-id") is None
+        assert _helpers._arxiv_identity("") is None
+        assert _helpers._arxiv_identity(None) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> **Stacked on #506.** This branch contains that PR's two commits as well, so the diff here shows all three. Only the last one — `fix(dedup): pass the title on the ISBN path too` — is new. Happy to rebase once #506 lands, or drop this if #506 goes a different way, since it depends on the `title=` parameter that one adds.

In #506 we noted the `isbn` and plain-`url` dedup paths "look like they have the same problem". We went and checked rather than assuming, and the answer differs between the two.

## ISBN: same problem, and the same fallback fits

Four items were selected *for having an ISBN*, then searched by their own ISBN:

| Item | ISBN | hits |
|---|---|---|
| 3X3TXTWX | `978-0-7803-9151-2` | 0 |
| 57TNTZZB | `978-0-387-00454-9` | 0 |
| WYI4U23M | `3-355-40948-0` | 0 |
| BXV9UMXU | `978-0-19-955204-7` | 0 |

Four of four, consistent with the DOI and arXiv results in #506 and with the docs note that `q` searches titles and creators only.

`add_by_isbn` checks twice — once before the Open Library / Google Books lookup and once inside the identifier lock afterwards. The second has a title in hand, so that's the one this changes. The first has no title and is left alone.

## Plain URL: same problem, but the fallback does *not* fit

Four items searched by their own stored `url` also returned zero hits each, so the search limitation is the same. But we're **not** proposing a change there, because the generic-webpage branch has no title to fall back to — it creates the item with the URL *as* the title:

```python
template = write_zot.item_template("webpage")
template["url"] = url
template["title"] = url
```

So `title=` would just be the URL again, which is the thing that doesn't match. That path needs a different answer — an exact-match endpoint, a local lookup, or normalising `http`/`https` and trailing slashes before comparing — and we don't have a confident proposal. Flagging it rather than papering over it.

Worth noting the plain-url matcher is also an exact string compare after `rstrip("/")`, so `http://` vs `https://`, a trailing slash, or a tracking query parameter all read as different items. We haven't measured how often that bites and haven't touched it.

## Tests

Two added, mirroring the arXiv ones in #506: the identifier-blind fake finds the book by title, and a same-title-different-ISBN is still rejected so the ISBN keeps deciding.

Full suite 2,741 passed; the 5 `test_rate_limit_guard.py` failures are pre-existing on an untouched `3cb3e2e`. `ruff check` unchanged.

## Where we could be wrong

- Everything in #506's "Where we could be wrong" applies here too — one library, Web API only, `ZOTERO_LOCAL` untested, and the extra call per miss.
- **Book titles are more collision-prone than paper titles.** Editions, translations and reissues share a title far more often than papers do. The ISBN still decides, so a wrong match shouldn't get through — but `limit=50` truncating the candidate list is a more realistic worry here than it is for arXiv IDs, and we haven't characterised it.
- **We only checked four ISBNs**, on one library. Fewer than the six DOIs in #506, because fewer items in that library carry one.
