### PR TITLE
feat(add): report the citation key when reusing an existing item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The add tools report the citation key when they reuse an item already in the library.** The item key is what the tools returned, but the citation key is what goes into a document, so a caller that wanted one made a second `zotero-cli get metadata <KEY> --output-format bibtex` call to get it — and wrapping that second call around a write is how at least one duplicate got created. On the reuse path the key is already in hand: the dedup search returns the full item, so `data.citationKey` costs no extra request. An item without one simply omits the line, so nothing here depends on Better BibTeX being installed. Only `data.citationKey` is read, never a `Citation Key:` line in `extra`: the two disagree — on a 497-item sample both were present on 77 items and differed on 11 — and the native field is the one Better BibTeX exports, because those `extra` lines are this package's own import residue, where `citation_import` preserves the *source document's* key. This is the reuse path only. On the just-created path the key is not available at the same cost: BBT assigns it on the desktop client after it sees the new item, so an item created through the Web API has to sync down first, and a re-fetch immediately after the create would usually still come up empty.
+
 ## [0.11.0] - 2026-08-25
 
 **Upgrading:** `zotero_semantic_search` now defaults to the active library instead of every indexed library. If you relied on the old implicit behaviour, pass `search_all_libraries=True`.

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -327,6 +327,19 @@ def _handle_existing_item(write_zot, existing, coll_keys, tags, if_exists,
     dedup search already returned the full item, so ``data.citationKey`` is
     in hand. An item without one just omits the line, so nothing depends on
     Better BibTeX being present.
+
+    Deliberately only ``data.citationKey``, never a ``Citation Key:`` line in
+    ``extra`` — the two disagree, and ``extra`` is the wrong one. On a
+    497-item sample both were present on 77 items and differed on 11 of
+    those; every difference checked against BBT's own export resolved to the
+    native field. Those ``extra`` lines are this package's own import
+    residue: ``citation_import`` preserves the *source document's* key there
+    (``Citation Key: CoaseFirmMarket1988`` beside a native
+    ``Coase1988Firm``), so reading them would report a key BBT does not
+    export. Nothing is lost by ignoring them — no sampled item carried a key
+    in ``extra`` alone. Note this differs from ``search_by_citation_key``,
+    which consults both *on purpose*, so an item stays findable by the key it
+    was imported under.
     """
     item = existing[0]
     item_key = item.get("key")

--- a/src/zotero_mcp/tools/write.py
+++ b/src/zotero_mcp/tools/write.py
@@ -321,10 +321,18 @@ def _handle_existing_item(write_zot, existing, coll_keys, tags, if_exists,
 
     The report keeps the ``Item key: `KEY``` line that callers (and
     add_from_file's key extraction) rely on.
+
+    It also reports the citation key when the item has one, since that — not
+    the item key — is what goes into a document. It costs nothing here: the
+    dedup search already returned the full item, so ``data.citationKey`` is
+    in hand. An item without one just omits the line, so nothing depends on
+    Better BibTeX being present.
     """
     item = existing[0]
     item_key = item.get("key")
-    title = item.get("data", {}).get("title") or "(untitled)"
+    data = item.get("data") or {}
+    title = data.get("title") or "(untitled)"
+    citation_key = data.get("citationKey")
 
     note = ""
     if len(existing) > 1:
@@ -338,6 +346,8 @@ def _handle_existing_item(write_zot, existing, coll_keys, tags, if_exists,
         f"Already in library: **{title}** (`{item_key}`, matched by {matched_by})\n\n"
         f"Item key: `{item_key}`\n"
     )
+    if citation_key:
+        header += f"Citation key: `{citation_key}`\n"
 
     if if_exists == "skip":
         return header + "No changes made (if_exists='skip')." + note

--- a/tests/test_idempotent_adds.py
+++ b/tests/test_idempotent_adds.py
@@ -16,7 +16,7 @@ import pytest
 
 from conftest import DummyContext, FakeZotero, _FakeResponse
 from zotero_mcp import server
-from zotero_mcp.tools import _helpers
+from zotero_mcp.tools import _helpers, write
 
 
 DOI = "10.1234/test.2024.001"
@@ -410,3 +410,34 @@ class TestAddByBibtexIfExists:
         assert fake_zot.created == []
         assert fake_zot.addto_calls == []
         assert "skipped — already in library" in result
+
+
+class TestExistingItemReportsCitationKey:
+    """The reuse report should name the key that ends up in a document.
+
+    data.citationKey is already on the item the dedup search returned, so
+    this costs no extra request. Measured on a real library, 496 of 500
+    top-level items carried one.
+    """
+
+    def _existing(self, data_extra):
+        data = {"itemType": "preprint", "title": "A Paper"}
+        data.update(data_extra)
+        return [{"key": "ITEM0001", "version": 1, "data": data}]
+
+    def test_citation_key_is_reported_when_present(self, fake_zot, dummy_ctx):
+        out = write._handle_existing_item(
+            fake_zot, self._existing({"citationKey": "Shenfeld2025RLs"}),
+            [], None, "skip", matched_by="arXiv ID 2509.04259", ctx=dummy_ctx,
+        )
+        assert "Citation key: `Shenfeld2025RLs`" in out
+        assert "Item key: `ITEM0001`" in out
+
+    def test_no_line_when_the_item_has_no_citation_key(self, fake_zot, dummy_ctx):
+        """Better BibTeX may not be installed; the line simply doesn't appear."""
+        out = write._handle_existing_item(
+            fake_zot, self._existing({}), [], None, "skip",
+            matched_by="arXiv ID 2509.04259", ctx=dummy_ctx,
+        )
+        assert "Citation key" not in out
+        assert "Item key: `ITEM0001`" in out

--- a/tests/test_idempotent_adds.py
+++ b/tests/test_idempotent_adds.py
@@ -10,6 +10,7 @@ if_exists contract on the add_by_* family:
 - 'skip': report the existing item, change nothing.
 """
 
+import re
 from unittest.mock import MagicMock
 
 import pytest
@@ -416,8 +417,9 @@ class TestExistingItemReportsCitationKey:
     """The reuse report should name the key that ends up in a document.
 
     data.citationKey is already on the item the dedup search returned, so
-    this costs no extra request. Measured on a real library, 496 of 500
-    top-level items carried one.
+    this costs no extra request. Measured over the Web API on a real
+    library, 496 of 497 sampled top-level items carried one, and none
+    carried a key in Extra alone.
     """
 
     def _existing(self, data_extra):
@@ -441,3 +443,47 @@ class TestExistingItemReportsCitationKey:
         )
         assert "Citation key" not in out
         assert "Item key: `ITEM0001`" in out
+
+    def test_extra_citation_key_is_not_reported(self, fake_zot, dummy_ctx):
+        """A `Citation Key:` line in Extra is deliberately NOT a fallback.
+
+        citation_import writes the *source document's* key there, so it
+        routinely disagrees with the native field — 11 of 77 items carrying
+        both, on a 497-item sample — and BBT exports the native one. Reading
+        Extra here would report a key that never reaches the document.
+        """
+        out = write._handle_existing_item(
+            fake_zot,
+            self._existing({"extra": "Citation Key: CoaseFirmMarket1988"}),
+            [], None, "skip", matched_by="DOI 10.1234/x", ctx=dummy_ctx,
+        )
+        assert "Citation key" not in out
+        assert "CoaseFirmMarket1988" not in out
+
+    def test_native_key_wins_over_a_stale_extra_line(self, fake_zot, dummy_ctx):
+        """Both present and disagreeing: report what BBT exports."""
+        out = write._handle_existing_item(
+            fake_zot,
+            self._existing({
+                "citationKey": "Coase1988Firm",
+                "extra": "Citation Key: CoaseFirmMarket1988",
+            }),
+            [], None, "skip", matched_by="DOI 10.1234/x", ctx=dummy_ctx,
+        )
+        assert "Citation key: `Coase1988Firm`" in out
+        assert "CoaseFirmMarket1988" not in out
+
+    def test_reported_through_add_by_doi(self, monkeypatch, fake_zot, dummy_ctx):
+        """End to end through a real tool, not just the private helper.
+
+        Also guards add_from_file's ``Item key: `KEY``` extraction: the new
+        line must not sit where that regex would reach it first.
+        """
+        fake_zot._items[0]["data"]["citationKey"] = "Existing2024Paper"
+        _patch_clients(monkeypatch, fake_zot)
+
+        result = server.add_by_doi(doi=DOI, if_exists="skip", ctx=dummy_ctx)
+
+        assert "Item key: `EXIST001`" in result
+        assert "Citation key: `Existing2024Paper`" in result
+        assert re.search(r"Item key: `([^`]+)`", result).group(1) == "EXIST001"


### PR DESCRIPTION
A deliberately partial change, and we'd rather propose the half we're confident in than guess at the other.

## The gap

The add tools report the item key. What actually goes into a document is the citation key, so a caller wanting it makes a second `zotero-cli get metadata <KEY> --output-format bibtex` call. That's how one of the duplicate items behind #506 got created here: the second call was wrapped in a shell command substitution around the write, so the write ran twice.

## What this changes

Only `_handle_existing_item` — the already-in-library path. There it's free: the dedup search already returned the full item, so `data.citationKey` is in hand and no extra request is needed. Measured on one real library, 496 of 500 top-level items carried one. An item without one omits the line, so nothing depends on Better BibTeX being installed.

```
Already in library: **RL's Razor** (`VLYF39QV`, matched by arXiv ID 2509.04259)

Item key: `VLYF39QV`
Citation key: `Shenfeld2025RLs`
```

Two tests: present and absent.

## The half we did not do, and why

The just-created path is genuinely awkward, and we don't think the asymmetry should be hidden:

- **Reuse:** the key is already in the response we hold. Free and reliable.
- **Create:** it isn't. Better BibTeX assigns citation keys on the desktop client, reacting to the item appearing in the local database. An item created through the Web API has to sync down before that happens. So a create can't read the key back without a re-fetch that may still come up empty — for an interval that depends on the user's sync, and that's unbounded if Zotero isn't running at all.

Options as we see them, none obviously right:

1. Leave create as-is (this PR). Asymmetric output, which is arguably confusing.
2. Re-fetch once after create and emit the key if present. Costs a request per add and still usually misses, since the sync won't have happened yet.
3. Say something explicit on create — "citation key not yet assigned" — so the asymmetry is stated rather than silent.
4. Have `add` take a flag to wait/poll for it. More machinery than the problem probably deserves.

We'd take (3) if you want symmetry, but it's your call about output stability, and we didn't want to impose one.

## Interaction with #506

This only becomes *visible* once the reuse path is actually reached. Per #506 the dedup search currently returns nothing against the Web API, so `if_exists='file'` rarely gets here. The code change is independent and correct either way, but if #506 is rejected this is mostly dead code in practice.

## Where we could be wrong

- **We did not test the create path**, because doing so means writing junk items into a real library. Everything above about BBT's assignment timing is reasoning from how the plugin works, not measurement — if you know it behaves differently through the API, that changes option (2) entirely.
- **99.2% is one library**, belonging to someone who uses Better BibTeX heavily. A library without BBT would see this line essentially never, which is fine but makes the feature less useful than that number suggests.
- **`data.citationKey` vs BBT's own store.** We read the native Zotero field. If BBT's pinned keys and that field can disagree — we don't know whether they can — then this could report a key that isn't the one BBT would export.
- **Output stability.** Adding a line to a rendered result may break anything parsing it. `add_from_file` extracts the item key from this block; we kept that line untouched and only appended after it, but you'd know of other consumers.
