### PR TITLE
fix: zotero_get_attachment_path accepts an attachment's own key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`zotero_get_attachment_path` accepts an attachment's own key.** Handed the key of a PDF attachment — which is exactly what `zotero_get_item_children` lists — it returned "No attachments found for item", because it only walked the parent's children via `get_item_by_key`, whose query excludes the 'attachment' item type (the #372 root cause again). It now falls back to `get_attachment_by_key` and resolves that single attachment; parent keys behave as before, and an unknown key still reports nothing.
+
 ## [0.11.0] - 2026-08-25
 
 **Upgrading:** `zotero_semantic_search` now defaults to the active library instead of every indexed library. If you relied on the old implicit behaviour, pass `search_all_libraries=True`.

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -296,6 +296,14 @@ def get_attachment_path(
 
         with LocalZoteroReader(db_path=load_config().resolve_zotero_db_path()) as reader:
             attachments = reader.get_attachment_paths(item_key)
+            if not attachments:
+                # item_key may be the attachment's OWN key (get_item_by_key
+                # excludes attachments, so the parent lookup yields nothing).
+                att = reader.get_attachment_by_key(item_key)
+                if att:
+                    resolved = reader._resolve_attachment_path(att["key"], att.get("zotero_path") or "")
+                    attachments = [{**att, "resolved_path": resolved,
+                                    "exists": bool(resolved and resolved.exists())}]
 
         if not attachments:
             return f"No attachments found for item `{item_key}`."

--- a/tests/test_attachment_path_attachment_key.py
+++ b/tests/test_attachment_path_attachment_key.py
@@ -1,0 +1,56 @@
+"""``zotero_get_attachment_path`` given an ATTACHMENT key said "No attachments found".
+
+Same root cause as #372: the tool only walked ``get_attachment_paths(parent_key)``,
+which goes through ``get_item_by_key`` — a query that excludes the 'attachment'
+item type — so the attachment's own key resolved to nothing. The reader already
+had ``get_attachment_by_key`` (added for #372); the path tool never used it.
+Keys handed out by ``zotero_get_item_children`` are attachment keys, so this was
+the natural next call to make, and it failed every time.
+"""
+
+import types
+
+from conftest import DummyContext
+from test_issue_372_pdf_tools import ATTACHMENT_KEY, PARENT_KEY, make_library
+
+from zotero_mcp.tools import retrieval as retrieval_tools
+
+
+def use_local_library(monkeypatch, db_path):
+    monkeypatch.setattr("zotero_mcp.utils.is_local_mode", lambda: True)
+    monkeypatch.setattr(
+        retrieval_tools,
+        "load_config",
+        lambda: types.SimpleNamespace(resolve_zotero_db_path=lambda: str(db_path)),
+    )
+
+
+def test_attachment_key_resolves_to_its_own_path(monkeypatch, tmp_path):
+    db_path, pdf_path = make_library(tmp_path)
+    use_local_library(monkeypatch, db_path)
+
+    result = retrieval_tools.get_attachment_path(item_key=ATTACHMENT_KEY, ctx=DummyContext())
+
+    assert "No attachments found" not in result
+    assert f"## `{ATTACHMENT_KEY}` (application/pdf)" in result
+    assert f"- Local path: `{pdf_path}`" in result
+    assert "missing on disk" not in result
+
+
+def test_parent_key_still_lists_children(monkeypatch, tmp_path):
+    db_path, pdf_path = make_library(tmp_path)
+    use_local_library(monkeypatch, db_path)
+
+    result = retrieval_tools.get_attachment_path(item_key=PARENT_KEY, ctx=DummyContext())
+
+    assert f"## `{ATTACHMENT_KEY}` (application/pdf)" in result
+    assert f"- Local path: `{pdf_path}`" in result
+
+
+def test_unknown_key_still_reports_nothing(monkeypatch, tmp_path):
+    db_path, _ = make_library(tmp_path)
+    use_local_library(monkeypatch, db_path)
+
+    result = retrieval_tools.get_attachment_path(item_key="NOSUCHKEY", ctx=DummyContext())
+
+    assert result == "No attachments found for item `NOSUCHKEY`."


### PR DESCRIPTION
## Problem

`zotero_get_item_children` lists PDF attachments by their own keys. Feeding one of those keys to `zotero_get_attachment_path` returns:

```
No attachments found for item `JDK3PHY8`.
```

for every attachment, in local mode, even though the file resolves fine. The tool only calls `get_attachment_paths(parent_key)`, which goes through `get_item_by_key` — and that query excludes the `attachment` item type. So an attachment key resolves to nothing. This is the same root cause as #372; the reader already gained `get_attachment_by_key()` for it, but the path tool never used it.

Observed on 0.9.1 and still present on `main` (0.11.0). It made an agent give up on the MCP and read `zotero.sqlite` directly.

## Fix

When the parent lookup yields nothing, fall back to `reader.get_attachment_by_key(item_key)` and resolve that one attachment through the existing `_resolve_attachment_path`. Eight lines in `tools/retrieval.py`. Parent keys behave exactly as before; an unknown key still reports "No attachments found".

## Tests

`tests/test_attachment_path_attachment_key.py` reuses the #372 fixture library:
- attachment key → its own resolved path (fails on `main`, passes here)
- parent key → still lists its children
- unknown key → unchanged message

Full suite: 2727 passed. The 6 failures I see locally (`test_local_db.py::…without_base_path…` and 5 in `test_rate_limit_guard.py`) fail identically on pristine `main` in my environment and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUngiCkpsVqJmo4fNzDxVk
