### PR TITLE
fix: correct three inaccuracies in the zotero-cli skill reference

### DIFF
--- a/scripts/gen_skill_reference.py
+++ b/scripts/gen_skill_reference.py
@@ -29,7 +29,10 @@ Generated from the CLI's own argument parser by
 `scripts/gen_skill_reference.py` -- do not edit by hand.
 
 Every command also accepts `--json` (machine-readable envelope on stdout) and
-`-v` (diagnostics on stderr), before or after the command name. Run
+`-v` (diagnostics on stderr). Both are defined on the top-level parser and on
+each first-level command, so they may precede the command name or follow it,
+but not follow a sub-command: `get --json metadata KEY` parses and
+`get metadata --json KEY` does not. Run
 `zotero-cli --json-schema` for the output contract.
 
 """
@@ -68,7 +71,27 @@ def _render(name: str, parser, out: io.StringIO, depth: int = 2,
     if desc:
         out.write(f"\n{desc}\n")
 
-    lines = [ln for ln in (_format_action(a) for a in parser._actions) if ln]
+    # Options in a mutually exclusive group are rendered as one entry. Listing them
+    # flatly reads as "pass either, or both", which argparse rejects at parse time.
+    exclusive = {}
+    for group in getattr(parser, "_mutually_exclusive_groups", []):
+        members = [a for a in group._group_actions if _format_action(a)]
+        if len(members) > 1:
+            for a in members:
+                exclusive[id(a)] = members
+    lines, rendered = [], set()
+    for action in parser._actions:
+        members = exclusive.get(id(action))
+        if members is None:
+            line = _format_action(action)
+            if line:
+                lines.append(line)
+            continue
+        if id(members[0]) in rendered:
+            continue
+        rendered.add(id(members[0]))
+        names = " / ".join(f"`{m.option_strings[0]}`" for m in members)
+        lines.append(f" - {names} -- mutually exclusive")
     if lines:
         out.write("\n")
         out.write("\n".join(lines))

--- a/src/zotero_mcp/skills/zotero-cli/SKILL.md
+++ b/src/zotero_mcp/skills/zotero-cli/SKILL.md
@@ -65,6 +65,7 @@ zotero-cli --json search "diffusion models" --limit 5 --detail keys_only \
 | `tag` | items you filed under a tag | `search --mode tag "to-read,important"` |
 | `advanced` | structured field conditions | `search --mode advanced --conditions '[...]'` |
 | `citekey` | a BibTeX citation key | `search --mode citekey smith2020` |
+| `notes` | text inside your notes, not item fields | `search --mode notes "research question"` |
 
 `semantic` needs the search index built (`zotero-cli db status` to check,
 `zotero-cli db update` to build). If it is empty, fall back to `items` and

--- a/src/zotero_mcp/skills/zotero-cli/reference.md
+++ b/src/zotero_mcp/skills/zotero-cli/reference.md
@@ -4,7 +4,10 @@ Generated from the CLI's own argument parser by
 `scripts/gen_skill_reference.py` -- do not edit by hand.
 
 Every command also accepts `--json` (machine-readable envelope on stdout) and
-`-v` (diagnostics on stderr), before or after the command name. Run
+`-v` (diagnostics on stderr). Both are defined on the top-level parser and on
+each first-level command, so they may precede the command name or follow it,
+but not follow a sub-command: `get --json metadata KEY` parses and
+`get metadata --json KEY` does not. Run
 `zotero-cli --json-schema` for the output contract.
 
 
@@ -272,8 +275,7 @@ Every command also accepts `--json` (machine-readable envelope on stdout) and
  - `--allow-mass-deletion`
  - `--config-path`
  - `--db-path`
- - `--openai-batch`
- - `--no-openai-batch`
+ - `--openai-batch` / `--no-openai-batch` -- mutually exclusive
 
 ### `db batch-status`
 


### PR DESCRIPTION
# Three documentation defects in the zotero-cli skill

Found while vendoring `src/zotero_mcp/skills/zotero-cli` into another repository and
checking every claim in it against the parser. All three are still present on `main`.
Each was verified by running the real `build_parser()`, not by reading.

## 1. The search-mode table is missing a mode

`SKILL.md` documents five `--mode` values. The parser accepts six:

    --mode {items,tag,citekey,advanced,semantic,notes}

`reference.md` already lists all six, so only the table in `SKILL.md` is short. An agent
working from the table alone will not reach `notes` mode.

## 2. The `--json` placement rule is wrong for two-level commands

`reference.md` says the flag works "before or after the command name". That holds for
single-level commands and fails for sub-commands, because `--json` is defined on the
top-level parser and on each first-level command but not on sub-parsers:

    zotero-cli search --json "q"           # parses
    zotero-cli get --json metadata KEY     # parses
    zotero-cli get metadata --json KEY     # error: unrecognized arguments: --json

The sentence lives in `HEADER` in `scripts/gen_skill_reference.py`, so it is fixed there
rather than in the generated file.

## 3. Mutually exclusive flags are rendered as independent options

`db update` declares `[--openai-batch | --no-openai-batch]`, and the generated reference
lists them as two separate bullets, which reads as "pass either, or both". The generator
walks `parser._actions` flatly and never consults `_mutually_exclusive_groups`.

This is the only mutually exclusive pair in the CLI today, confirmed by walking every
command and sub-command, so the generator change alters exactly one line of output.

## What this changes

- `scripts/gen_skill_reference.py`: corrected `HEADER` text, and options in a mutually
  exclusive group now render as one entry.
- `src/zotero_mcp/skills/zotero-cli/SKILL.md`: one row added for `notes`.
- `src/zotero_mcp/skills/zotero-cli/reference.md`: regenerated. The diff is limited to
  the two intended changes, which also confirms the generator change is not disruptive.

Regenerated with the installed 0.11.0 parser via `python scripts/gen_skill_reference.py`.
