### PR TITLE
fix: page the JSON re-fetch so local-API children stop truncating it (#499)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`zotero-cli --json` no longer drops most of a search's results in local mode (#499).** The JSON path reuses the markdown path's selection verbatim — it reads the item keys back out of the rendered markdown and re-fetches them — so the two modes are meant to differ only in rendering. The re-fetch asked for `itemKey=<chunk>` with `limit=len(chunk)`, which is exactly right against the web API and wrong against the local one: the local API answers an `itemKey` filter with the requested items *plus* their children, and it lists the children first. A cap sized to the number of keys asked for therefore truncated the response before any parent appeared. Requesting a single key at `limit=1` returned that item's attachment and nothing else, leaving `found` holding only child keys, and the projection step — which drops keys it cannot resolve rather than faking them — returned nothing. On a live library a search that markdown mode answered with 14 items came back as `count: 6`, and single-key selections came back as `count: 0`; no error was raised in either case, so a caller reading only the JSON saw a smaller library than it has. The re-fetch is now paged through `_paginate` and filtered to the requested keys, which is what `zotero_export_bibliography` already does for the same quirk (#371). Web API users are unaffected and pay no extra request: that API filters `itemKey` correctly, so the first page comes back short of a full page and paging stops there.
+
 ## [0.11.0] - 2026-08-25
 
 **Upgrading:** `zotero_semantic_search` now defaults to the active library instead of every indexed library. If you relied on the old implicit behaviour, pass `search_all_libraries=True`.

--- a/src/zotero_mcp/cli_standalone.py
+++ b/src/zotero_mcp/cli_standalone.py
@@ -31,6 +31,7 @@ from zotero_mcp.cli import (
     obfuscate_config_for_display,
     setup_zotero_environment,
 )
+from zotero_mcp.utils import _paginate
 
 # ---------------------------------------------------------------------------
 # Context
@@ -139,6 +140,18 @@ def _fetch_projected(zot, keys: list[str], detail: str = "summary") -> list[dict
     -- so it is restored explicitly rather than left to whatever the API
     returns. Keys the fetch does not return (deleted between the two calls,
     or not visible to this client) are dropped rather than faked.
+
+    The fetch is paged rather than capped at ``len(chunk)``. The local API
+    answers an ``itemKey`` filter with the requested items *plus* their
+    children, and it lists the children first, so a cap sized to the number of
+    keys asked for truncates the response before the parents appear. A single
+    key -- ``limit=1`` -- came back as that item's attachment alone, leaving
+    ``found`` without the one key the caller wanted. Nothing raised: the caller
+    just saw a shorter list than markdown mode returns for the same query, or
+    ``count: 0`` when children filled the cap outright (#499). The same quirk
+    is already handled this way for ``zotero_export_bibliography`` (#371). Paging is a no-op against the web API, which filters correctly and
+    returns at most ``len(chunk)`` records: the first page comes back short and
+    the loop stops, so no extra request is made.
     """
     if not keys:
         return []
@@ -147,7 +160,7 @@ def _fetch_projected(zot, keys: list[str], detail: str = "summary") -> list[dict
     for i in range(0, len(keys), 50):
         chunk = keys[i:i + 50]
         try:
-            batch = zot.items(itemKey=",".join(chunk), limit=len(chunk))
+            batch = _paginate(zot.items, itemKey=",".join(chunk))
         except Exception:
             batch = []
         for item in batch or []:

--- a/tests/test_cli_json_output.py
+++ b/tests/test_cli_json_output.py
@@ -176,12 +176,52 @@ class TestFetchProjected:
         """itemKey takes at most 50 per request."""
         keys = [f"K{i:07d}" for i in range(120)]
         zot = MagicMock()
-        zot.items.side_effect = lambda itemKey, limit: [
+        zot.items.side_effect = lambda itemKey, start=0, limit=100: [
             _raw(k) for k in itemKey.split(",")
         ]
         got = _fetch_projected(zot, keys, "keys_only")
         assert len(got) == 120
         assert zot.items.call_count == 3
+
+    def test_local_api_children_do_not_crowd_out_the_parents(self):
+        """The local API answers an itemKey filter with the requested items
+        *plus* their children, and lists the children first. Sizing the request
+        to the number of keys asked for therefore truncated the response before
+        any parent appeared: `found` came back holding only child keys, and a
+        search markdown mode answers with eight items rendered as
+        `count: 0` (#499).
+
+        The fake honours `start`/`limit` so the pre-fix call -- one request
+        capped at len(keys) -- is expressible against it, and fails.
+        """
+        keys = ["AAAA1111", "BBBB2222"]
+        expanded = [
+            _raw("CHILD001", item_type="attachment"),
+            _raw("CHILD002", item_type="attachment"),
+            _raw("AAAA1111"),
+            _raw("CHILD003", item_type="note"),
+            _raw("BBBB2222"),
+        ]
+        zot = MagicMock()
+        zot.items.side_effect = (
+            lambda itemKey, start=0, limit=100: expanded[start:start + limit]
+        )
+        got = _fetch_projected(zot, keys, "keys_only")
+        assert [i["key"] for i in got] == keys
+
+    def test_a_web_api_selection_still_costs_one_request(self):
+        """The web API filters itemKey correctly and returns at most one record
+        per key, so the first page comes back short of a full page and paging
+        stops there. Fixing the local API's behaviour must not buy a second
+        round trip for everyone else."""
+        keys = ["AAAA1111", "BBBB2222"]
+        zot = MagicMock()
+        zot.items.side_effect = lambda itemKey, start=0, limit=100: (
+            [_raw(k) for k in itemKey.split(",")] if start == 0 else []
+        )
+        got = _fetch_projected(zot, keys, "keys_only")
+        assert [i["key"] for i in got] == keys
+        assert zot.items.call_count == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #499.

## The bug

`zotero-cli --json search` silently returns a subset of what markdown mode returns, in local mode. On a live library here:

```console
$ zotero-cli search "bandit" --limit 20 | grep -c '^## '
14
$ zotero-cli --json search "bandit" --limit 20 | jq '.data.count'
6
```

No error either way — a caller reading only the JSON just sees a smaller library than it has. With a single-key selection it collapses to `count: 0`, which is how the issue was originally reported.

## Why

The JSON path deliberately reuses the markdown path's selection: it reads the item keys back out of the rendered markdown and re-fetches them, so that the two modes can only differ in rendering. The re-fetch was:

```python
batch = zot.items(itemKey=",".join(chunk), limit=len(chunk))
```

That cap is exactly right against the web API, and wrong against the local one. The local API answers an `itemKey` filter with the requested items **plus their children**, and lists the children **first**:

```console
$ curl -s 'http://localhost:23119/api/users/0/items?itemKey=F8WAS3ID,CTXJTJTF,...&limit=8' | jq -r '.[].data.title'
Preprint PDF          # <- children, filling the cap
Preprint PDF
Preprint PDF
Preprint PDF
Preprint PDF
Threshold Bandit, With and Without Censored Feedback
From Restless to Contextual: A Thresholding Bandit Reformulation ...
Satisficing Regret Minimization in Bandits ...
```

Eight keys requested, `limit=8`, three parents survive. `found` holds mostly child keys, and the projection step — which drops keys it cannot resolve rather than faking them — discards the rest. Requesting the same eight keys at `limit=100` returns 8/8.

`_keys_from_markdown` is not implicated; it extracted all eight keys correctly in every case I checked.

## The fix

Page the re-fetch through `_paginate` and keep the existing filter to the requested keys. This is the handling `zotero_export_bibliography` already uses for the same local-API quirk (#371) — that path fetches wide and filters client-side, and the CHANGELOG entry for #371 describes the identical behaviour ("requesting a single key returned it alongside three others").

**Web API users are unaffected and pay no extra request.** That API filters `itemKey` correctly and returns at most one record per key, so the first page comes back short of a full page and `_paginate` stops there. `test_a_web_api_selection_still_costs_one_request` pins that.

## Tests

- `test_local_api_children_do_not_crowd_out_the_parents` — the new regression test. Its fake honours `start`/`limit`, so the pre-fix call (one request capped at `len(keys)`) is expressible against it; on `main` the test fails with `assert [] == ['AAAA1111', 'BBBB2222']`, which is the reported bug rather than a mock signature mismatch.
- `test_a_web_api_selection_still_costs_one_request` — new, guards the round-trip count.
- `test_more_than_fifty_keys_are_chunked` — existing; its fake gained `start=0, limit=100` defaults. Assertions unchanged, still 3 calls for 120 keys.

`pytest tests/ --ignore=tests/live`: 2465 passed. Six failures are present unchanged on `main` at `3cb3e2e` and are unrelated to this change — `test_pdf_cascade.py::test_cascade_order`, and five in `test_rate_limit_guard.py` that look like the pyzotero/httpx2 fixture problem already tracked in #511/#513.

Verified end-to-end against a live Zotero 7 local API on Linux: markdown 14, JSON 14 after the patch; markdown 14, JSON 6 before it.

## Note

#500 and #505 are two more reports against this same markdown-keys → re-fetch → project layer. This PR fixes only the `limit` truncation in `_fetch_projected`; #500's `- Key:` parsing is a separate defect in `_keys_from_markdown` and is left to #504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9BdFs5DQQy2WZ1hoj54m8
