### PR TITLE
Maintenance: 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`zotero_get_item_fulltext` says when a document was cut short.** Reads stop at `fulltext_display_max_pages` (10 by default), but the text returned for the first ten pages of a 442-page book was byte-for-byte indistinguishable from the text returned for a complete three-page note: same `## Full Text` heading, no marker anywhere, and a tool description that promised "the entire paper". An agent summarized and cited the excerpt as if it had read the whole thing. The parser already reports `page_count` and `truncated` on every extraction, so both capped paths — local storage and the last-resort download+parse — now carry them through to the heading: `## Full Text (pages 1-10 of 442 — TRUNCATED)`, followed by the config key to raise and the `zotero_read_pdf_pages` call that resumes at the first unread page. A read that fits under the cap is unchanged. Zotero's own `.zotero-ft-cache` and the transient fulltext cache are not page-capped and are never reported as truncated. `LocalZoteroReader`'s parser seam returns the whole `ExtractedDoc` instead of just its text, so page bookkeeping has one source of truth rather than being re-derived by callers (#448).
+
 ## [0.11.0] - 2026-08-25
 
 **Upgrading:** `zotero_semantic_search` now defaults to the active library instead of every indexed library. If you relied on the old implicit behaviour, pass `search_all_libraries=True`.

--- a/src/zotero_mcp/local_db.py
+++ b/src/zotero_mcp/local_db.py
@@ -22,6 +22,7 @@ from . import fulltext_cache
 from . import search_semantics as _semantics
 from .config import load_config
 from .extract import (
+    ExtractedDoc,
     categorize_attachment,
     extract_file,
     normalize_attachment_priority,
@@ -65,6 +66,23 @@ class KeyGroupMap(NamedTuple):
 
     groups: dict[str, int]
     excluded_keys: set[str]
+
+
+@dataclass
+class FulltextExtraction:
+    """Extracted attachment text, plus how much of the document it covers.
+
+    ``page_count`` is the document's real length and ``truncated`` says the
+    page cap dropped pages from the tail — both straight from
+    :class:`~zotero_mcp.extract.ExtractedDoc`. They carry their defaults on
+    the cache paths, which are not page-capped and keep no page bookkeeping
+    (#448).
+    """
+
+    text: str
+    source: str
+    page_count: int | None = None
+    truncated: bool = False
 
 
 def _read_string_pref(prefs_path: Path, pref: str) -> str | None:
@@ -805,10 +823,15 @@ class LocalZoteroReader:
         except ValueError:
             return DEFAULT_PDF_MAX_PAGES
 
-    def _extract_text_from_file(self, file_path: Path) -> str:
-        """Extract text from an attachment file, or "" if nothing readable."""
-        doc = extract_file(file_path, max_pages=self._resolve_pdf_max_pages())
-        return doc.text if doc else ""
+    def _extract_doc_from_file(self, file_path: Path) -> ExtractedDoc | None:
+        """Parse an attachment file, or None if nothing readable came back.
+
+        Returns the whole document rather than its text: how long the source
+        is and whether the page cap cut it short are the parser's to report,
+        and a caller that has to re-derive them gets a second source of truth
+        (#448).
+        """
+        return extract_file(file_path, max_pages=self._resolve_pdf_max_pages())
 
     def _get_fulltext_meta_for_item(self, item_id: int):
         meta = []
@@ -997,10 +1020,10 @@ class LocalZoteroReader:
                 return result
         return None
 
-    def _extract_fulltext_for_item(
+    def extract_fulltext_detailed(
         self, item_id: int, item_key: str | None = None
-    ) -> tuple[str, str] | None:
-        """Attempt to extract fulltext and source from the item's best attachment.
+    ) -> FulltextExtraction | None:
+        """Extract fulltext from the item's best attachment, with page limits.
 
         Preference order:
         1. Our own extraction of the best attachment on disk, chosen by
@@ -1018,6 +1041,10 @@ class LocalZoteroReader:
         If the sqlite-recorded filename doesn't resolve on disk, scan the
         attachment's storage folder for a content-type-matching file before
         giving up (#291, #265).
+
+        ``page_count`` and ``truncated`` are whatever the parser reported, so
+        they are set on that path alone: both caches store flat text with no
+        page bookkeeping, and neither is page-capped to begin with (#448).
         """
         chosen = self._resolve_extraction_target(item_id)
 
@@ -1026,17 +1053,26 @@ class LocalZoteroReader:
             target, attachment_key = chosen
             hit = self._cache_lookup(target, attachment_key)
             if hit:
-                return hit
-            text = self._extract_text_from_file(target)
-            if text:
+                return FulltextExtraction(*hit)
+            doc = self._extract_doc_from_file(target)
+            if doc:
                 source = _source_for_path(target)
-                self._cache_store(target, attachment_key, item_key, text, source)
-                return (text, source)
+                self._cache_store(target, attachment_key, item_key, doc.text, source)
+                return FulltextExtraction(
+                    doc.text, source, doc.page_count, doc.truncated
+                )
 
         # 2. Zotero's own cache, for whatever step 1 could not read.
-        return self._zotero_ft_cache_fallback(item_id, chosen, item_key)
+        cached = self._zotero_ft_cache_fallback(item_id, chosen, item_key)
+        return FulltextExtraction(*cached) if cached else None
 
-        return None
+    def _extract_fulltext_for_item(
+        self, item_id: int, item_key: str | None = None
+    ) -> tuple[str, str] | None:
+        """``extract_fulltext_detailed`` as the ``(text, source)`` pair that the
+        indexing paths consume."""
+        extraction = self.extract_fulltext_detailed(item_id, item_key)
+        return (extraction.text, extraction.source) if extraction else None
 
     def close(self):
         """Close database connection."""

--- a/src/zotero_mcp/tools/retrieval.py
+++ b/src/zotero_mcp/tools/retrieval.py
@@ -14,6 +14,7 @@ from zotero_mcp._app import mcp
 from zotero_mcp._context import Context
 from zotero_mcp.client import with_zotero_api_lock
 from zotero_mcp.config import load_config
+from zotero_mcp.extract import extract_file
 from zotero_mcp.tools import _helpers
 
 #: Pages of a PDF to surface when an agent reads a paper inline, if nothing
@@ -36,6 +37,28 @@ def _fulltext_display_max_pages() -> int:
     except Exception:
         return DEFAULT_FULLTEXT_DISPLAY_MAX
     return DEFAULT_FULLTEXT_DISPLAY_MAX if configured is None else configured
+
+
+def _fulltext_section_heading(
+    truncated: bool, page_count: int | None, max_pages: int, item_key: str
+) -> tuple[str, str]:
+    """Return the "Full Text" heading and any page-limit notice.
+
+    A capped read is byte-for-byte indistinguishable from a complete one, so
+    an agent summarizes and cites the first ten pages of a 442-page book as
+    if it had read the paper (#448). Name the range that was read instead,
+    and where to pick the document up again.
+    """
+    if not truncated:
+        return "## Full Text", ""
+    return (
+        f"## Full Text (pages 1-{max_pages} of {page_count} — TRUNCATED)",
+        f"> Only the first {max_pages} of {page_count} pages were extracted. "
+        f"Raise `semantic_search.extraction.fulltext_display_max_pages` in the "
+        f"zotero-mcp config to read more of the document in one call, or use "
+        f"zotero_read_pdf_pages(item_key='{item_key}', start_page={max_pages + 1}) "
+        f"to read on from where this stops.",
+    )
 
 
 @mcp.tool(
@@ -114,13 +137,16 @@ def get_item_metadata(
 @mcp.tool(
     name="zotero_get_item_fulltext",
     description=(
-        "Return the full extracted text of a Zotero item's primary "
+        "Return the extracted text of a Zotero item's primary "
         "attachment (PDF or EPUB). "
-        "WARNING: returns the entire paper (often 10K+ tokens). Use ONLY "
-        "when the user explicitly wants to READ the paper — not for "
+        "WARNING: returns most or all of the paper (often 10K+ tokens). Use "
+        "ONLY when the user explicitly wants to READ the paper — not for "
         "searching or browsing. For topic search use "
         "zotero_semantic_search; for metadata only use "
         "zotero_get_item_metadata. "
+        "PDFs are read up to fulltext_display_max_pages (10 by default); "
+        "when that cuts a document short the heading names the page range "
+        "and TRUNCATED — read on with zotero_read_pdf_pages. "
         "Avoid calling this on multiple papers in one conversation unless "
         "the user specifically asked to read several. "
         "item_key: 8-character Zotero item key. Normally the parent item — "
@@ -198,12 +224,17 @@ def get_item_fulltext(
                 ) as reader:
                     local_item = reader.get_item_by_key(item_key)
                     if local_item:
-                        extracted = reader.extract_fulltext_for_item(local_item.item_id)
-                        if extracted and extracted[0]:
-                            source = extracted[1] if len(extracted) > 1 else "file"
-                            ctx.info(f"Retrieved full text from local storage ({source})")
+                        extracted = reader.extract_fulltext_detailed(local_item.item_id)
+                        if extracted and extracted.text:
+                            ctx.info(f"Retrieved full text from local storage ({extracted.source})")
+                            heading, notice = _fulltext_section_heading(
+                                extracted.truncated, extracted.page_count, max_pages, item_key
+                            )
+                            body = "\n\n".join(
+                                part for part in (heading, notice, extracted.text) if part
+                            )
                             return _helpers._prepend_size_warning(
-                                f"{metadata}\n\n---\n\n## Full Text\n\n{extracted[0]}",
+                                f"{metadata}\n\n---\n\n{body}",
                                 "Consider using zotero_semantic_search to find specific content instead of reading full papers."
                             )
         except Exception as local_extract_error:
@@ -244,9 +275,23 @@ def get_item_fulltext(
 
                 if download.path and download.path.exists():
                     ctx.info(f"Downloaded file via {download.source} to {download.path}, converting to markdown")
-                    converted_text = _client.convert_to_markdown(download.path, max_pages=max_pages)
+                    # extract_file rather than convert_to_markdown: this path
+                    # applies the same page cap, so it needs the document's
+                    # page bookkeeping and not only its text (#448).
+                    doc = extract_file(download.path, max_pages=max_pages)
+                    if doc is None:
+                        heading, notice = "## Full Text", ""
+                        converted_text = f"Error converting file to markdown: {download.path.name}"
+                    else:
+                        heading, notice = _fulltext_section_heading(
+                            doc.truncated, doc.page_count, max_pages, item_key
+                        )
+                        converted_text = doc.text
+                    body = "\n\n".join(
+                        part for part in (heading, notice, converted_text) if part
+                    )
                     return _helpers._prepend_size_warning(
-                        f"{metadata}\n\n---\n\n## Full Text\n\n{converted_text}",
+                        f"{metadata}\n\n---\n\n{body}",
                         "Consider using zotero_semantic_search to find specific content instead of reading full papers."
                     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -247,3 +247,22 @@ def dummy_ctx():
 @pytest.fixture
 def fake_zot():
     return FakeZotero()
+
+
+def extracted_doc(text, *, page_count=1, source="pdf", truncated=False):
+    """Build an :class:`~zotero_mcp.extract.ExtractedDoc` for stubbing the
+    parser seam (``LocalZoteroReader._extract_doc_from_file``).
+
+    Tests that stub extraction are usually about attachment *selection*, so
+    they only care about the text; the page fields carry harmless defaults.
+    """
+    from zotero_mcp.extract import ExtractedDoc
+
+    return ExtractedDoc(
+        text=text,
+        pages=(text,),
+        page_numbers=(0,),
+        page_count=page_count,
+        source=source,
+        truncated=truncated,
+    )

--- a/tests/test_attachment_priority.py
+++ b/tests/test_attachment_priority.py
@@ -10,7 +10,7 @@ rest behaviour exactly so nobody's library changes under them on upgrade.
 from pathlib import Path
 
 import pytest
-from conftest import FakeZotero
+from conftest import FakeZotero, extracted_doc
 
 from zotero_mcp import client as client_module
 from zotero_mcp.extract import (
@@ -165,8 +165,8 @@ class _Reader(LocalZoteroReader):
     def _read_zotero_ft_cache(self, _attachment_key):
         return None
 
-    def _extract_text_from_file(self, file_path):
-        return f"text of {Path(file_path).name}"
+    def _extract_doc_from_file(self, file_path):
+        return extracted_doc(f"text of {Path(file_path).name}")
 
 
 @pytest.fixture

--- a/tests/test_fulltext_non_pdf_html.py
+++ b/tests/test_fulltext_non_pdf_html.py
@@ -12,6 +12,8 @@ the existing ``_extract_text_from_file`` fallback already handles it.
 
 from pathlib import Path
 
+from conftest import extracted_doc
+
 from zotero_mcp.extract import DEFAULT_ATTACHMENT_PRIORITY, is_extractable
 from zotero_mcp.local_db import LocalZoteroReader
 
@@ -105,11 +107,11 @@ def test_extract_fulltext_prefers_pdf_over_textual(tmp_path):
     txt.write_text("plaintext fallback content")
 
     class _ReaderWithPdfText(_Reader):
-        def _extract_text_from_file(self, file_path):
+        def _extract_doc_from_file(self, file_path):
             # Asserting the suffix is the point of the test: the chooser must
             # hand us the PDF, not the .txt sitting alongside it.
             assert file_path.suffix == ".pdf"
-            return "PDF content extracted"
+            return extracted_doc("PDF content extracted")
 
     reader = _ReaderWithPdfText(
         attachments=[

--- a/tests/test_fulltext_truncation.py
+++ b/tests/test_fulltext_truncation.py
@@ -1,0 +1,246 @@
+"""Regression tests for #448: a page-capped read must say it was capped.
+
+``zotero_get_item_fulltext`` stops at ``fulltext_display_max_pages`` — 10 by
+default. The text it returned for the first ten pages of a 442-page book was
+byte-for-byte indistinguishable from the text it returned for a complete
+three-page note: same ``## Full Text`` heading, no marker anywhere. An agent
+summarizes and cites the excerpt as if it had read the paper.
+
+The parser already reports ``page_count`` and ``truncated`` on every
+extraction; these tests pin that they reach the caller and get rendered.
+"""
+
+from pathlib import Path
+
+from conftest import DummyContext, FakeZotero
+
+import zotero_mcp.client as zotero_client
+import zotero_mcp.local_db as local_db
+import zotero_mcp.utils as zotero_utils
+from zotero_mcp.extract import ExtractedDoc
+from zotero_mcp.local_db import FulltextExtraction, LocalZoteroReader
+from zotero_mcp.tools import retrieval
+
+TARGET = Path("/nonexistent/book.pdf")
+
+
+def _doc(text="body text", *, page_count=442, truncated=True, source="pdf"):
+    """An ExtractedDoc shaped like what the parser returns for a capped read."""
+    return ExtractedDoc(
+        text=text,
+        pages=(text,),
+        page_numbers=(0,),
+        page_count=page_count,
+        source=source,
+        truncated=truncated,
+    )
+
+
+class _Reader(LocalZoteroReader):
+    """LocalZoteroReader stub with no DB and one resolvable attachment."""
+
+    def __init__(self, *, target=TARGET, cached=None):
+        self.db_path = "/dev/null"
+        self._connection = None
+        self.pdf_max_pages = 10
+        self.pdf_timeout = 30
+        self.fulltext_cache_enabled = False
+        self._target = target
+        self._cached = cached
+
+    def _resolve_extraction_target(self, item_id):
+        return (self._target, "ATT1") if self._target else None
+
+    def _iter_parent_attachments(self, item_id):
+        yield ("ATT1", "storage:book.pdf", "application/pdf")
+
+    def _read_zotero_ft_cache(self, attachment_key):
+        return self._cached
+
+
+# ---------------------------------------------------------------------------
+# extract_fulltext_detailed — carrying the parser's page bookkeeping up
+# ---------------------------------------------------------------------------
+
+
+def test_capped_read_carries_page_count_and_truncation(monkeypatch):
+    monkeypatch.setattr(local_db, "extract_file", lambda p, **kw: _doc())
+
+    extraction = _Reader().extract_fulltext_detailed(item_id=1)
+
+    assert extraction.source == "pdf"
+    assert extraction.text == "body text"
+    assert extraction.page_count == 442
+    assert extraction.truncated is True
+
+
+def test_complete_read_is_not_marked_truncated(monkeypatch):
+    monkeypatch.setattr(
+        local_db, "extract_file", lambda p, **kw: _doc(page_count=3, truncated=False)
+    )
+
+    extraction = _Reader().extract_fulltext_detailed(item_id=1)
+
+    assert extraction.truncated is False
+    assert retrieval._fulltext_section_heading(False, 3, 10, "ABCD1234") == (
+        "## Full Text",
+        "",
+    )
+
+
+def test_zotero_ft_cache_fallback_reports_no_page_limits(monkeypatch):
+    """Zotero's own cache is flat text with no page bookkeeping, and is not
+    page-capped — it must never be reported as truncated."""
+    monkeypatch.setattr(local_db, "extract_file", lambda p, **kw: None)
+
+    extraction = _Reader(cached="whole document from Zotero").extract_fulltext_detailed(1)
+
+    assert extraction.source == "zotero-cache"
+    assert extraction.page_count is None
+    assert extraction.truncated is False
+
+
+def test_transient_cache_hit_still_returns_an_extraction(monkeypatch):
+    """A cache hit short-circuits before the parser, so it carries text and
+    source only — and must not crash on the missing page fields."""
+    reader = _Reader()
+    reader._cache_lookup = lambda target, key: ("cached text", "pdf")
+    monkeypatch.setattr(local_db, "extract_file", lambda p, **kw: _doc())
+
+    extraction = reader.extract_fulltext_detailed(item_id=1)
+
+    assert (extraction.text, extraction.source) == ("cached text", "pdf")
+    assert extraction.truncated is False
+
+
+def test_nothing_readable_returns_none(monkeypatch):
+    monkeypatch.setattr(local_db, "extract_file", lambda p, **kw: None)
+
+    assert _Reader().extract_fulltext_detailed(item_id=1) is None
+
+
+def test_indexing_paths_still_get_a_text_source_pair(monkeypatch):
+    """The semantic indexer and get_items_with_text unpack a 2-tuple."""
+    monkeypatch.setattr(local_db, "extract_file", lambda p, **kw: _doc())
+
+    text, source = _Reader()._extract_fulltext_for_item(item_id=1)
+
+    assert (text, source) == ("body text", "pdf")
+
+
+# ---------------------------------------------------------------------------
+# _fulltext_section_heading — what the caller is told
+# ---------------------------------------------------------------------------
+
+
+def test_heading_names_the_range_and_how_to_read_on():
+    heading, notice = retrieval._fulltext_section_heading(True, 442, 10, "ABCD1234")
+
+    assert heading == "## Full Text (pages 1-10 of 442 — TRUNCATED)"
+    assert "442" in notice
+    assert "fulltext_display_max_pages" in notice
+    # Points at the next unread page, not at page 1 again.
+    assert "start_page=11" in notice
+
+
+def test_heading_is_unchanged_when_nothing_was_cut():
+    assert retrieval._fulltext_section_heading(False, 3, 10, "ABCD1234") == (
+        "## Full Text",
+        "",
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_item_fulltext — end to end, both capped paths
+# ---------------------------------------------------------------------------
+
+
+class _FakeConfig:
+    class semantic_search:  # noqa: N801 — mirrors the config object's shape
+        class extraction:
+            fulltext_display_max_pages = 10
+            attachment_priority = ("pdf", "html", "other")
+
+    def resolve_zotero_db_path(self):
+        return "/dev/null"
+
+
+def _install_local_mode(monkeypatch, extraction):
+    """Point get_item_fulltext's local branch at ``extraction``."""
+
+    class _FakeReader:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def get_item_by_key(self, key):
+            return type("I", (), {"item_id": 1})()
+
+        def extract_fulltext_detailed(self, item_id):
+            return extraction
+
+    monkeypatch.setattr(zotero_utils, "is_local_mode", lambda: True)
+    monkeypatch.setattr(zotero_client, "get_zotero_client", FakeZotero)
+    monkeypatch.setattr(retrieval, "load_config", lambda: _FakeConfig())
+    monkeypatch.setattr(local_db, "LocalZoteroReader", _FakeReader)
+
+
+def test_truncated_local_read_says_so_in_the_output(monkeypatch):
+    _install_local_mode(
+        monkeypatch,
+        FulltextExtraction("first ten pages", "pdf", page_count=442, truncated=True),
+    )
+
+    out = retrieval.get_item_fulltext(item_key="ABCD1234", ctx=DummyContext())
+
+    assert "## Full Text (pages 1-10 of 442 — TRUNCATED)" in out
+    assert "zotero_read_pdf_pages(item_key='ABCD1234', start_page=11)" in out
+    assert "first ten pages" in out
+
+
+def test_complete_local_read_keeps_the_plain_heading(monkeypatch):
+    _install_local_mode(
+        monkeypatch,
+        FulltextExtraction("the whole thing", "pdf", page_count=4, truncated=False),
+    )
+
+    out = retrieval.get_item_fulltext(item_key="ABCD1234", ctx=DummyContext())
+
+    assert "## Full Text\n\nthe whole thing" in out
+    assert "TRUNCATED" not in out
+    assert "zotero_read_pdf_pages" not in out
+
+
+def test_download_fallback_path_reports_truncation_too(monkeypatch):
+    """The last-resort download+parse path applies the same cap, so it must
+    report the same way rather than silently returning an excerpt."""
+    monkeypatch.setattr(zotero_utils, "is_local_mode", lambda: False)
+    monkeypatch.setattr(zotero_client, "get_zotero_client", FakeZotero)
+    monkeypatch.setattr(retrieval, "load_config", lambda: _FakeConfig())
+    monkeypatch.setattr(
+        retrieval._client,
+        "get_attachment_details",
+        lambda zot, item: type("A", (), {"key": "ATT1", "content_type": "application/pdf", "filename": "p.pdf"})(),
+    )
+    # Zotero's server-side index has nothing, so we fall through to download.
+    monkeypatch.setattr(
+        FakeZotero, "fulltext_item", lambda self, key: {}, raising=False
+    )
+
+    _path = type("P", (), {"exists": lambda self: True, "name": "p.pdf"})()
+    monkeypatch.setattr(
+        retrieval._client,
+        "download_attachment_file",
+        lambda *a, **kw: type("D", (), {"path": _path, "source": "web", "errors": []})(),
+    )
+    monkeypatch.setattr(retrieval, "extract_file", lambda p, **kw: _doc(page_count=120))
+
+    out = retrieval.get_item_fulltext(item_key="ABCD1234", ctx=DummyContext())
+
+    assert "## Full Text (pages 1-10 of 120 — TRUNCATED)" in out
+    assert "start_page=11" in out

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -1,6 +1,8 @@
 import sqlite3
 from pathlib import Path
 
+from conftest import extracted_doc
+
 from zotero_mcp.extract import DEFAULT_ATTACHMENT_PRIORITY
 from zotero_mcp.local_db import PERSONAL_LIBRARY_GROUP_ID, LocalZoteroReader, ZoteroItem
 
@@ -25,9 +27,9 @@ class FakeLocalZoteroReader(LocalZoteroReader):
         """Return the injected fake path."""
         return self._fake_pdf_path
 
-    def _extract_text_from_file(self, file_path):
-        """Return the injected fake text instead of reading a real file."""
-        return self._fake_text
+    def _extract_doc_from_file(self, file_path):
+        """Return the injected fake document instead of reading a real file."""
+        return extracted_doc(self._fake_text)
 
 
 def test_extract_fulltext_preserves_long_text(tmp_path):

--- a/tests/test_zotero_ft_cache.py
+++ b/tests/test_zotero_ft_cache.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from conftest import skip_on_ci
+from conftest import extracted_doc, skip_on_ci
 from zotero_mcp.extract import DEFAULT_ATTACHMENT_PRIORITY
 from zotero_mcp.local_db import LocalZoteroReader
 
@@ -71,7 +71,7 @@ def test_ft_cache_covers_an_attachment_whose_file_cannot_be_resolved(tmp_path):
     def _boom(_path):
         raise AssertionError("nothing resolvable to extract — must not be called")
 
-    reader._extract_text_from_file = _boom  # type: ignore[assignment]
+    reader._extract_doc_from_file = _boom  # type: ignore[assignment]
 
     result = reader._extract_fulltext_for_item(item_id=1)
     assert result is not None
@@ -96,8 +96,8 @@ def test_our_extraction_wins_over_the_ft_cache(tmp_path):
         storage_dir=storage,
     )
     reader._resolve_attachment_path = lambda _k, _p: pdf  # type: ignore[assignment]
-    reader._extract_text_from_file = (  # type: ignore[assignment]
-        lambda _path: "## Heading\n\nparsed markdown"
+    reader._extract_doc_from_file = (  # type: ignore[assignment]
+        lambda _path: extracted_doc("## Heading\n\nparsed markdown")
     )
 
     text, source = reader._extract_fulltext_for_item(item_id=1)
@@ -122,7 +122,7 @@ def test_ft_cache_rescues_a_file_that_fails_to_parse(tmp_path):
     )
     reader._resolve_attachment_path = lambda _k, _p: pdf  # type: ignore[assignment]
     # What extract_file does for an unreadable file: log and yield nothing.
-    reader._extract_text_from_file = lambda _path: ""  # type: ignore[assignment]
+    reader._extract_doc_from_file = lambda _path: None  # type: ignore[assignment]
 
     text, source = reader._extract_fulltext_for_item(item_id=1)
     assert source == "zotero-cache"
@@ -171,9 +171,9 @@ def test_storage_scan_recovers_from_renamed_pdf(tmp_path):
 
     def _fake_extract(path):
         captured["path"] = path
-        return "extracted via scan fallback"
+        return extracted_doc("extracted via scan fallback")
 
-    reader._extract_text_from_file = _fake_extract  # type: ignore[assignment]
+    reader._extract_doc_from_file = _fake_extract  # type: ignore[assignment]
 
     text, source = reader._extract_fulltext_for_item(item_id=1)
     assert text == "extracted via scan fallback"


### PR DESCRIPTION
Follow-up to #544. #516 was reviewed for 0.12.0 but missed in the merge sequence, so it goes out as 0.12.1.

- #516 `zotero_get_item_fulltext` reports when a document was cut short at `fulltext_display_max_pages` (#448). Conflicts resolved: `tests/conftest.py` keeps both `fake_local_zot` and the new `extracted_doc` helper; the CHANGELOG entry sits under `[Unreleased]`, above the released 0.12.0 section.

Full suite locally, 0 failures: pyzotero 1.14.0 3113 passed, pyzotero 1.15.1 3108 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWFcbar8rXcBcrmS1Vfrn2
