### PR TITLE
test: build rate-limit fixtures from the HTTP library pyzotero uses (#511)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The test suite was red on a clean checkout against pyzotero >=1.15 (#511).** pyzotero 1.15 moved off httpx onto httpx2 — httpx 2.x, published under a separate distribution name, and a disjoint class hierarchy. `tests/test_rate_limit_guard.py` did `import httpx`, which resolves to the httpx 0.28 that `mcp`/`httpx-sse` pull in regardless of pyzotero, and built its 429 fixtures as `httpx.Response`. pyzotero's `_post_check` catches only `httpx2.HTTPError`, so those responses escaped it uncaught: the retry loop never saw the 429, `error_handler` never recorded the backoff, and `TooManyRetriesError` was never raised. Five tests failed — three leaking `HTTPStatusError` where they expect a retry or the typed error, two degrading to `[]` because `find_existing_items`' generic `except Exception` caught the leaked error instead of the typed clause above it. Since CI installs bare `pyzotero` against a floor with no ceiling and there is no lockfile, it resolves whatever is newest, so every PR opened after 1.15.0 reached PyPI showed the same five red checks. The fixtures are now built from whatever HTTP library the installed pyzotero speaks — asked of pyzotero rather than guessed at import time, since both libraries can be installed at once — which keeps the declared `pyzotero>=1.13.5` range green rather than narrowing it. Nothing the tests pin actually changed: 1.15.1 still retries a rate-limited read three times and still waits out a server-supplied backoff. The same mismatch has a *runtime* consequence on the local-API path, where our own httpx 0.28 client bypasses pyzotero's error handling for real; that is #512 and is not addressed here.
+
 ## [0.11.0] - 2026-08-25
 
 **Upgrading:** `zotero_semantic_search` now defaults to the active library instead of every indexed library. If you relied on the old implicit behaviour, pass `search_all_libraries=True`.

--- a/tests/test_rate_limit_guard.py
+++ b/tests/test_rate_limit_guard.py
@@ -13,7 +13,8 @@ the symptom is a silent duplicate rather than an error, so these tests are the
 only thing standing between the two.
 """
 
-import httpx
+import importlib
+
 import pytest
 from conftest import DummyContext
 from pyzotero.zotero import Zotero
@@ -21,7 +22,50 @@ from pyzotero.zotero_errors import TooManyRetriesError
 
 from zotero_mcp.tools import _helpers
 
-_REQ = httpx.Request("GET", "https://api.zotero.org/users/1/items")
+
+def _zotero():
+    """A web-API Zotero. Constructing one opens no socket."""
+    return Zotero(library_id="1", library_type="user", api_key="x" * 24)
+
+
+def _pyzotero_http():
+    """The HTTP library the installed pyzotero speaks.
+
+    pyzotero 1.15 moved from httpx to httpx2 (httpx 2.x, published under a
+    separate distribution name). The two are disjoint class hierarchies, and
+    pyzotero catches only its own::
+
+        try:
+            resp.raise_for_status()
+        except httpx2.HTTPError as exc:
+            error_handler(self, resp, exc)
+
+    ``httpx.HTTPStatusError`` is not an ``httpx2.HTTPError``, so a 429 built
+    from the wrong library escapes that clause uncaught: the retry loop never
+    sees the 429, no backoff is recorded, and TooManyRetriesError is never
+    raised. Every test below then fails as though the retry contract had
+    regressed, when all that is wrong is the fixture (#511).
+
+    Importing whichever library imports cleanly does not tell them apart —
+    both can be installed at once. httpx arrives transitively via mcp/httpx-sse
+    whatever pyzotero does, and FastMCP 4 brings httpx2 in alongside a pyzotero
+    that may still be on httpx. Ask pyzotero instead: the client it builds for
+    itself is an instance of the library it speaks, on either side of 1.15.
+    """
+    client = _zotero().client
+    module = importlib.import_module(type(client).__module__.partition(".")[0])
+    if not hasattr(module, "Response"):
+        raise RuntimeError(
+            "cannot tell which HTTP library the installed pyzotero uses: its "
+            f"client is a {type(client).__module__}.{type(client).__qualname__}, "
+            "and that module exposes no Response to build fixtures from"
+        )
+    return module
+
+
+_http = _pyzotero_http()
+
+_REQ = _http.Request("GET", "https://api.zotero.org/users/1/items")
 _ITEM = [{"key": "EXIST001", "version": 1,
           "data": {"itemType": "journalArticle", "DOI": "10.1234/test"}}]
 
@@ -36,13 +80,13 @@ def _429(backoff="1"):
     headers = {"Content-Type": "text/plain"}
     if backoff is not None:
         headers["Backoff"] = backoff
-    return httpx.Response(
+    return _http.Response(
         429, headers=headers, content=b"Too many requests. Slow down", request=_REQ,
     )
 
 
 def _200(items=None):
-    return httpx.Response(
+    return _http.Response(
         200, headers={"Content-Type": "application/json"},
         json=_ITEM if items is None else items, request=_REQ,
     )
@@ -50,7 +94,7 @@ def _200(items=None):
 
 def _client(responses):
     """A client whose transport replays `responses` in order."""
-    zot = Zotero(library_id="1", library_type="user", api_key="x" * 24)
+    zot = _zotero()
     seq = iter(responses)
     zot.client.get = lambda url, params=None, timeout=None, **kw: next(seq)
     zot._set_backoff = lambda *a, **kw: None  # don't sleep in tests


### PR DESCRIPTION
Fixes #511.

`tests/test_rate_limit_guard.py` fails five ways on a clean checkout of `main`, and has done since pyzotero 1.15.0 reached PyPI. Nothing in the tree changed — CI installs bare `pyzotero` against a floor with no ceiling and there is no lockfile, so it resolves whatever is newest. Every PR opened since [main's last green run](https://github.com/54yyyu/zotero-mcp/actions/runs/32799744535) shows the same five red checks.

## Cause

pyzotero 1.15 moved off `httpx` onto `httpx2` (httpx 2.x, published under a separate distribution name). The two are disjoint class hierarchies.

The test module did `import httpx`, which resolves to httpx 0.28.1 — pulled in transitively by `mcp`/`httpx-sse`, not by pyzotero — and built its fixtures as `httpx.Response(429, ...)`. pyzotero's `_client._post_check` then does:

```python
try:
    resp.raise_for_status()
except httpx2.HTTPError as exc:
    error_handler(self, resp, exc)
```

`httpx.HTTPStatusError` is not an `httpx2.HTTPError`, so the 429 escaped that clause uncaught. The retry loop in `_retrieve_data` never saw it, `error_handler` never recorded the backoff, and `TooManyRetriesError` was never raised. That accounts for all five: the three in `TestUpstreamRateLimitHandling` leak `HTTPStatusError` where they expect a retry or the typed error, and the two in `TestDedupUnderThrottling` degrade to `[]` because `find_existing_items`' generic `except Exception` catches the leaked error instead of the typed clause above it.

So the fixtures were wrong, not the behaviour they pin. pyzotero 1.15.1 keeps the retry semantics these tests exist to guard: `MAX_RETRY_ATTEMPTS` is still 3, and `errors.error_handler` still swallows a 429 carrying a backoff header and returns for the caller to retry.

## Fix

Build the fixtures from whatever HTTP library the installed pyzotero speaks, rather than from whichever one happens to import — option 2 of the three sketched in the issue.

I went looking for whether the range below 1.15 is worth keeping green before choosing, since option 1 (bump the floor to `>=1.15`) is simpler and the answer decides it. It is: the **full suite passes unmodified on pyzotero 1.14.0**, so nothing else in the tree has drifted past that range, and the floor comment in `pyproject.toml` argues at some length for keeping the floor where it is. Narrowing the supported range to fix a fixture seemed like the wrong trade. Say the word if you'd rather take option 1 and I'll cut it down.

One deviation from what I proposed in the issue. I suggested `try: import httpx2 as httpx / except ImportError: import httpx`, which does not actually distinguish the two — **both can be installed at once**. httpx arrives transitively whatever pyzotero does, and the comment on the `fastmcp<4` pin notes that FastMCP 4 swaps httpx for httpx2, which would put httpx2 on the path beside a pyzotero still using httpx and make that import guess wrong in exactly the direction this PR exists to fix. Asking pyzotero is unambiguous instead: the client it builds for itself is an instance of the library it speaks, on either side of 1.15. A future pyzotero whose client is neither raises with a message naming the class, so the next migration costs one legible error rather than five opaque failures.

## Verification

Full suite on both sides of the split, Python 3.12, dependencies installed exactly as the CI job does:

| | result |
|---|---|
| pyzotero 1.15.1 + httpx2 2.12.0 | 2715 passed, 45 skipped — *was 5 failed* |
| pyzotero 1.14.0 + httpx 0.28.1 | 2715 passed, 45 skipped |

The tests are not passing vacuously in either configuration: `test_transient_429_is_retried_and_recovers` only passes if the retry loop actually ran, and `TooManyRetriesError` is only raised if `error_handler` actually recorded the backoff — the two things that were being bypassed.

`ruff check` is clean. I did not run `ruff format` on the file: it was already non-conformant on `main`, and reformatting it would bury a 5-line change under unrelated churn.

## Not fixed here

**#512** — the same library mismatch on the local-API path at runtime, where `_make_local_http_client` hands pyzotero an httpx 0.28 client, so its error handling is bypassed for real and a throttled dedup search silently duplicates. That one needs a decision about whether `_make_local_http_client`'s HTTP/1.1 pinning (#160) carries over to httpx2 before it can be patched, and it is not a test-only change. Worth noting that this PR does not make the suite cover it: these fixtures now exercise the web-API path, which was never the broken one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
