### PR TITLE
fix: cap pyzotero at <1.15 — 1.15 drops TooManyRetriesError, breaking 429 handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,9 @@ jobs:
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-timeout "fastmcp<4" pyzotero python-dotenv "pdf-inspector==0.2.6" markdownify chromadb unidecode bibtexparser tiktoken pymupdf
+          # pyzotero must be pinned here too: the editable install below uses
+          # --no-deps, which skips pyproject's dependency constraints.
+          python -m pip install pytest pytest-timeout "fastmcp<4" "pyzotero>=1.13.5,<1.15" python-dotenv "pdf-inspector==0.2.6" markdownify chromadb unidecode "bibtexparser>=1.4,<2" tiktoken pymupdf
           python -m pip install -e . --no-deps
       - name: Run tests
         run: pytest --ignore=tests/test_lifespan.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,11 @@ dependencies = [
     # load-bearing, not just preferred. (1.13.3 is also required, for sending
     # Path(filename).name as the stored-file filename — upstream #341, without
     # which every attach pays for the two-step fallback in _attach_and_verify.)
-    "pyzotero>=1.13.5",
+    # 1.15 removes TooManyRetriesError (only TooManyRequestsError remains),
+    # so the same retry path raises a raw httpx.HTTPStatusError that
+    # find_existing_items does not catch — the 429 escape hatch this floor
+    # exists for. Cap at <1.15 until the error handling is adapted.
+    "pyzotero>=1.13.5,<1.15",
     "python-dotenv>=1.0.0",
     # PDF text extraction. Rust with prebuilt abi3 wheels for every platform
     # we support and no Python dependencies of its own. Pinned exactly while


### PR DESCRIPTION
## Problem

CI is currently red on `main` and on open PRs (e.g. run [34116303775](https://github.com/54yyyu/zotero-mcp/actions/runs/34116303775): 25 failures — all of `tests/test_rate_limit_guard.py` across the 5-job matrix):

```
httpx.HTTPStatusError: Client error '429 Too Many Requests' for url 'https://api.zotero.org/users/1/items'
```

## Root cause

pyzotero 1.15 removed `TooManyRetriesError` (only `TooManyRequestsError` remains). The internal retry path then raises a raw `httpx.HTTPStatusError` on a persistent 429, which `find_existing_items` does not catch — the exact escape the `>=1.13.5` floor was added for (urschrei/pyzotero#352).

This is not hypothetical: with pyzotero 1.15.1 installed, all five rate-limit tests fail; with 1.14.x they pass (verified on both 1.15.1 and 1.14.0 locally, and in CI logs on both sides of the version bump).

## Fix

- Cap `pyzotero>=1.13.5,<1.15` in `pyproject.toml`, extending the existing floor's comment.
- Apply the same pin in the workflow's test-dependency install line: `pip install -e . --no-deps` skips pyproject's constraints entirely, so the unpinned install resolves 1.15.1 regardless of the cap. Also pinned `bibtexparser>=1.4,<2` there to match pyproject (v1-only API), for the same bypass reason.

## Notes

- The cap is a stopgap; a follow-up could adapt `find_existing_items`' error handling to 1.15's exception shape and lift it.
- With these two pins the full 5-job matrix goes green again (same fix verified end-to-end on my fork's identical workflow: [green run](https://github.com/jianxing-chen/zotero-mcp/actions/runs/34122584767)).