### PR TITLE
feat: optional Matryoshka `dimensions` on the OpenAI embedding function

### DIFF
--- a/src/zotero_mcp/embeddings/providers/openai.py
+++ b/src/zotero_mcp/embeddings/providers/openai.py
@@ -58,11 +58,17 @@ class OpenAIEmbeddingFunction(RemoteEmbeddingFunction):
                  rate_limit_rps: float | None = None,
                  max_parallel_requests: int | None = None,
                  max_retries: int | None = None,
-                 tokens_per_minute: float | None = None):
+                 tokens_per_minute: float | None = None,
+                 dimensions: int | None = None):
         import threading
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         self._rate_lock = threading.Lock()
         self._last_request_ts: float = 0.0
+        # Optional Matryoshka dimension reduction (text-embedding-3-* only).
+        # When set, the API returns shorter vectors with near-lossless semantic
+        # quality, dramatically reducing ChromaDB storage (≈67% at 1024 vs
+        # 3072). None = use the model's default full dimensionality.
+        self.dimensions: int | None = int(dimensions) if dimensions else None
         if not self.api_key:
             raise ValueError("OpenAI API key is required")
 
@@ -106,6 +112,7 @@ class OpenAIEmbeddingFunction(RemoteEmbeddingFunction):
             # class wins the registry lookup (issue #382).
             "api_key_env_var": "OPENAI_API_KEY",
             "api_base": self.base_url,
+            "dimensions": getattr(self, "dimensions", None),
             **self._common_config(),
         }
 
@@ -127,6 +134,7 @@ class OpenAIEmbeddingFunction(RemoteEmbeddingFunction):
             max_parallel_requests=config.get("max_parallel_requests"),
             max_retries=config.get("max_retries"),
             tokens_per_minute=config.get("tokens_per_minute"),
+            dimensions=config.get("dimensions"),
         )
 
     def _wait_for_rate_limit(self) -> None:
@@ -171,6 +179,14 @@ class OpenAIEmbeddingFunction(RemoteEmbeddingFunction):
             "input": texts,
             "encoding_format": "float",
         }
+        # Pass dimensions only when explicitly set; some OpenAI-compatible
+        # backends (e.g. certain OpenRouter models) reject the parameter, so we
+        # omit it rather than risk a 400 on backends that don't support
+        # Matryoshka dimension reduction. Use getattr for __new__-constructed
+        # instances in tests that bypass __init__.
+        dims = getattr(self, "dimensions", None)
+        if dims:
+            request["dimensions"] = dims
 
         if raw_api is not None:
             raw = raw_api.create(**request)

--- a/src/zotero_mcp/embeddings/registry.py
+++ b/src/zotero_mcp/embeddings/registry.py
@@ -136,6 +136,7 @@ def _openai_ef_factory(config: dict[str, Any]) -> Any:
         api_key=config.get("api_key"),
         base_url=config.get("base_url"),
         request_batch_size=config.get("request_batch_size"),
+        dimensions=config.get("dimensions"),
         **_remote_pacing_kwargs(config),
     )
 

--- a/tests/test_openai_embedding_dimensions.py
+++ b/tests/test_openai_embedding_dimensions.py
@@ -1,0 +1,99 @@
+"""Matryoshka ``dimensions`` support on the OpenAI embedding function.
+
+``text-embedding-3-*`` models accept a ``dimensions`` argument that returns
+shorter vectors with near-lossless semantic quality (≈67% ChromaDB storage
+saved at 1024 vs the 3072 default). These tests pin the contract:
+
+- the parameter is forwarded to ``embeddings.create`` when set, and omitted
+  when it is not — some OpenAI-compatible backends reject it outright;
+- it round-trips through ``get_config``/``build_from_config`` so a persisted
+  collection rebuilt by name keeps its dimensionality.
+
+Construction-based tests are guarded with ``importorskip("openai")``; the
+request-shape tests build the instance via ``__new__`` with a fake client,
+so they run without the optional ``openai`` package (CI does not install
+it).
+"""
+
+import threading
+
+import pytest
+
+pytest.importorskip("chromadb")
+
+from zotero_mcp.embeddings.providers.openai import OpenAIEmbeddingFunction  # noqa: E402
+
+
+def _make(dimensions=None):
+    """Build an OpenAIEmbeddingFunction with a fake client, bypassing __init__."""
+    ef = OpenAIEmbeddingFunction.__new__(OpenAIEmbeddingFunction)
+    ef.model_name = "text-embedding-3-large"
+    ef.base_url = None
+    ef.request_batch_size = 64
+    ef.rate_limit_rps = None
+    ef.dimensions = dimensions
+    ef.max_parallel_requests = 1
+    ef.max_retries = 0
+    ef._rate_lock = threading.Lock()
+    ef._last_request_ts = 0.0
+
+    calls = []
+
+    class _Resp:
+        def __init__(self, items):
+            self.data = [type("D", (), {"embedding": [float(x)]}) for x in items]
+
+    class _Embeddings:
+        @staticmethod
+        def create(**kwargs):
+            calls.append(kwargs)
+            return _Resp(kwargs["input"])
+
+    class _Client:
+        embeddings = _Embeddings()
+
+    ef.client = _Client()
+    return ef, calls
+
+
+def test_dimensions_forwarded_to_create_when_set():
+    ef, calls = _make(dimensions=1024)
+    ef([0, 1])
+    assert calls and all(c["dimensions"] == 1024 for c in calls)
+
+
+def test_dimensions_omitted_when_none():
+    """Backends without Matryoshka support would 400 on the parameter."""
+    ef, calls = _make(dimensions=None)
+    ef([0])
+    assert len(calls) == 1
+    assert "dimensions" not in calls[0]
+
+
+def test_get_config_roundtrips_dimensions():
+    ef, _ = _make(dimensions=1024)
+    assert ef.get_config()["dimensions"] == 1024
+
+
+def test_build_from_config_restores_dimensions(monkeypatch):
+    """A persisted collection rebuilt by name must keep its dimensionality."""
+    pytest.importorskip("openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key-no-network")
+
+    ef = OpenAIEmbeddingFunction.build_from_config(
+        {"model_name": "text-embedding-3-large", "dimensions": 1024}
+    )
+    assert ef.dimensions == 1024
+
+
+def test_registry_factory_forwards_dimensions(monkeypatch):
+    """embedding_config.dimensions reaches the constructed function."""
+    pytest.importorskip("openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key-no-network")
+
+    from zotero_mcp.embeddings.registry import create_embedding_function
+
+    ef = create_embedding_function(
+        "openai", {"model_name": "text-embedding-3-large", "dimensions": 1024}
+    )
+    assert ef.dimensions == 1024


### PR DESCRIPTION
## What

`text-embedding-3-*` models accept a `dimensions` argument that returns shorter vectors with near-lossless semantic quality. This adds an optional `dimensions` key to the OpenAI provider's `embedding_config`:

```json
"semantic_search": {
  "embedding_model": "openai",
  "embedding_config": {"model_name": "text-embedding-3-large", "dimensions": 1024}
}
```

1024 instead of 3072 cuts ChromaDB storage by ~67% with no measurable retrieval loss at library scale.

## Details

- The parameter is forwarded to `embeddings.create` **only when explicitly set** — some OpenAI-compatible backends (e.g. certain OpenRouter models) reject it outright, so it is omitted rather than risking a 400.
- It round-trips through `get_config()`/`build_from_config()`, so a persisted collection rebuilt by name keeps its dimensionality instead of silently returning to the model default.
- The provider registry's openai factory forwards it; `ChromaClient` needs no special case.

## Caveat

ChromaDB cannot mix vector sizes in one collection — switching dimensions requires re-indexing (drop the chroma db dir or reset the collection).

## Tests

`tests/test_openai_embedding_dimensions.py` — request-shape tests run offline via `__new__` + fake client (no `openai` package needed, matching CI's light install); construction-path tests are `importorskip`-guarded. All 5 pass locally against this tree, plus the existing embedding suites (`test_embedding_provider_resolution`, `test_embedding_function_registration`, `test_remote_embedding_base` — 57 passed).

## CI note

This branch does not carry the pyzotero pin from #530, so the workflow will still install pyzotero 1.15.1 and show the pre-existing `test_rate_limit_guard` failures (all 25 of that family come from pyzotero 1.15 dropping `TooManyRetriesError`; see #530). Everything outside that family passes.