### PR TITLE
fix: follow pyzotero 1.15 to httpx2 — local-mode errors escaped raw, and CI has been red since 08-31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **With pyzotero 1.15, every error response from the local Zotero API escaped as a raw `httpx.HTTPStatusError` instead of a pyzotero error.** pyzotero 1.15.0 replaced `httpx` with `httpx2`. For the local server we hand pyzotero our own client, pinned to HTTP/1.1 (#160), and that client was still an `httpx.Client`. pyzotero classifies error responses by calling `raise_for_status` inside `except httpx2.HTTPError`, which does not catch the `httpx` error the old client's responses raise — so a 404 was no longer a `ResourceNotFoundError`, a 412 no longer a `PreConditionFailedError`, and nothing downstream that catches pyzotero's errors saw them. The same mismatch is why the rate-limit tests, which fabricate `httpx.Response` objects, failed on every platform against 1.15.1: the 429 never reached pyzotero's retry loop. The local client is now built from whichever library pyzotero itself imports (`httpx2` from 1.15, `httpx` before — the two share the `Client`/`HTTPTransport` API), and the tests fabricate their responses from the same one, so both hold on either side of the switch. Verified against pyzotero 1.14.0 and 1.15.1.
+
 ## [0.11.0] - 2026-08-25
 
 **Upgrading:** `zotero_semantic_search` now defaults to the active library instead of every indexed library. If you relied on the old implicit behaviour, pass `search_all_libraries=True`.

--- a/src/zotero_mcp/client.py
+++ b/src/zotero_mcp/client.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import httpx
 from dotenv import load_dotenv
 from pyzotero import zotero
 
@@ -162,17 +161,39 @@ def get_active_group_id() -> int:
     return 0
 
 
-def _make_local_http_client() -> httpx.Client:
-    """Return an httpx.Client pinned to HTTP/1.1 for the local Zotero server.
+def _pyzotero_http():
+    """The HTTP library pyzotero speaks: ``httpx2`` from 1.15, ``httpx`` before.
+
+    pyzotero classifies error responses by calling ``raise_for_status`` inside
+    ``except <its library>.HTTPError``. A client built from the *other* library
+    returns responses whose errors that clause does not catch, so every non-2xx
+    from the local API would escape as that library's raw ``HTTPStatusError``
+    instead of a ``ResourceNotFoundError``, ``PreConditionFailedError`` and so
+    on. The two libraries share the ``Client``/``HTTPTransport`` API, so the
+    only thing that has to match is which one we build from; pyzotero's own
+    import is the one place that choice is recorded.
+    """
+    from pyzotero import _client as pz_client
+
+    module = getattr(pz_client, "httpx2", None) or getattr(pz_client, "httpx", None)
+    if module is None:  # a future pyzotero; fall back to what it depended on so far
+        import httpx as module
+    return module
+
+
+def _make_local_http_client():
+    """Return an HTTP client pinned to HTTP/1.1 for the local Zotero server.
 
     Zotero 8's local server (port 23119) only speaks HTTP/1.0. httpx defaults
     to attempting HTTP/2 negotiation, which the local server rejects with 502
     Bad Gateway — every tool call fails even though the MCP starts cleanly
     (#160). Forcing http1=True / http2=False on the transport keeps requests
-    on HTTP/1.1 and the local API answers normally.
+    on HTTP/1.1 and the local API answers normally. Built from the library
+    pyzotero uses (see :func:`_pyzotero_http`).
     """
-    return httpx.Client(
-        transport=httpx.HTTPTransport(http1=True, http2=False),
+    http = _pyzotero_http()
+    return http.Client(
+        transport=http.HTTPTransport(http1=True, http2=False),
         follow_redirects=True,
     )
 

--- a/tests/test_local_http1_transport.py
+++ b/tests/test_local_http1_transport.py
@@ -6,10 +6,14 @@ to attempting HTTP/2 negotiation, which the local server rejects with
 cleanly. The fix pins the local pyzotero client's transport to HTTP/1.1.
 """
 
-import httpx
 from pyzotero import zotero
 
 from zotero_mcp import client as zclient
+
+# The library pyzotero uses: httpx2 from 1.15, httpx before. The local
+# client must be built from the same one, or pyzotero cannot classify its
+# error responses.
+httpx = zclient._pyzotero_http()
 
 
 def test_make_local_http_client_pins_http1():

--- a/tests/test_pyzotero_http_module.py
+++ b/tests/test_pyzotero_http_module.py
@@ -1,0 +1,56 @@
+"""pyzotero 1.15 replaced httpx with httpx2; our local-mode client must follow.
+
+For the local Zotero server we hand pyzotero our own HTTP client, pinned to
+HTTP/1.1 (#160). pyzotero turns error responses into its exception classes by
+calling ``raise_for_status`` inside ``except <its library>.HTTPError``. A client
+from the *other* library returns responses whose errors that clause does not
+catch, so with pyzotero 1.15.1 and an ``httpx.Client`` every non-2xx from the
+local API escaped as a raw ``httpx.HTTPStatusError`` — a 404 was no longer a
+``ResourceNotFoundError``, a 412 no longer a ``PreConditionFailedError`` — and
+nothing downstream that catches pyzotero's errors saw them.
+
+These tests are written against whichever library pyzotero imports, so they
+hold on both sides of the 1.15 switch.
+"""
+
+import sys
+
+import pytest
+from pyzotero import zotero_errors as ze
+from pyzotero.zotero import Zotero
+
+from zotero_mcp import client as zclient
+
+
+def _module_pyzotero_uses():
+    """Read it off a real pyzotero instance, independently of the helper under test."""
+    zot = Zotero(library_id="1", library_type="user", api_key="x" * 24)
+    return sys.modules[type(zot.client).__module__.split(".")[0]]
+
+
+def test_helper_names_the_library_pyzotero_uses():
+    assert zclient._pyzotero_http() is _module_pyzotero_uses()
+
+
+def test_local_client_is_the_kind_pyzotero_handles():
+    c = zclient._make_local_http_client()
+    try:
+        assert isinstance(c, _module_pyzotero_uses().Client)
+    finally:
+        c.close()
+
+
+def test_error_responses_still_become_pyzotero_errors():
+    """The user-visible regression: a 404 through our client must be a
+    ResourceNotFoundError, not the HTTP library's own status error."""
+    http = zclient._pyzotero_http()
+
+    def not_found(request):
+        return http.Response(404, headers={"Content-Type": "text/plain"},
+                             content=b"Not found", request=request)
+
+    zot = Zotero(library_id="1", library_type="user", api_key="x" * 24)
+    zot.client = http.Client(transport=http.MockTransport(not_found))
+
+    with pytest.raises(ze.ResourceNotFoundError):
+        zot.item("NOPE")

--- a/tests/test_rate_limit_guard.py
+++ b/tests/test_rate_limit_guard.py
@@ -13,13 +13,19 @@ the symptom is a silent duplicate rather than an error, so these tests are the
 only thing standing between the two.
 """
 
-import httpx
 import pytest
 from conftest import DummyContext
 from pyzotero.zotero import Zotero
 from pyzotero.zotero_errors import TooManyRetriesError
 
+from zotero_mcp.client import _pyzotero_http
 from zotero_mcp.tools import _helpers
+
+# Responses must come from the library pyzotero itself uses (httpx2 from 1.15,
+# httpx before): its retry loop catches only that library's HTTPError, so a
+# response from the other one escapes as a raw status error instead of
+# being retried.
+httpx = _pyzotero_http()
 
 _REQ = httpx.Request("GET", "https://api.zotero.org/users/1/items")
 _ITEM = [{"key": "EXIST001", "version": 1,


### PR DESCRIPTION
## The bug

CI on `main` has been red on all five platforms since [the 2026-08-31 run](https://github.com/54yyyu/zotero-mcp/actions/runs/33391898366) — on the 0.11.0 release commit, which passed on 08-25. The difference between the two runs is pyzotero: 1.14.0 then, 1.15.1 now. pyzotero 1.15.0 (2026-08-29) replaced `httpx` with `httpx2` (urschrei/pyzotero@272634c).

That breaks more than the tests. For the local Zotero server, `_make_local_http_client()` hands pyzotero an `httpx.Client` pinned to HTTP/1.1 (#160). pyzotero turns error responses into its exception classes with `raise_for_status()` inside `except httpx2.HTTPError` — which does not catch the `httpx.HTTPStatusError` that an `httpx` response raises. So with pyzotero 1.15.1 in local mode, every non-2xx escapes raw:

```
$ python -c "..."   # Zotero() with an httpx.Client whose transport answers 404
BUG: httpx.HTTPStatusError - Client error '404 Not Found' for url 'https://api.zotero.org/users/1/items/NOPE'
```

instead of `ResourceNotFoundError`. Nothing downstream that catches pyzotero's errors (`PreConditionFailedError` in the write helpers, `TooManyRetriesError`/`TooManyRequestsError` in `find_existing_items`, ...) sees them any more.

The five `test_rate_limit_guard.py` failures are the same mismatch from the other side: the tests fabricate `httpx.Response` objects, whose 429 never reaches pyzotero's retry loop, hence `httpx.HTTPStatusError: Client error '429'` on every platform.

## The fix

`client._pyzotero_http()` returns whichever library pyzotero itself imports (`httpx2` from 1.15, `httpx` before; read off `pyzotero._client`, the one place the choice is recorded), and `_make_local_http_client()` builds from that. The two libraries share the `Client` / `HTTPTransport(http1=, http2=)` / `MockTransport` API, so nothing else changes. The rate-limit and HTTP/1.1 transport tests fabricate their responses from the same module, so they hold on either side of the switch.

Not touched: the `httpx>=0.27` entry in `pyproject.toml`. After this change nothing in `src/` imports `httpx` directly, so it could go, but that is a separate decision.

## Verification

- New `tests/test_pyzotero_http_module.py`: the helper names the library a real `Zotero()` instance uses; the local client is that library's `Client`; and the regression itself — a 404 through our client is a `ResourceNotFoundError`.
- The three affected test files pass against pyzotero 1.15.1 (locked) and against 1.14.0 (`uv run --with "pyzotero==1.14.0" pytest ...`).
- Full suite: 2733 passed, 39 skipped, 0 failed (was 5 failed on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
